### PR TITLE
setup.cfg: add python package requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
+install_requires =
+    pytest
+    pyyaml
 
 [options.packages.find]
 include = logspec*


### PR DESCRIPTION
Add python packages to install along with the `logpsec` package installation.