### PR TITLE
errors/linux_kernel: handle incomplete kernel panics

### DIFF
--- a/logspec/errors/linux_kernel.py
+++ b/logspec/errors/linux_kernel.py
@@ -357,7 +357,15 @@ class KernelPanic(Error):
             report_end = match.start()
             self._report = text[:report_end]
         else:
-            return None
+            # If we couldn't find the end marker, we probably rebooted. So
+            # match sequential lines starting with timestamp.
+            lines = text.split('\n')
+            i = 0
+            while i < len(lines) and re.match(LINUX_TIMESTAMP, lines[i]):
+                i += 1
+            report_end = len('\n'.join(lines[:i]))
+            self._report = text[:report_end]
+
         text = text[:report_end]
 
         match_end = 0

--- a/logspec/errors/test.py
+++ b/logspec/errors/test.py
@@ -18,3 +18,22 @@ class TestError(Error):
         caller code working if it calls parse() to generate the error
         signature"""
         pass
+
+
+class KselftestError(Error):
+    """ Parser for kserlftest errors."""
+    def __init__(self):
+        super().__init__()
+        self.error_type = "linux.kselftest"
+
+    def _parse(self, text):
+        """Dummy parse function. The purpose of this is to keep the
+        caller code working if it calls parse() to generate the error
+        signature"""
+        match = re.search(r'(?P<message>not ok \d+ selftests:.*+)', text)
+        if not match:
+            return None
+        self.error_summary = match.group('message')
+        report_end = match.end()
+        self._report = text[:report_end]
+        return report_end

--- a/logspec/parser_defs.yaml
+++ b/logspec/parser_defs.yaml
@@ -3,6 +3,19 @@ version: 0.0.1
 # Parser definitions
 
 parsers:
+  test_kselftest:
+    states:
+      - name: generic_boot.generic_boot
+        transitions:
+          - function: linux.linux_start_detected
+            state: linux_kernel.kernel_load
+      - name: linux_kernel.kernel_load
+        transitions:
+          - function: linux.linux_prompt_detected
+            state: test_kselftest.test_kselftest
+      - name: test_kselftest.test_kselftest
+    start_state: generic_boot.generic_boot
+
   generic_linux_boot:
     # Parse a Linux boot from kernel startup until it reaches a
     # command-line prompt.

--- a/logspec/states/test_kselftest.py
+++ b/logspec/states/test_kselftest.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2024 Collabora Limited
+# Author: Helen Koike <helen.koike@collabora.com>
+
+import re
+from logspec.parser_classes import State
+from logspec.utils.test_kselftest_errors import find_test_kselftest_error
+from logspec.parser_loader import register_state
+
+MODULE_NAME = 'test_kselftest'
+
+
+# State functions
+
+def detect_test_kselftest(text, start=None, end=None):
+    start_tags = [
+        'kselftest.sh',
+    ]
+    if start or end:
+        text = text[start:end]
+    data = {
+        '_signature_fields': [
+            'test.kselftest.script_call',
+            'test.kselftest.start',
+        ],
+    }
+    regex = '|'.join(start_tags)
+
+    # Check for test start
+    match = re.search(regex, text)
+    if not match:
+        data['test.kselftest.script_call'] = False
+        data['test.kselftest.start'] = False
+        data['_match_end'] = end if end else len(text)
+        data['_summary'] = "Kselftest not detected"
+        return data
+
+    test_start = match.end()
+    test_end = None
+    data['test.kselftest.script_call'] = True
+    data['_summary'] = "Kselftest started"
+
+    # Check for test end, consider the last line starting with "ok \d+ selftests:"
+    # or "not ok \d+ selftests:"
+    regex = r'(?:not )?ok \d+ selftests:'
+    matches = list(re.finditer(regex, text[test_start:]))
+    match = matches[-1] if matches else None
+    if match:
+        data['test.kselftest.start'] = True
+        test_end = test_start + match.end()
+        data['_match_end'] = test_end + start if start else test_end
+    else:
+        data['test.kselftest.start'] = False
+        # TODO: check if this is correct
+        data['_match_end'] = end if end else len(text)
+
+
+    # Check for linux-specific errors in the log. If the `done'
+    # condition was found, search only before it. Otherwise search in
+    # the full log.
+    data['errors'] = []
+    while True:
+        error = find_test_kselftest_error(text[test_start:test_end])
+        if not error:
+            break
+        data['errors'].append(error['error'])
+        test_start += error['_end']
+    return data
+
+
+# Create and register states
+
+register_state(
+    MODULE_NAME,
+    State(
+        name="Kselftest test",
+        description="Search and process a kseftest test",
+        function=detect_test_kselftest),
+    'test_kselftest')

--- a/logspec/utils/test_kselftest_errors.py
+++ b/logspec/utils/test_kselftest_errors.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2024 Collabora Limited
+# Author: Ricardo Cañuelo <ricardo.canuelo@collabora.com>
+
+from logspec.utils.defs import *
+from logspec.errors.test import *
+
+
+def find_test_kselftest_error(text):
+    error = KselftestError()
+    # Parsing on a generic TestError object simply generates a
+    # signature, we already did the parsing above
+    report_end = error.parse(text)
+    if not report_end:
+        return None
+    return {
+        'error': error,
+        '_end': report_end,
+    }

--- a/tests/logs/linux_boot/linux_boot_008.log
+++ b/tests/logs/linux_boot/linux_boot_008.log
@@ -1,0 +1,6754 @@
+[Enter `^Ec?' for help]
+[DL] 00000000 00000000 010701
+F0: 102B 0000
+F1: 0000 0000
+V0: 0000 0000 [0001]
+00: 1027 0002
+01: 0000 0000
+BP: 0C00 0251 [0000]
+G0: 1182 0000
+EC: 0000 0000 [1000]
+T0: 0000 00C5 [1010]
+Jump to BL
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 bootblock starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x1000000000000) with new page table @0x00100000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00000000:0x200000000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x8000000000) with new page table @0x00101000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00100000:0x00110000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x40000000) with new page table @0x00102000^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x00200000) with new page table @0x00103000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00200000:0x00400000) with new page table @0x00104000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00107000:0x00108000) as non-cacheable | read-write |     secure | normal^[[0m
+^[[0m[INFO ]  WDT: Status = 0x0^[[0m
+^[[0m[INFO ]  WDT: Last reset was cold boot^[[0m
+^[[0m[DEBUG]  SPI1(PAD0) initialized at 2951351 Hz^[[0m
+^[[0m[DEBUG]  SPI2(PAD0) initialized at 992727 Hz^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  VBOOT: Loading verstage.^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 1148 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  FMAP: Found "FLASH" version 1.1 at 0x20000.^[[0m
+^[[0m[DEBUG]  FMAP: base = 0x0 size = 0x800000 #areas = 26^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 0 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[INFO ]  CBFS: mcache @0x0010c000 built for 68 files, used 0x1a3c of 0x2000 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/verstage' @0x49800 size 0xa7c2 in mcache @0x0010c3b0^[[0m
+^[[0m[DEBUG]  read SPI 0x6a880 0xa7c2: 3612 us, 11889 KB/s, 95.112 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 42946 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 verstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  FMAP: area RW_NVRAM found @ 57b000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  TPM ready after 2272 ms^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5ad9^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_send_startup: Startup return code is 0^[[0m
+^[[0m[INFO ]  TPM: setup succeeded^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1007 return code 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1008 return code 0^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  Reading cr50 boot mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Cr50 says boot_mode is VERIFIED_RW(0x00).^[[0m
+^[[0m[INFO ]  Phase 1^[[0m
+^[[0m[DEBUG]  FMAP: area GBB found @ 3f3000 (12032 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() Recovery reason from previous boot: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() We have a recovery request: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  Recovery requested (1009000e)^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: boot mode` into PCR 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: boot mode` to PCR 0 measured^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: GBB HWID` into PCR 1^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: GBB HWID` to PCR 1 measured^[[0m
+^[[0m[DEBUG]  VBOOT: Returning from verstage.^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/romstage' @0x80 size 0xe96a in mcache @0x0010c02c^[[0m
+^[[0m[DEBUG]  read SPI 0x21100 0xe96a: 5009 us, 11929 KB/s, 95.432 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 59754 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: bootblock times (exec / console): total (unknown) / 236 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 romstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  pmic_check_hwcid: ID = 0x6610^[[0m
+^[[0m[INFO ]  Check CPU freq: 1999968 KHz, cci: 1385006 KHz^[[0m
+^[[0m[INFO ]  [RTC]rtc_set_capid,243: read back capid: 0xe0^[[0m
+^[[0m[INFO ]  [RTC]rtc_enable_dcxo,50: con = 0x482, osc32con = 0xc272, sec = 0x200d^[[0m
+^[[0m[INFO ]  [RTC]rtc_check_state,173: con=482, pwrkey1=a357, pwrkey2=67d2^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,62: osc32con val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,20: PMIC_RG_FQMTR_CKSEL=0x4a^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0xf, output = 0x2d9^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x17, output = 0x395^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x13, output = 0x337^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x308^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x308^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,47: left: 17, middle: 17, right: 18^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,66: EOSC32 cali val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,202: RTC_STATE_REBOOT^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,220: irqsta=0, bbpu=9, con=482^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,319: rtc_write_trigger = 1^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,322: done BBPU = 0x9^[[0m
+^[[0m[INFO ]  CPU: 0x81861001^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[1;4m[WARN ]  DRAM-K: Invalid data in flash (size: 0xffffffffffffffff, expected: 0xf80)^[[0m
+^[[0m[INFO ]  DRAM-K: Running full calibration^[[0m
+^[[0m[INFO ]  DRAM-K: ddr_type: DSC, config_dvfs: 0, ddr_geometry: 2CH_2RK_4GB_2_2^[[0m
+^[[0m[INFO ]  header.status = 0x0^[[0m
+^[[0m[INFO ]  header.version = 0x1 (expected: 0x1)^[[0m
+^[[0m[INFO ]  header.size = 0xf80 (expected: 0xf80)^[[0m
+^[[0m[INFO ]  header.flags = 0x0^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/dram' @0x2d980 size 0x14ab1 in mcache @0x0010c2e0^[[0m
+^[[0m[DEBUG]  read SPI 0x4e9fc 0x14ab1: 6899 us, 12270 KB/s, 98.160 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 84657 bytes, hash algo 2, HW acceleration forbidden^[[0m
+dram_init: MediaTek DRAM firmware version: 0.1.0, accepting param version 1
+EMI_MPU_CTRL=0 1st
+EMI_MPU_CTRL=0 2nd
+Vm18 = 1800000
+Vdram = 0
+Vddq = 0
+Vmddr = 750000
+Will call Init_DRAM MDL_USED
+[EMI] CEN_CONA(0x3530154),CEN_CONF(0x421000),CEN_CONH(0x88880033),CEN_CONK(0x0),CHN_CONA(0x488005d)
+[DRAMC] type = 6
+[1600][CH0][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 62 at CA0, Window Sum 370
+[1600][CH0][RK1][CBT] Best Vref 30 VrefRange 1, Window Min 62 at CA0, Window Sum 370
+[1600][CH0][RK0][TX] Best Vref 26 VrefRange 1, Window Min 27 at DQ1, Window Sum 469
+[1600][CH0][RK0][RX] Best Vref B0 = 44, Window Min 71 at DQ3, Window Sum 622
+[1600][CH0][RK0][RX] Best Vref B1 = 44, Window Min 73 at DQ9, Window Sum 624
+[1600][CH0][RK1][TX] Best Vref 28 VrefRange 1, Window Min 27 at DQ5, Window Sum 469
+[1600][CH1][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 62 at CA3, Window Sum 370
+[1600][CH1][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA4, Window Sum 368
+[1600][CH1][RK0][TX] Best Vref 26 VrefRange 1, Window Min 28 at DQ8, Window Sum 470
+[1600][CH1][RK0][RX] Best Vref B0 = 44, Window Min 73 at DQ4, Window Sum 638
+[1600][CH1][RK0][RX] Best Vref B1 = 42, Window Min 73 at DQ15, Window Sum 642
+[1600][CH1][RK1][TX] Best Vref 24 VrefRange 1, Window Min 27 at DQ8, Window Sum 459
+sync_frequency_calibration_params sync calibration params of frequency 800 to shu:6
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 800
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 28
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 32
+[0] MIN Duty = 4928%(X100), DQS PI = 20
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 180%
+CH0 DQS 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 12
+[0] MIN Duty = 4928%(X100), DQS PI = 2
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 36
+[0] MIN Duty = 5000%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 108%
+CH0 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 12
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 38
+[0] MIN Duty = 4964%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 144%
+CH0 DQ 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5109%(X100), DQS PI = 34
+[0] MIN Duty = 4819%(X100), DQS PI = 4
+[0] AVG Duty = 4964%(X100)
+CH1 CLK Duty spec in!! Max-Min= 290%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4855%(X100), DQS PI = 50
+[-1] AVG Duty = 4981%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5036%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 253%
+CH1 DQS 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 56
+[0] AVG Duty = 4963%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 24
+[1] MIN Duty = 4892%(X100), DQS PI = 52
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 217%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5181%(X100), DQS PI = 30
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5054%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 28
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4964%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3200][CH0][RK0][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 360
+[3200][CH0][RK1][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 361
+[3200][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ4, Window Sum 450
+[3200][CH0][RK0][RX] Best Vref B0 = 20, Window Min 33 at DQ6, Window Sum 299
+[3200][CH0][RK0][RX] Best Vref B1 = 20, Window Min 34 at DQ10, Window Sum 296
+[3200][CH0][RK1][TX] Best Vref 24 VrefRange 0, Window Min 26 at DQ4, Window Sum 436
+[3200][CH1][RK0][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA1, Window Sum 362
+[3200][CH1][RK1][CBT] Best Vref 24 VrefRange 0, Window Min 60 at CA1, Window Sum 363
+[3200][CH1][RK0][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ0, Window Sum 450
+[3200][CH1][RK0][RX] Best Vref B0 = 20, Window Min 29 at DQ2, Window Sum 291
+[3200][CH1][RK0][RX] Best Vref B1 = 20, Window Min 31 at DQ11, Window Sum 288
+[3200][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ0, Window Sum 445
+sync_frequency_calibration_params sync calibration params of frequency 1600 to shu:7
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1600
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 26
+[0] MIN Duty = 4855%(X100), DQS PI = 44
+[0] AVG Duty = 4963%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 48
+[0] MIN Duty = 4892%(X100), DQS PI = 36
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 217%
+CH0 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 12
+[0] MIN Duty = 4928%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 22
+[0] MIN Duty = 4964%(X100), DQS PI = 56
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 144%
+CH0 DQM 1 Duty spec in!! Max-Min= 181%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 14
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5018%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 48
+[0] MIN Duty = 4928%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 180%
+CH0 DQ 1 Duty spec in!! Max-Min= 217%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 24
+[0] MIN Duty = 4746%(X100), DQS PI = 58
+[0] AVG Duty = 4909%(X100)
+CH1 CLK Duty spec in!! Max-Min= 326%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5072%(X100), DQS PI = 24
+[-1] MIN Duty = 4856%(X100), DQS PI = 0
+[-1] AVG Duty = 4964%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5144%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 216%
+CH1 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 0
+[0] AVG Duty = 4981%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 16
+[1] MIN Duty = 4892%(X100), DQS PI = 52
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 253%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 32
+[0] MIN Duty = 4819%(X100), DQS PI = 0
+[0] AVG Duty = 4945%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 26
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3732][CH0][RK0][CBT] Best Vref 26 VrefRange 0, Window Min 58 at CA1, Window Sum 358
+[3732][CH0][RK1][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 361
+[3732][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 25 at DQ10, Window Sum 436
+[3732][CH0][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ1, Window Sum 430
+[3732][CH0][RK0][RX] Best Vref B0 = 19, Window Min 30 at DQ3, Window Sum 255
+[3732][CH0][RK0][RX] Best Vref B1 = 19, Window Min 30 at DQ8, Window Sum 248
+[3732][CH0][RK1][RX] Best Vref B0 = 19, Window Min 29 at DQ3, Window Sum 239
+[3732][CH0][RK1][RX] Best Vref B1 = 19, Window Min 28 at DQ10, Window Sum 237
+[3732][CH1][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 358
+[3732][CH1][RK1][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA3, Window Sum 359
+[3732][CH1][RK0][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ1, Window Sum 444
+[3732][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ3, Window Sum 446
+[3732][CH1][RK0][RX] Best Vref B0 = 21, Window Min 29 at DQ2, Window Sum 249
+[3732][CH1][RK0][RX] Best Vref B1 = 21, Window Min 30 at DQ8, Window Sum 245
+[3732][CH1][RK1][RX] Best Vref B0 = 21, Window Min 30 at DQ2, Window Sum 249
+[3732][CH1][RK1][RX] Best Vref B1 = 21, Window Min 30 at DQ8, Window Sum 244
+sync_frequency_calibration_params sync calibration params of frequency 1866 to shu:0
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1866
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+sync common calibartion params.
+sync cbt_mode0:0, 1:0
+[DRAMC] rank_nr = 2
+0:dram_rank_size:100000000
+0:dram_rank_size:100000000
+1:dram_rank_size:100000000
+1:dram_rank_size:100000000
+sync rank num:2, rank0_size:0x100000000, rank1_size:0x100000000
+[freqGroup] freqGroup: 1866, Freq= 1792
+dram_init: dram init end (result: 0)
+^[[0m[INFO ]  DRAM-K: Full calibration passed in 2391 msecs^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x240000000) as     cacheable | read-write | non-secure | normal^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x40100000) as non-cacheable | read-write | non-secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x80000000) with new page table @0x00105000^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x40200000) with new page table @0x00106000^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[DEBUG]  CBMEM:^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xfffff000 254 entries.^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xffffec00 62 entries.^[[0m
+^[[0m[DEBUG]  FMAP: area RO_VPD found @ 3f8000 (32768 bytes)^[[0m
+^[[1;4m[WARN ]  RO_VPD is uninitialized or empty.^[[0m
+^[[0m[DEBUG]  FMAP: area RW_VPD found @ 577000 (16384 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/ramstage' @0xea80 size 0x105d7 in mcache @0x0010c0ac^[[0m
+^[[0m[DEBUG]  read SPI 0x2fb00 0x105d7: 5374 us, 12473 KB/s, 99.784 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 67031 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: romstage times (exec / console): total (unknown) / 1645 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 ramstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  Enumerating buses...^[[0m
+^[[0m[SPEW ]  Show all devs... Before device enumeration.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[SPEW ]  Compare with tree...^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]   CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  Root Device scanning...^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 enabled^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device done^[[0m
+^[[0m[DEBUG]  scan_bus: bus Root Device finished in 12 msecs^[[0m
+^[[0m[INFO ]  done^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE run times (exec / console): 0 / 51 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_MRC_CACHE found @ 57d000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE exit times (exec / console): 0 / 13 ms^[[0m
+^[[0m[INFO ]  Allocating resources...^[[0m
+^[[0m[INFO ]  Reading resources...^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0^[[0m
+^[[0m[INFO ]  dram size: 0x200000000^[[0m
+^[[0m[SPEW ]  dev: CPU_CLUSTER: 0, index: 0x0, base: 0x40000000, size: 0x200000000^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done reading resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After reading.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done setting resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After assigning values.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[INFO ]  Done allocating resources.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_RESOURCES run times (exec / console): 0 / 102 ms^[[0m
+^[[0m[INFO ]  Enabling resources...^[[0m
+^[[0m[INFO ]  done.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENABLE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[INFO ]  Initializing devices...^[[0m
+^[[0m[DEBUG]  Root Device init^[[0m
+^[[0m[DEBUG]  init hardware done!^[[0m
+^[[0m[DEBUG]  0x00000018: ctrlr->caps^[[0m
+^[[0m[DEBUG]  52.000 MHz: ctrlr->f_max^[[0m
+^[[0m[DEBUG]  0.400 MHz: ctrlr->f_min^[[0m
+^[[0m[DEBUG]  0x40ff8080: ctrlr->voltages^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  Early init status = 3^[[0m
+^[[0m[INFO ]  SD card init^[[0m
+^[[0m[INFO ]  [SSUSB] Setting up USB HOST controller...^[[0m
+^[[0m[INFO ]  [SSUSB] u3phy_ports_enable u2p:1, u3p:1^[[0m
+^[[0m[INFO ]  [SSUSB] phy power-on done.^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 cf 1f 01 00 00 08 00 06 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 7f 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 51 2b ^[[0m
+^[[0m[INFO ]  FW_CONFIG value from CBI is 0x2b51^[[0m
+^[[0m[INFO ]  fw_config match found: AUDIO_AMP=AMP_ALC1019^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'spm_firmware.bin' @0x2b440 size 0x249c in mcache @0xfffdc278^[[0m
+^[[0m[DEBUG]  read SPI 0x4c4a8 0x249c: 765 us, 12250 KB/s, 98.000 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 9372 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  SPM: binary array size = 0xbb8^[[0m
+^[[0m[INFO ]  SPM: spmfw (version pcm_suspend_mp_v1109            )^[[0m
+^[[0m[DEBUG]  spm_kick_im_to_fetch: ptr = 0x80000010, pmem/dmem words = 0xbb7/0x1^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) spm_firmware.bin in 47 msecs (12064 bytes)^[[0m
+^[[0m[INFO ]  SPM: spm_init done in 55 msecs, spm pc = 0x250^[[0m
+^[[0m[DEBUG]  out: cmd=0x6: 03 f7 06 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f9 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 02 00 ^[[0m
+^[[0m[INFO ]  mtk_display_init: Starting display initialization^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Init interface.^[[0m
+^[[0m[INFO ]  anx7625_disable_pd_protocol: Disabled PD feature.^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Firmware: ver 0x13, rev 0x0.^[[0m
+^[[0m[INFO ]  anx7625_start_dp_work: Secure OCM version=00^[[0m
+^[[0m[INFO ]  anx7625_hpd_change_detect: HPD received 0x7e:0x45=0x91^[[0m
+^[[0m[INFO ]  sp_tx_get_edid_block: EDID Block = 1^[[0m
+^[[0m[SPEW ]  Extracted contents:^[[0m
+^[[0m[SPEW ]  header:          00 ff ff ff ff ff ff 00^[[0m
+^[[0m[SPEW ]  serial number:   06 af 5c 63 00 00 00 00 00 1b^[[0m
+^[[0m[SPEW ]  version:         01 04^[[0m
+^[[0m[SPEW ]  basic params:    95 1a 0e 78 02^[[0m
+^[[0m[SPEW ]  chroma info:     99 85 95 55 56 92 28 22 50 54^[[0m
+^[[0m[SPEW ]  established:     00 00 00^[[0m
+^[[0m[SPEW ]  standard:        01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01^[[0m
+^[[0m[SPEW ]  descriptor 1:    66 1c 56 a0 50 00 19 30 30 20 46 00 00 90 10 00 00 18^[[0m
+^[[0m[SPEW ]  descriptor 2:    00 00 00 0f 00 00 00 00 00 00 00 00 00 00 00 00 00 20^[[0m
+^[[0m[SPEW ]  descriptor 3:    00 00 00 fe 00 41 55 4f 0a 20 20 20 20 20 20 20 20 20^[[0m
+^[[0m[SPEW ]  descriptor 4:    00 00 00 fe 00 42 31 31 36 58 41 4e 30 36 2e 33 20 0a^[[0m
+^[[0m[SPEW ]  extensions:      00^[[0m
+^[[0m[SPEW ]  checksum:        02^[[0m
+^[[0m
+^[[0m[SPEW ]  Manufacturer: AUO Model 635c Serial Number 0^[[0m
+^[[0m[SPEW ]  Made week 0 of 2017^[[0m
+^[[0m[SPEW ]  EDID version: 1.4^[[0m
+^[[0m[SPEW ]  Digital display^[[0m
+^[[0m[SPEW ]  6 bits per primary color channel^[[0m
+^[[0m[SPEW ]  DisplayPort interface^[[0m
+^[[0m[SPEW ]  Maximum image size: 26 cm x 14 cm^[[0m
+^[[0m[SPEW ]  Gamma: 220%^[[0m
+^[[0m[SPEW ]  Check DPMS levels^[[0m
+^[[0m[SPEW ]  Supported color formats: RGB 4:4:4^[[0m
+^[[0m[SPEW ]  First detailed timing is preferred timing^[[0m
+^[[0m[SPEW ]  Established timings supported:^[[0m
+^[[0m[SPEW ]  Standard timings supported:^[[0m
+^[[0m[SPEW ]  Detailed timings^[[0m
+^[[0m[SPEW ]  Hex of detail: 661c56a05000193030204600009010000018^[[0m
+^[[0m[SPEW ]  Detailed mode (IN HEX): Clock 72700 KHz, 100 mm x 90 mm^[[0m
+^[[0m[SPEW ]                 0556 0586 05a6 05f6 hborder 0^[[0m
+^[[0m[SPEW ]                 0300 0304 030a 0319 vborder 0^[[0m
+^[[0m[SPEW ]                 -hsync -vsync^[[0m
+^[[0m[SPEW ]  Did detailed timing^[[0m
+^[[0m[SPEW ]  Hex of detail: 0000000f0000000000000000000000000020^[[0m
+^[[0m[SPEW ]  Manufacturer-specified data, tag 15^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe0041554f0a202020202020202020^[[0m
+^[[0m[SPEW ]  ASCII string: AUO^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe004231313658414e30362e33200a^[[0m
+^[[0m[SPEW ]  ASCII string: B116XAN06.3 ^[[0m
+^[[0m[SPEW ]  Checksum^[[0m
+^[[0m[SPEW ]  Checksum: 0x2 (valid)^[[0m
+^[[0m[INFO ]  DSI data_rate: 436200000 bps^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: set default k value to 0x3d for panel^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: pixelclock(72700).^[[0m
+^[[0m[INFO ]   hactive(1366), hsync(32), hfp(48), hbp(80)^[[0m
+^[[0m[INFO ]   vactive(768), vsync(6), vfp(4), vbp(15)^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: config dsi.^[[0m
+^[[0m[INFO ]  anx7625_dsi_video_config: compute M(11911168), N(552960), divider(8).^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: success to config DSI^[[0m
+^[[0m[INFO ]  anx7625_dp_start: MIPI phy setup OK.^[[0m
+^[[0m[INFO ]  mtk_display_init: 'AUO B116XAN06.3 ' 1366x768@0Hz^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: display resolution: 1366x768@0 bpp 4^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: invalid vrefresh; setting to 60^[[0m
+^[[0m[INFO ]  framebuffer_info: bytes_per_line: 5464, bits_per_pixel: 32^[[0m
+^[[0m[INFO ]                     x_res x y_res: 1366 x 768, size: 4196352 at 0x0^[[0m
+^[[0m[DEBUG]  Root Device init finished in 725 msecs^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[INFO ]  CBFS: Found 'sspm.bin' @0x1f7c0 size 0xbc20 in mcache @0xfffdc218^[[0m
+^[[0m[DEBUG]  read SPI 0x40820 0xbc20: 3878 us, 12418 KB/s, 99.344 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 48160 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) sspm.bin in 30 msecs (134356 bytes)^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_0: 0x50100200^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_1: 0x43000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_2: 0x50000000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_3: 0x240000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_5: 0xc008f0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_0: 0xf3ffc3c3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_1: 0xffcc0fef^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_2: 0xff22ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_3: 0xffffffce^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_4: 0x2fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_7: 0xffc3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_8: 0x8ffff3ff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_0: 0xfcffcfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_1: 0xffffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_4: 0xfcc3fcc3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_5: 0xc300000f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_0: 0xfffff333^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_3: 0xffffffcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_5: 0xfcfffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_6: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_0: 0xf0fffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_1: 0xfcffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_4: 0xf0003fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_5: 0xf0fff3f3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_0: 0xf0fffffc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_9: 0xfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_7: 0xfff3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO)MAS_SEC_0: 0x200000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_6: 0x3fffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_7: 0x3fc00000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_20: 0xffc3ffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_20: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO)MAS_SEC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_2: 0x44^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_2: 0xcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)MAS_0: 0x6^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)SEC_0: 0x0^[[0m
+^[[0m[INFO ]  dfd_init: enable DFD (Design For Debug)^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init finished in 1194 msecs^[[0m
+^[[0m[INFO ]  Devices initialized^[[0m
+^[[0m[SPEW ]  Show all devs... After init.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_INIT run times (exec / console): 279 / 1676 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_ELOG found @ 57f000 (4096 bytes)^[[0m
+^[[0m[INFO ]  ELOG: NV offset 0x57f000 size 0x1000^[[0m
+^[[0m[DEBUG]  read SPI 0x57f000 0x1000: 363 us, 11283 KB/s, 90.264 Mbps^[[0m
+^[[0m[INFO ]  ELOG: area is 4096 bytes, full threshold 3842, shrink size 1024^[[0m
+^[[0m[INFO ]  ELOG: Event(17) added with size 13 at 2025-01-29 01:20:19 UTC^[[0m
+^[[0m[DEBUG]  out: cmd=0x121: 03 db 21 01 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 79 00 00 2c 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 34 0d 01 00 00 00 00 00 02 04 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() boot_mode=`Broken screen`^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() recovery_reason: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() fw_tried=`A` fw_try_count=0 fw_prev_tried=`A` fw_prev_result=`Unknown`.^[[0m
+^[[0m[INFO ]  ELOG: Event(B7) added with size 13 at 2025-01-29 01:20:19 UTC^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE entry times (exec / console): 2 / 84 ms^[[0m
+^[[0m[INFO ]  Finalize devices...^[[0m
+^[[0m[INFO ]  Devices finalized^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[DEBUG]  Writing coreboot table at 0xffec4000^[[0m
+^[[0m[DEBUG]   0. 0000000000100000-0000000000106fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   1. 0000000000108000-000000000010afff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   2. 0000000040000000-00000000400fffff: RAM^[[0m
+^[[0m[DEBUG]   3. 0000000040100000-0000000040330fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   4. 0000000040331000-00000000545fffff: RAM^[[0m
+^[[0m[DEBUG]   5. 0000000054600000-000000005465ffff: BL31^[[0m
+^[[0m[DEBUG]   6. 0000000054660000-0000000069ffffff: RAM^[[0m
+^[[0m[DEBUG]   7. 000000006a000000-000000006a0fffff: RESERVED^[[0m
+^[[0m[DEBUG]   8. 000000006a100000-00000000ffec3fff: RAM^[[0m
+^[[0m[DEBUG]   9. 00000000ffec4000-00000000ffffffff: CONFIGURATION TABLES^[[0m
+^[[0m[DEBUG]  10. 0000000100000000-000000023fffffff: RAM^[[0m
+^[[0m[INFO ]  Passing 4 GPIOs to payload:^[[0m
+^[[0m[INFO ]              NAME |       PORT | POLARITY |     VALUE^[[0m
+^[[0m[INFO ]      EC interrupt | 0x0000000d |      low | undefined^[[0m
+^[[0m[INFO ]          EC in RW | 0x0000000e |      low | undefined^[[0m
+^[[0m[INFO ]     TPM interrupt | 0x0000000f |     high | undefined^[[0m
+^[[0m[INFO ]    speaker enable | 0x00000096 |     high | undefined^[[0m
+^[[0m[DEBUG]  ADC[3]: Raw value=317871 ID=2^[[0m
+^[[0m[DEBUG]  ADC[2]: Raw value=67749 ID=0^[[0m
+^[[0m[DEBUG]  RAM Code: 0x20^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 d3 1f 01 00 00 08 00 02 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f7 00 00 04 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 00 00 02 00 ^[[0m
+^[[0m[DEBUG]  SKU Code: 0x20000^[[0m
+^[[0m[INFO ]  Board ID: 2^[[0m
+^[[0m[INFO ]  RAM code: 32^[[0m
+^[[0m[INFO ]  SKU ID: 131072^[[0m
+^[[0m[INFO ]  FW config: 0x2b51^[[0m
+^[[0m[DEBUG]  Wrote coreboot table at: 0xffec4000, 0x3cc bytes, checksum a5f9^[[0m
+^[[0m[DEBUG]  coreboot table: 996 bytes.^[[0m
+^[[0m[DEBUG]  IMD ROOT    0. 0xfffff000 0x00001000^[[0m
+^[[0m[DEBUG]  IMD SMALL   1. 0xffffe000 0x00001000^[[0m
+^[[0m[DEBUG]  CONSOLE     2. 0xfffde000 0x00020000^[[0m
+^[[0m[DEBUG]  RO MCACHE   3. 0xfffdc000 0x00001a3c^[[0m
+^[[0m[DEBUG]  FMAP        4. 0xfffdb000 0x0000047c^[[0m
+^[[0m[DEBUG]  TIME STAMP  5. 0xfffda000 0x00000910^[[0m
+^[[0m[DEBUG]  VBOOT WORK  6. 0xfffc6000 0x00014000^[[0m
+^[[0m[DEBUG]  RAMOOPS     7. 0xffec6000 0x00100000^[[0m
+^[[0m[DEBUG]  COREBOOT    8. 0xffec4000 0x00002000^[[0m
+^[[0m[DEBUG]  IMD small region:^[[0m
+^[[0m[DEBUG]    IMD ROOT    0. 0xffffec00 0x00000400^[[0m
+^[[0m[DEBUG]    VPD         1. 0xffffeba0 0x0000004c^[[0m
+^[[0m[DEBUG]    MEM CHIP INFO 2. 0xffffeb40 0x00000054^[[0m
+^[[0m[DEBUG]    MMC STATUS  3. 0xffffeb20 0x00000004^[[0m
+^[[0m[DEBUG]  BS: BS_WRITE_TABLES run times (exec / console): 2 / 217 ms^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[0m[INFO ]  Checking cr50 for pending updates^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Reading cr50 TPM mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD entry times (exec / console): 19505 / 212 ms^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/payload' @0x2dacc0 size 0x252ee in mcache @0xfffdd9a4^[[0m
+^[[0m[DEBUG]  read SPI 0x2fbd18 0x252ee: 12185 us, 12499 KB/s, 99.992 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 152302 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0xf1000000 memsize 0x21b26a0 srcaddr 0x40100038 filesize 0x252b6^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0xf1000000 memsz: 0x00000000021b26a0 filesz: 0x00000000000252b6^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0xf1000000, f1058238, 0xf31b26a0) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x00000000f1058238 memsz: 0x000000000215a468^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0xf1000000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD run times (exec / console): 36 / 88 ms^[[0m
+^[[0m[DEBUG]  Jumping to boot code at 0xf1000000(0xffec4000)^[[0m
+^[[0m[SPEW ]  CPU0: stack: 0x00108000 - 0x0010a800, lowest used address 0x00109d60, stack used: 2720 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/bl31' @0x424c0 size 0x72db in mcache @0xfffdc35c^[[0m
+^[[0m[DEBUG]  read SPI 0x63514 0x72db: 2372 us, 12395 KB/s, 99.160 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 29403 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0x54600000 memsize 0x2c000 srcaddr 0x40100038 filesize 0x72a3^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0x54600000 memsz: 0x000000000002c000 filesz: 0x00000000000072a3^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0x54600000, 54612aa8, 0x5462c000) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x0000000054612aa8 memsz: 0x0000000000019558^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0x54601000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+INFO:    MT8186 bl31_setup
+NOTICE:  BL31: v2.7(debug):v2.7.0-625-g5c5ee8798
+NOTICE:  BL31: Built : Tue May 14 10:29:19 UTC 2024
+INFO:    dcm_set_default: 1INFO:    GICv3 without legacy support detected.
+INFO:    ARM GICv3 driver initialized in EL3
+INFO:    Maximum SPI INTID supported: 511
+INFO:    [mt_systimer_init] systimer initialization
+NOTICE:  MT8186 spm_boot_init
+INFO:    BL31: Initializing runtime services
+INFO:    BL31: cortex_a55: CPU workaround for 1221012 was applied
+INFO:    BL31: cortex_a55: CPU workaround for 1530923 was applied
+INFO:    SPM: enable CPC mode
+INFO:    mcdi ready for mcusys-off-idle and system suspend
+INFO:    BL31: Preparing for EL3 exit to normal world
+INFO:    Entry point address = 0xf1000000
+INFO:    SPSR = 0x8
+Starting depthcharge on Steelix...
+fw_config match found: AUDIO_AMP=AMP_ALC1019
+[board_setup] Setup ALC1019
+Wipe memory regions:
+[0x00000040000000, 0x00000054600000)
+[0x00000054660000, 0x0000006a000000)
+[0x0000006a100000, 0x000000f1000000)
+[0x000000f31b26a0, 0x000000ffec4000)
+[0x00000100000000, 0x00000240000000)
+Initializing XHCI USB controller at 0x11280000.
+R8152: Initializing
+Version 9 (ocp_data = 6010)
+R8152: Done initializing
+Adding net device
+Adding net device
+[firmware-corsola-15194.B-collabora] Jun 25 2024 16:04:16
+corsola: tftpboot 192.168.201.1 17544617/tftp-deploy-m3hxdhxm/kernel/image.itb 17544617/tftp-deploy-m3hxdhxm/kernel/cmdline
+Waiting for link
+done.
+MAC: 78:2d:7e:14:04:fa
+Sending DHCP discover... done.
+Waiting for reply... Receive failed.
+done.
+Sending DHCP request... done.
+Waiting for reply... done.
+My ip is 192.168.201.18
+The DHCP server ip is 192.168.201.1
+TFTP server IP predefined by user: 192.168.201.1
+Bootfile predefined by user: 17544617/tftp-deploy-m3hxdhxm/kernel/image.itb
+Sending tftp read request... done.
+Waiting for the transfer...
+00000000 ################################################################
+00080000 ################################################################
+00100000 ################################################################
+00180000 ################################################################
+00200000 ################################################################
+00280000 ################################################################
+00300000 ################################################################
+00380000 ################################################################
+00400000 ################################################################
+00480000 ################################################################
+00500000 ################################################################
+00580000 ################################################################
+00600000 ################################################################
+00680000 ################################################################
+00700000 ################################################################
+00780000 ################################################################
+00800000 ################################################################
+00880000 ################################################################
+00900000 ################################################################
+00980000 ################################################################
+00a00000 ################################################################
+00a80000 ################################################################
+00b00000 ################################################################
+00b80000 ################################################################
+00c00000 ################################################################
+00c80000 ################################################################
+00d00000 ################################################################
+00d80000 ################################################################
+00e00000 ################################################################
+00e80000 ################################################################
+00f00000 ################################################################
+00f80000 ################################################################
+01000000 ################################################################
+01080000 ################################################################
+01100000 ################################################################
+01180000 ################################################################
+01200000 ################################################################
+01280000 ################################################################
+01300000 ################################################################
+01380000 ################################################################
+01400000 ################################################################
+01480000 ################################################################
+01500000 ################################################################
+01580000 ################################################################
+01600000 ################################################################
+01680000 ################################################################
+01700000 ################################################################
+01780000 ################ done.
+The bootfile was 24772166 bytes long.
+Sending tftp read request... done.
+Waiting for the transfer...
+00000000 # done.
+Command line loaded dynamically from TFTP file: 17544617/tftp-deploy-m3hxdhxm/kernel/cmdline
+The command line is: console=ttyS0,115200n8 root=/dev/nfs rw nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1
+Loading FIT.
+Image ramdisk-1 has 12893723 bytes.
+Image fdt-1 has 68885 bytes.
+Image kernel-1 has 11807514 bytes.
+Compat preference: google,steelix-rev2-sku131072 google,steelix-rev2 google,steelix-sku131072 google,steelix
+Config conf-1 (default), kernel kernel-1, fdt fdt-1, ramdisk ramdisk-1, compat google,steelix-sku131072 (match) google,steelix mediatek,mt8186
+Choosing best match conf-1 for compat google,steelix-sku131072.
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Connected to device vid:did:rid of 6666:504a:53
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+exceeded tpm wait in burst loop
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+failed to get expected status 0x90
+W d40024: 80 01 00 00 00 0c 00 00 01 7b 00 40
+tpm_get_response: tpm transaction failed for 0x17b with error 0x5004
+TPM failed to populate kASLR seed buffer.
+ec_init: CrosEC protocol v3 supported (544, 544)
+LPDDR4 chan0(x16) rank0: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan0(x16) rank1: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan1(x16) rank0: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan1(x16) rank1: density 16384mbits x16, MF ff rev 0700
+tpm_cleanup: add release locality here.
+Shutting down all USB controllers.
+Removing current net device
+Exiting depthcharge with code 4 at timestamp: 238565271
+LZMA decompressing kernel-1 to 0xf31b1b48
+LZMA decompressing kernel-1 to 0x40000000
+jumping to kernel
+[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd050]
+[    0.000000] Linux version 6.13.0 (kernelci@kci-67996a1265fae3351e2f0137-kbuild-gcc-12-arm64-chro-0blthcbts) (aarch64-linux-gnu-gcc (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT Wed Jan 29 00:24:19 UTC 2025
+[    0.000000] KASLR enabled
+[    0.000000] random: crng init done
+[    0.000000] Machine model: Google Steelix board
+[    0.000000] OF: reserved mem: 0x00000000ffec6000..0x00000000fffc5fff (1024 KiB) map non-reusable ramoops
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000061000000, size 1 MiB
+[    0.000000] OF: reserved mem: initialized node memory@61000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000061000000..0x00000000610fffff (1024 KiB) nomap non-reusable memory@61000000
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000060000000, size 16 MiB
+[    0.000000] OF: reserved mem: initialized node memory@60000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000060000000..0x0000000060ffffff (16384 KiB) nomap non-reusable memory@60000000
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000050000000, size 16 MiB
+[    0.000000] OF: reserved mem: initialized node memory@50000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000050000000..0x000000005109ffff (17024 KiB) nomap non-reusable memory@50000000
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000040000000-0x00000000ffffffff]
+[    0.000000]   DMA32    empty
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000040000000-0x000000004fffffff]
+[    0.000000]   node   0: [mem 0x0000000050000000-0x000000005109ffff]
+[    0.000000]   node   0: [mem 0x00000000510a0000-0x00000000545fffff]
+[    0.000000]   node   0: [mem 0x0000000054700000-0x000000005fffffff]
+[    0.000000]   node   0: [mem 0x0000000060000000-0x00000000610fffff]
+[    0.000000]   node   0: [mem 0x0000000061100000-0x0000000069ffffff]
+[    0.000000]   node   0: [mem 0x000000006a100000-0x00000000ffdfffff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000023fffffff]
+[    0.000000] On node 0, zone DMA: 256 pages in unavailable ranges
+[    0.000000] On node 0, zone DMA: 256 pages in unavailable ranges
+[    0.000000] On node 0, zone Normal: 512 pages in unavailable ranges
+[    0.000000] psci: probing for conduit method from DT.
+[    0.000000] psci: PSCIv1.1 detected in firmware.
+[    0.000000] psci: Using standard PSCI v0.2 function IDs
+[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
+[    0.000000] psci: SMC Calling Convention v1.2
+[    0.000000] percpu: Embedded 33 pages/cpu s97704 r8192 d29272 u135168
+[    0.000000] Detected VIPT I-cache on CPU0
+[    0.000000] CPU features: detected: GIC system register CPU interface
+[    0.000000] CPU features: detected: Virtualization Host Extensions
+[    0.000000] CPU features: kernel page table isolation forced ON by KASLR
+[    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
+[    0.000000] CPU features: detected: ARM errata 1165522, 1319367, or 1530923
+[    0.000000] alternatives: applying boot alternatives
+[    0.000000] Kernel command line: console=ttyS0,115200n8 root=/dev/nfs rw nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1
+[    0.000000] Unknown kernel command line parameters "nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1", will be passed to user space.
+[    0.000000] printk: log buffer data + meta data: 262144 + 917504 = 1179648 bytes
+[    0.000000] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes, linear)
+[    0.000000] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes, linear)
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2096128
+[    0.000000] mem auto-init: stack:all(zero), heap alloc:on, heap free:off
+[    0.000000] software IO TLB: area num 8.
+[    0.000000] software IO TLB: mapped [mem 0x00000000fbe00000-0x00000000ffe00000] (64MB)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] ftrace: allocating 51171 entries in 200 pages
+[    0.000000] ftrace: allocated 200 pages with 3 groups
+[    0.000000] rcu: Preemptible hierarchical RCU implementation.
+[    0.000000] ?Trampoline variant of Tasks RCU enabled.
+[    0.000000] ?Rude variant of Tasks RCU enabled.
+[    0.000000] ?Tracing variant of Tasks RCU enabled.
+[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
+[    0.000000] RCU Tasks: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] RCU Tasks Rude: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] RCU Tasks Trace: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
+[    0.000000] GICv3: 480 SPIs implemented
+[    0.000000] GICv3: 0 Extended SPIs implemented
+[    0.000000] Root IRQ handler: gic_handle_irq
+[    0.000000] GICv3: GICv3 features: 16 PPIs
+[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
+[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c040000
+[    0.000000] GICv3: GIC: PPI partition interrupt-partition-0[0] { /cpus/cpu@0[0] /cpus/cpu@100[1] /cpus/cpu@200[2] /cpus/cpu@300[3] /cpus/cpu@400[4] /cpus/cpu@500[5] }
+[    0.000000] GICv3: GIC: PPI partition interrupt-partition-1[1] { /cpus/cpu@600[6] /cpus/cpu@700[7] }
+[    0.000000] rcu: ?Offload RCU callbacks from CPUs: 0-7.
+[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
+[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
+[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
+[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
+[    0.000453] kfence: initialized - using 2097152 bytes for 255 objects at 0x(____ptrval____)-0x(____ptrval____)
+[    0.000563] Console: colour dummy device 80x25
+[    0.000596] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=13000)
+[    0.000602] pid_max: default: 32768 minimum: 301
+[    0.000672] LSM: initializing lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf
+[    0.000779] landlock: Up and running.
+[    0.000781] Yama: becoming mindful.
+[    0.000795] LoadPin: ready to pin (currently not enforcing)
+[    0.000813] SELinux:  Initializing.
+[    0.001543] LSM support for eBPF active
+[    0.001614] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.001630] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.004009] rcu: Hierarchical SRCU implementation.
+[    0.004013] rcu: ?Max phase no-delay instances is 400.
+[    0.004266] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
+[    0.006008] smp: Bringing up secondary CPUs ...
+[    0.010233] Detected VIPT I-cache on CPU1
+[    0.010291] GICv3: CPU1: found redistributor 100 region 0:0x000000000c060000
+[    0.010321] CPU1: Booted secondary processor 0x0000000100 [0x411fd050]
+[    0.014307] Detected VIPT I-cache on CPU2
+[    0.014358] GICv3: CPU2: found redistributor 200 region 0:0x000000000c080000
+[    0.014381] CPU2: Booted secondary processor 0x0000000200 [0x411fd050]
+[    0.016255] Detected VIPT I-cache on CPU3
+[    0.016300] GICv3: CPU3: found redistributor 300 region 0:0x000000000c0a0000
+[    0.016321] CPU3: Booted secondary processor 0x0000000300 [0x411fd050]
+[    0.019309] Detected VIPT I-cache on CPU4
+[    0.019352] GICv3: CPU4: found redistributor 400 region 0:0x000000000c0c0000
+[    0.019371] CPU4: Booted secondary processor 0x0000000400 [0x411fd050]
+[    0.021329] Detected VIPT I-cache on CPU5
+[    0.021373] GICv3: CPU5: found redistributor 500 region 0:0x000000000c0e0000
+[    0.021392] CPU5: Booted secondary processor 0x0000000500 [0x411fd050]
+[    0.025360] CPU features: detected: Spectre-v4
+[    0.025365] CPU features: detected: Spectre-BHB
+[    0.025367] CPU features: detected: ARM erratum 1418040
+[    0.025368] CPU features: detected: ARM erratum 1463225
+[    0.025371] CPU features: detected: SSBS not fully self-synchronizing
+[    0.025373] Detected PIPT I-cache on CPU6
+[    0.025412] GICv3: CPU6: found redistributor 600 region 0:0x000000000c100000
+[    0.025418] arch_timer: Enabling local workaround for ARM erratum 1418040
+[    0.025429] CPU6: Booted secondary processor 0x0000000600 [0x413fd0b0]
+[    0.028360] Detected PIPT I-cache on CPU7
+[    0.028403] GICv3: CPU7: found redistributor 700 region 0:0x000000000c120000
+[    0.028410] arch_timer: Enabling local workaround for ARM erratum 1418040
+[    0.028420] CPU7: Booted secondary processor 0x0000000700 [0x413fd0b0]
+[    0.028488] smp: Brought up 1 node, 8 CPUs
+[    0.028493] SMP: Total of 8 processors activated.
+[    0.028495] CPU: All CPU(s) started at EL2
+[    0.028498] CPU features: detected: 32-bit EL0 Support
+[    0.028500] CPU features: detected: Data cache clean to the PoU not required for I/D coherence
+[    0.028503] CPU features: detected: Common not Private translations
+[    0.028505] CPU features: detected: CRC32 instructions
+[    0.028510] CPU features: detected: RCpc load-acquire (LDAPR)
+[    0.028512] CPU features: detected: LSE atomic instructions
+[    0.028514] CPU features: detected: Privileged Access Never
+[    0.028516] CPU features: detected: RAS Extension Support
+[    0.028519] CPU features: detected: Speculative Store Bypassing Safe (SSBS)
+[    0.028562] alternatives: applying system-wide alternatives
+[    0.031098] CPU features: detected: Hardware dirty bit management on CPU6-7
+[    0.031284] Memory: 8052028K/8384512K available (15680K kernel code, 2998K rwdata, 23036K rodata, 6848K init, 689K bss, 326456K reserved, 0K cma-reserved)
+[    0.032476] devtmpfs: initialized
+[    0.037857] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275000 ns
+[    0.037876] futex hash table entries: 2048 (order: 5, 131072 bytes, linear)
+[    0.037931] 2G module region forced by RANDOMIZE_MODULE_REGION_FULL
+[    0.037932] 0 pages in range for non-PLT usage
+[    0.037934] 511920 pages in range for PLT usage
+[    0.038048] pinctrl core: initialized pinctrl subsystem
+[    0.038436] NET: Registered PF_NETLINK/PF_ROUTE protocol family
+[    0.038953] DMA: preallocated 1024 KiB GFP_KERNEL pool for atomic allocations
+[    0.039117] DMA: preallocated 1024 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
+[    0.039269] DMA: preallocated 1024 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
+[    0.039287] audit: initializing netlink subsys (disabled)
+[    0.039387] audit: type=2000 audit(0.037:1): state=initialized audit_enabled=0 res=1
+[    0.039709] thermal_sys: Registered thermal governor 'step_wise'
+[    0.039711] thermal_sys: Registered thermal governor 'user_space'
+[    0.039714] thermal_sys: Registered thermal governor 'power_allocator'
+[    0.039749] cpuidle: using governor ladder
+[    0.039766] cpuidle: using governor menu
+[    0.039798] NET: Registered PF_QIPCRTR protocol family
+[    0.039907] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
+[    0.040027] ASID allocator initialised with 32768 entries
+[    0.040831] ramoops: found existing invalid buffer, size 11040, start 4221728
+[    0.040859] ramoops: found existing invalid buffer, size 3146560, start 131072
+[    0.041005] pstore: Using crash dump compression: deflate
+[    0.041010] printk: legacy console [ramoops-1] enabled
+[    0.041443] pstore: Registered ramoops as persistent store backend
+[    0.041448] ramoops: using 0x100000@0xffec6000, ecc: 0
+[    0.045490] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
+[    0.045620] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58/aux-bus/panel
+[    0.045635] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.045653] /soc/i2c@11007000/anx7625@58/aux-bus/panel: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.045815] /soc/dsi@14013000: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.050583] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58/aux-bus/panel
+[    0.050604] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.050622] /soc/i2c@11007000/anx7625@58/aux-bus/panel: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.053768] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.053804] /soc/dsi@14013000: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.058777] cryptd: max_cpu_qlen set to 1000
+[    0.061198] iommu: Default domain type: Translated
+[    0.061207] iommu: DMA domain TLB invalidation policy: strict mode
+[    0.062547] SCSI subsystem initialized
+[    0.062616] usbcore: registered new interface driver usbfs
+[    0.062630] usbcore: registered new interface driver hub
+[    0.062645] usbcore: registered new device driver usb
+[    0.062687] mc: Linux media interface: v0.10
+[    0.062707] videodev: Linux video capture interface: v2.00
+[    0.063559] Advanced Linux Sound Architecture Driver Initialized.
+[    0.064056] vgaarb: loaded
+[    0.064262] clocksource: Switched to clocksource arch_sys_counter
+[    0.064481] VFS: Disk quotas dquot_6.6.0
+[    0.064502] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.068937] NET: Registered PF_INET protocol family
+[    0.069100] IP idents hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+[    0.098988] tcp_listen_portaddr_hash hash table entries: 4096 (order: 5, 131072 bytes, linear)
+[    0.099101] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
+[    0.099151] TCP established hash table entries: 65536 (order: 7, 524288 bytes, linear)
+[    0.099840] TCP bind hash table entries: 65536 (order: 10, 4194304 bytes, linear)
+[    0.102209] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.102378] UDP hash table entries: 4096 (order: 7, 655360 bytes, linear)
+[    0.102734] UDP-Lite hash table entries: 4096 (order: 7, 655360 bytes, linear)
+[    0.103079] NET: Registered PF_UNIX/PF_LOCAL protocol family
+[    0.103376] RPC: Registered named UNIX socket transport module.
+[    0.103385] RPC: Registered udp transport module.
+[    0.103388] RPC: Registered tcp transport module.
+[    0.103392] RPC: Registered tcp-with-tls transport module.
+[    0.103395] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[    0.103404] PCI: CLS 0 bytes, default 64
+[    0.103586] Unpacking initramfs...
+[    0.109707] kvm [1]: nv: 566 coarse grained trap handlers
+[    0.109936] kvm [1]: IPA Size Limit: 40 bits
+[    0.109954] kvm [1]: GICv3: no GICV resource entry
+[    0.109958] kvm [1]: disabling GICv2 emulation
+[    0.109979] kvm [1]: GIC system register CPU interface enabled
+[    0.109996] kvm [1]: vgic interrupt IRQ18
+[    0.110018] kvm [1]: VHE mode initialized successfully
+[    0.337465] Initialise system trusted keyrings
+[    0.337630] workingset: timestamp_bits=62 max_order=21 bucket_order=0
+[    0.338031] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.338322] NFS: Registering the id_resolver key type
+[    0.338336] Key type id_resolver registered
+[    0.338341] Key type id_legacy registered
+[    0.367287] Key type asymmetric registered
+[    0.367301] Asymmetric key parser 'x509' registered
+[    0.367359] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 245)
+[    0.367478] io scheduler mq-deadline registered
+[    0.367485] io scheduler kyber registered
+[    0.367509] io scheduler bfq registered
+[    0.373028] Cannot find regmap for /soc/clock-controller@1a000000: -EINVAL
+[    0.373046] clk-mt8186-cam 1a000000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.373079] Cannot find regmap for /soc/clock-controller@1a04f000: -EINVAL
+[    0.373087] clk-mt8186-cam 1a04f000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.373111] Cannot find regmap for /soc/clock-controller@1a06f000: -EINVAL
+[    0.373118] clk-mt8186-cam 1a06f000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.373211] Cannot find regmap for /soc/clock-controller@15020000: -EINVAL
+[    0.373218] clk-mt8186-img 15020000.clock-controller: probe with driver clk-mt8186-img failed with error -22
+[    0.373243] Cannot find regmap for /soc/clock-controller@15820000: -EINVAL
+[    0.373257] clk-mt8186-img 15820000.clock-controller: probe with driver clk-mt8186-img failed with error -22
+[    0.373329] Cannot find regmap for /soc/clock-controller@11017000: -EINVAL
+[    0.373336] clk-mt8186-imp_iic_wrap 11017000.clock-controller: probe with driver clk-mt8186-imp_iic_wrap failed with error -22
+[    0.373439] Cannot find regmap for /soc/clock-controller@1c000000: -EINVAL
+[    0.373446] clk-mt8186-ipe 1c000000.clock-controller: probe with driver clk-mt8186-ipe failed with error -22
+[    0.373653] Cannot find regmap for /soc/clock-controller@1b000000: -EINVAL
+[    0.373661] clk-mt8186-mdp 1b000000.clock-controller: probe with driver clk-mt8186-mdp failed with error -22
+[    0.373722] Cannot find regmap for /soc/clock-controller@13000000: -EINVAL
+[    0.373729] clk-mt8186-mfg 13000000.clock-controller: probe with driver clk-mt8186-mfg failed with error -22
+[    0.373838] Cannot find regmap for /soc/clock-controller@1602f000: -EINVAL
+[    0.373845] clk-mt8186-vdec 1602f000.clock-controller: probe with driver clk-mt8186-vdec failed with error -22
+[    0.373920] Cannot find regmap for /soc/clock-controller@17000000: -EINVAL
+[    0.373927] clk-mt8186-venc 17000000.clock-controller: probe with driver clk-mt8186-venc failed with error -22
+[    0.373999] Cannot find regmap for /soc/clock-controller@14020000: -EINVAL
+[    0.374006] clk-mt8186-wpe 14020000.clock-controller: probe with driver clk-mt8186-wpe failed with error -22
+[    0.378599] mtk-socinfo mtk-socinfo.0.auto: MediaTek Kompanio 520 (MT8186) SoC detected.
+[    0.379518] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+[    0.380573] printk: legacy console [ttyS0] disabled
+[    0.400811] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 245, base_baud = 1625000) is a ST16650V2
+[    0.400853] printk: legacy console [ttyS0] enabled
+[    0.468772] Freeing initrd memory: 12588K
+[    0.484300] usbcore: registered new interface driver udl
+[    2.084837] loop: module loaded
+[    2.088030] lkdtm: No crash points registered, enable through debugfs
+[    2.095003] mt6359-auxadc: Failed to locate of_node [id: -1]
+[    2.100811] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vs2
+[    2.111598] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vdram1
+[    2.122642] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vs1
+[    2.134008] mt6358-keys: Failed to locate of_node [id: -1]
+[    2.142336] spi-nor spi2.0: supply vcc not found, using dummy regulator
+[    2.150328] mtk-spi-nor 11000000.spi: spi frequency: 39000000 Hz
+[    2.156928] PPP generic driver version 2.4.2
+[    2.161376] PPP MPPE Compression module registered
+[    2.167036] usbcore: registered new interface driver cdc_acm
+[    2.172702] cdc_acm: USB Abstract Control Model driver for USB modems and ISDN adapters
+[    2.172703] tpm_tis_spi spi1.0: IRQ not confirmed - will use delays
+[    2.180824] usbcore: registered new interface driver uas
+[    2.192277] usbcore: registered new interface driver usb-storage
+[    2.198287] usbcore: registered new device driver onboard-usb-dev
+[    2.205586] mt6397-rtc mt6358-rtc: registered as rtc0
+[    2.210806] mt6397-rtc mt6358-rtc: setting system clock to 2025-01-29T01:23:13 UTC (1738113793)
+[    2.219543] i2c_dev: i2c /dev entries driver
+[    2.224545] device-mapper: ioctl: 4.49.0-ioctl (2025-01-17) initialised: dm-devel@lists.linux.dev
+[    2.234561] sdhci: Secure Digital Host Controller Interface driver
+[    2.240747] sdhci: Copyright(c) Pierre Ossman
+[    2.245397] sdhci-pltfm: SDHCI platform and OF driver helper
+[    2.251121] coreboot_table firmware:coreboot: probe with driver coreboot_table failed with error -22
+[    2.260360] SMCCC: SOC_ID: ID = jep106:0426:8186 Revision = 0x00000000
+[    2.266909] hid: raw HID events driver (C) Jiri Kosina
+[    2.272314] usbcore: registered new interface driver usbhid
+[    2.277896] usbhid: USB HID core driver
+[    2.282071] spi_master spi0: will run message pump with realtime priority
+[    2.289025] hw perfevents: enabled with armv8_cortex_a55 PMU driver, 7 (0,8000003f) counters available
+[    2.299547] hw perfevents: enabled with armv8_cortex_a76 PMU driver, 7 (0,8000003f) counters available
+[    2.312686] GACT probability NOT on
+[    2.316338] xt_time: kernel timezone is -0000
+[    2.320844] Initializing XFRM netlink socket
+[    2.325183] NET: Registered PF_INET6 protocol family
+[    2.330554] tpm_tis_spi spi1.0: 2.0 TPM (device-id 0x504A, rev-id 83)
+[    2.330886] Segment Routing with IPv6
+[    2.340677] In-situ OAM (IOAM) with IPv6
+[    2.344674] NET: Registered PF_PACKET protocol family
+[    2.349740] NET: Registered PF_KEY protocol family
+[    2.349754] Key type dns_resolver registered
+[    2.358978] NET: Registered PF_VSOCK protocol family
+[    2.367919] registered taskstats version 1
+[    2.372248] Loading compiled-in X.509 certificates
+[    2.377311] thermal thermal_zone0: power_allocator: sustainable_power will be estimated
+[    2.381776] Key type .fscrypt registered
+[    2.385442] sbs-battery 6-000b: sbs-battery: battery gas gauge device registered
+[    2.389230] Key type fscrypt-provisioning registered
+[    2.389364] Key type encrypted registered
+[    2.419293] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ovl@14005000
+[    2.427763] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ovl@14006000
+[    2.436173] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/rdma@14007000
+[    2.444684] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/color@14009000
+[    2.453295] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ccorr@1400b000
+[    2.461950] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/aal@1400c000
+[    2.470340] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/gamma@1400d000
+[    2.477981] sbs-battery 6-000b: I2C adapter does not support I2C_FUNC_SMBUS_READ_BLOCK_DATA.
+[    2.477981] Fallback method does not support PEC.
+[    2.478955] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/dsi@14013000
+[    2.500358] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/rdma@1401f000
+[    2.520797] cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 1999998 kHz, changing to: 2000000 kHz
+[    2.529596] pp3300_vcn33_x: Bringing 3500000uV into 3300000-3300000uV
+[    2.531831] cpu cpu0: EM: created perf domain
+[    2.535456] input: cros_ec as /devices/platform/soc/11010000.spi/spi_master/spi0/spi0.0/11010000.spi:ec@0:keyboard-controller/input/input0
+[    2.538858] pp2760_vsim2_x: Bringing 1860000uV into 2700000-2700000uV
+[    2.543157] cpufreq: cpufreq_online: CPU6: Running at unlisted initial frequency: 1084999 kHz, changing to: 1085000 kHz
+[    2.572333] cpu cpu6: EM: created perf domain
+[    2.578636] input: cros_ec_buttons as /devices/platform/soc/11010000.spi/spi_master/spi0/spi0.0/11010000.spi:ec@0:keyboard-controller/input/input1
+[    2.578987] mmc0: CQHCI version 5.10
+[    2.579409] mtk-msdc 11240000.mmc: allocated mmc-pwrseq
+[    2.579931] mt6358-sound mt6358-sound: mt6358_platform_driver_probe(), dev name mt6358-sound
+[    2.589031] input: gpio-keys as /devices/platform/gpio-keys/input/input2
+[    2.589360] input: wifi-wakeup as /devices/platform/wifi-wakeup/input/input3
+[    2.598289] cros-ec-spi spi0.0: Chrome EC device registered
+[    2.610888] clk: Disabling unused clocks
+[    2.632495] PM: genpd: Disabling unused power domains
+[    2.637549] ALSA device list:
+[    2.640511]   No soundcards found.
+[    2.656862] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=00000C00; host->error=0x00000002
+[    2.666490] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=80000C08; host->error=0x00000002
+[    2.701698] mmc1: new UHS-I speed SDR104 SDIO card at address 0001
+[    2.776710] mtk-msdc 11230000.mmc: Final PAD_DS_TUNE: 0x11814
+[    2.783585] mmc0: Command Queue Engine enabled
+[    2.788036] mmc0: new HS400 MMC card at address 0001
+[    2.793543] mmcblk0: mmc0:0001 MMC64G 58.3 GiB
+[    2.800861]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12
+[    2.808182] mmcblk0boot0: mmc0:0001 MMC64G 4.00 MiB
+[    2.813679] mmcblk0boot1: mmc0:0001 MMC64G 4.00 MiB
+[    2.819206] mmcblk0rpmb: mmc0:0001 MMC64G 16.0 MiB, chardev (241:0)
+[    2.867607] tpm_tis_spi spi1.0: Cr50 firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5a
+[    2.880976] Freeing unused kernel memory: 6848K
+[    2.885559] Run /init as init process
+Loading, please wait...
+Starting systemd-udevd version 252.22-1~deb12u1
+[    3.081343] LoadPin: mnt_sb lacks block device, treating as: writable
+[    3.087802] LoadPin: kernel-module pinned obj="/usr/lib/modules/6.13.0/kernel/drivers/watchdog/mtk_wdt.ko" pid=171 cmdline="(udev-worker)"
+[    3.101325] mtk-wdt 10007000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
+[    3.111878] mtk-lvts-thermal 1100b000.thermal-sensor: fake golden temp=50
+[    3.112744] mt8186-audio 11210000.audio-controller: mtk_afe_combine_sub_dai(), num of dai 41
+[    3.113003] mtk-scp 10500000.scp: assigned reserved memory node memory@50000000
+[    3.113893] remoteproc remoteproc0: scp is available
+[    3.113928] remoteproc remoteproc0: powering up scp
+[    3.113931] remoteproc remoteproc0: Booting fw image mediatek/mt8186/scp.img, size 419488
+[    3.113935] mtk-scp 10500000.scp: IPI buf addr 0x0003bdb0
+[    3.119323] thermal thermal_zone1: power_allocator: sustainable_power will be estimated
+[    3.127382] mt8186-audio 11210000.audio-controller: No cache defaults, reading back from HW
+[    3.135580] thermal thermal_zone2: power_allocator: sustainable_power will be estimated
+[    3.183130] thermal thermal_zone3: power_allocator: sustainable_power will be estimated
+[    3.191881] thermal thermal_zone4: power_allocator: sustainable_power will be estimated
+[    3.200736] thermal thermal_zone5: power_allocator: sustainable_power will be estimated
+[    3.202609] mtk-scp 10500000.scp: creating channel cros-ec-rpmsg addr 0xd
+[    3.202653] mtk-scp 10500000.scp: SCP is ready. FW version corsola_scp_v2.0.18944-70c8f752
+[    3.202657] remoteproc remoteproc0: remote processor scp is now up
+[    3.209554] thermal thermal_zone6: power_allocator: sustainable_power will be estimated
+[    3.216173] cros-ec-dev cros-ec-dev.16.auto: CrOS System Control Processor MCU detected
+[    3.224614] thermal thermal_zone7: power_allocator: sustainable_power will be estimated
+[    3.231671] cros-ec-rpmsg 10500000.scp.cros-ec-rpmsg.13.-1: Chrome EC device registered
+[    3.239303] thermal thermal_zone8: power_allocator: sustainable_power will be estimated
+[    3.274968] thermal thermal_zone9: power_allocator: sustainable_power will be estimated
+[    3.294423] Bluetooth: Core ver 2.22
+[    3.298445] NET: Registered PF_BLUETOOTH protocol family
+[    3.303803] Bluetooth: HCI device and connection manager initialized
+[    3.310273] Bluetooth: HCI socket layer initialized
+[    3.315200] Bluetooth: L2CAP socket layer initialized
+[    3.320274] Bluetooth: SCO socket layer initialized
+[    3.323893] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+[    3.334319] cfg80211: failed to load regulatory.db
+[    3.347753] bluetooth hci0: Direct firmware load for mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin failed with error -2
+[    3.358066] Bluetooth: hci0: Failed to load firmware file (-2)
+[    3.363904] Bluetooth: hci0: Failed to setup 79xx firmware (-2)
+[    3.387222] mt7921s mmc1:0001:1: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a
+[    3.387222]
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/nfs-top ... done.
+Begin: Running /scripts/nfs-premount ... Waiting up to 60 secs for any ethernet to become available
+[    3.662851] mt7921s mmc1:0001:1: WM Firmware Version: ____010000, Build Time: 20241106151045
+Device /sys/class/net/wlan0 found
+done.
+Begin: Waiting up to 180 secs for any network device to become available ... done.
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 2 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 3 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+[   13.801058] mtk-vcodec-dec 16000000.video-decoder: deferred probe timeout, ignoring dependency
+[   13.823340] platform 14013000.dsi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.834249] platform 13040000.gpu: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.845130] platform 11201000.usb: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.855994] platform 16025000.video-codec: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.867553] platform 11281000.usb: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.878424] platform 11007000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.888680] platform 11008000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.898935] platform 11009000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.909191] platform 1100f000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.919446] platform 11016000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.929701] platform 14002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.940567] platform 14003000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.951431] platform 14004000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.962295] platform 14023000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.973157] platform 1502e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.984020] platform 1582e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.994883] platform 1602e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.005746] platform 17010000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.016608] platform 1a001000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.027472] platform 1a002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.038335] platform 1a00f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.049197] platform 1a010000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.060067] platform 1b002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.070930] platform 1c00f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.081805] platform 1c10f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.092673] platform 1100bc00.svs: deferred probe pending: mtk-svs: failed to get OPP device for bank 4
+[   14.102061] platform 10680000.adsp: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.113010] platform 17020000.video-encoder: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.124742] platform sound: deferred probe pending: mt8186_mt6366: I2S0: codec dai not found
+[   14.133174] platform 14001000.mutex: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.144210] platform 10006000.syscon:power-controller: deferred probe pending: mtk-power-controller: /soc/syscon@10006000/power-controller/power-domain@6/power-domain@14: failed to get child domain id
+[   14.162024] platform 14016000.iommu: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.173060] platform 1400c000.aal: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.183923] platform 1400b000.ccorr: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.194965] platform 14009000.color: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.206001] platform 1400d000.gamma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.217038] platform 14005000.ovl: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.227901] platform 17030000.jpeg-encoder: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.239544] platform 14006000.ovl: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.250408] platform 14007000.rdma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.261357] platform 1401f000.rdma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+IP-Config: no response after 4 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 6 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 9 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+[   32.737528] pp1000_edpbrdg: disabling
+[   32.741231] pp3300_edp_dx: disabling
+[   32.744849] ppvar_dvdd_vgpu: disabling
+[   32.748627] pp3300_disp_x: disabling
+[   32.752376] pp0900_dvdd_sram_gpu: disabling
+[   32.756627] pp1840_vaux18: disabling
+[   32.760380] pp2800_vaud28: disabling
+[   32.764004] pp1800_edpbrdg_dx: disabling
+IP-Config: no response after 16 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+[   62.434953] PDLOG 2025/01/29 01:19:14.660 P0 SNK Charger ??? 5000mV max 5000mV / 500mA
+[   62.444369] PDLOG 2025/01/29 01:19:14.832 P0 SNK Charger ??? 4975mV max 20000mV / 3250mA
+[   62.453937] PDLOG 2025/01/29 01:19:36.860 P0 SNK Charger ??? 11750mV max 20000mV / 3250mA
+IP-Config: no response after 25 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+#
+#
+IP-Config: no response after 36 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+IP-Config: no response after 64 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+#
+#
+#
+#
+IP-Config: no response after 100 secs - giving up
+/init: 384: .: [  271.403835] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
+[  271.412757] CPU: 7 UID: 0 PID: 1 Comm: init Not tainted 6.13.0 #1 865d6bb48e84b69528fd174092f0d34c61cedaf4
+[  271.422397] Hardware name: Google Steelix board (DT)
+[  271.427348] Call trace:
+[  271.429782]  show_stack+0x20/0x38 (C)
+[  271.433437]  dump_stack_lvl+0xc8/0xf8
+[  271.437089]  dump_stack+0x18/0x28
+[  271.440392]  panic+0x3d0/0x438
+[  271.443436]  do_exit+0x84c/0xa28
+[  271.446654]  __arm64_sys_exit+0x20/0x28
+[  271.450479]  invoke_syscall+0x70/0x100
+[  271.454218]  el0_svc_common.constprop.0+0x48/0xf0
+[  271.458911]  do_el0_svc+0x24/0x38
+[  271.462215]  el0_svc+0x34/0xf0
+[  271.465259]  el0t_64_sync_handler+0x10c/0x138
+[  271.469605]  el0t_64_sync+0x1b0/0x1b8
+[  271.473256] SMP: stopping secondary CPUs
+[  271.477240] Kernel Offset: 0x3aaa1de00000 from 0xffff800080000000
+[  271.483320] PHYS_OFFSET: 0xfff081e440000000
+[  271.487491] CPU features: 0x300,00006170,00901250,8200720b
+[  271.492962] Memory Limit: none
+[DL] 00000000 00000000 010701
+F0: 102B 0000
+F1: 0000 0000
+V0: 0000 0000 [0001]
+00: 1027 0002
+01: 0000 0000
+BP: 0C00 0251 [0000]
+G0: 1182 0000
+EC: 0000 0000 [1000]
+T0: 0000 00C5 [1010]
+Jump to BL
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 bootblock starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x1000000000000) with new page table @0x00100000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00000000:0x200000000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x8000000000) with new page table @0x00101000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00100000:0x00110000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x40000000) with new page table @0x00102000^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x00200000) with new page table @0x00103000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00200000:0x00400000) with new page table @0x00104000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00107000:0x00108000) as non-cacheable | read-write |     secure | normal^[[0m
+^[[0m[INFO ]  WDT: Status = 0x0^[[0m
+^[[0m[INFO ]  WDT: Last reset was cold boot^[[0m
+^[[0m[DEBUG]  SPI1(PAD0) initialized at 2951351 Hz^[[0m
+^[[0m[DEBUG]  SPI2(PAD0) initialized at 992727 Hz^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  VBOOT: Loading verstage.^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 1148 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  FMAP: Found "FLASH" version 1.1 at 0x20000.^[[0m
+^[[0m[DEBUG]  FMAP: base = 0x0 size = 0x800000 #areas = 26^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 0 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[INFO ]  CBFS: mcache @0x0010c000 built for 68 files, used 0x1a3c of 0x2000 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/verstage' @0x49800 size 0xa7c2 in mcache @0x0010c3b0^[[0m
+^[[0m[DEBUG]  read SPI 0x6a880 0xa7c2: 3614 us, 11883 KB/s, 95.064 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 42946 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 verstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  FMAP: area RW_NVRAM found @ 57b000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  TPM ready after 2272 ms^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5ad9^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_send_startup: Startup return code is 0^[[0m
+^[[0m[INFO ]  TPM: setup succeeded^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1007 return code 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1008 return code 0^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  Reading cr50 boot mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Cr50 says boot_mode is VERIFIED_RW(0x00).^[[0m
+^[[0m[INFO ]  Phase 1^[[0m
+^[[0m[DEBUG]  FMAP: area GBB found @ 3f3000 (12032 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() Recovery reason from previous boot: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() We have a recovery request: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  Recovery requested (1009000e)^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: boot mode` into PCR 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: boot mode` to PCR 0 measured^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: GBB HWID` into PCR 1^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: GBB HWID` to PCR 1 measured^[[0m
+^[[0m[DEBUG]  VBOOT: Returning from verstage.^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/romstage' @0x80 size 0xe96a in mcache @0x0010c02c^[[0m
+^[[0m[DEBUG]  read SPI 0x21100 0xe96a: 5015 us, 11915 KB/s, 95.320 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 59754 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: bootblock times (exec / console): total (unknown) / 236 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 romstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  pmic_check_hwcid: ID = 0x6610^[[0m
+^[[0m[INFO ]  Check CPU freq: 1999968 KHz, cci: 1385006 KHz^[[0m
+^[[0m[INFO ]  [RTC]rtc_set_capid,243: read back capid: 0xe0^[[0m
+^[[0m[INFO ]  [RTC]rtc_enable_dcxo,50: con = 0x482, osc32con = 0xc272, sec = 0x200d^[[0m
+^[[0m[INFO ]  [RTC]rtc_check_state,173: con=482, pwrkey1=a357, pwrkey2=67d2^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,62: osc32con val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,20: PMIC_RG_FQMTR_CKSEL=0x4a^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0xf, output = 0x2d8^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x17, output = 0x394^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x13, output = 0x335^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x307^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x307^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,47: left: 17, middle: 17, right: 18^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,66: EOSC32 cali val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,202: RTC_STATE_REBOOT^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,220: irqsta=0, bbpu=9, con=482^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,319: rtc_write_trigger = 1^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,322: done BBPU = 0x9^[[0m
+^[[0m[INFO ]  CPU: 0x81861001^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[1;4m[WARN ]  DRAM-K: Invalid data in flash (size: 0xffffffffffffffff, expected: 0xf80)^[[0m
+^[[0m[INFO ]  DRAM-K: Running full calibration^[[0m
+^[[0m[INFO ]  DRAM-K: ddr_type: DSC, config_dvfs: 0, ddr_geometry: 2CH_2RK_4GB_2_2^[[0m
+^[[0m[INFO ]  header.status = 0x0^[[0m
+^[[0m[INFO ]  header.version = 0x1 (expected: 0x1)^[[0m
+^[[0m[INFO ]  header.size = 0xf80 (expected: 0xf80)^[[0m
+^[[0m[INFO ]  header.flags = 0x0^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/dram' @0x2d980 size 0x14ab1 in mcache @0x0010c2e0^[[0m
+^[[0m[DEBUG]  read SPI 0x4e9fc 0x14ab1: 6909 us, 12253 KB/s, 98.024 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 84657 bytes, hash algo 2, HW acceleration forbidden^[[0m
+dram_init: MediaTek DRAM firmware version: 0.1.0, accepting param version 1
+EMI_MPU_CTRL=0 1st
+EMI_MPU_CTRL=0 2nd
+Vm18 = 1800000
+Vdram = 0
+Vddq = 0
+Vmddr = 750000
+Will call Init_DRAM MDL_USED
+[EMI] CEN_CONA(0x3530154),CEN_CONF(0x421000),CEN_CONH(0x88880033),CEN_CONK(0x0),CHN_CONA(0x488005d)
+[DRAMC] type = 6
+[1600][CH0][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA0, Window Sum 368
+[1600][CH0][RK1][CBT] Best Vref 26 VrefRange 1, Window Min 62 at CA0, Window Sum 370
+[1600][CH0][RK0][TX] Best Vref 26 VrefRange 1, Window Min 27 at DQ8, Window Sum 454
+[1600][CH0][RK0][RX] Best Vref B0 = 44, Window Min 69 at DQ1, Window Sum 620
+[1600][CH0][RK0][RX] Best Vref B1 = 44, Window Min 73 at DQ8, Window Sum 622
+[1600][CH0][RK1][TX] Best Vref 26 VrefRange 1, Window Min 27 at DQ8, Window Sum 452
+[1600][CH1][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA3, Window Sum 365
+[1600][CH1][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA3, Window Sum 365
+[1600][CH1][RK0][TX] Best Vref 28 VrefRange 1, Window Min 28 at DQ8, Window Sum 473
+[1600][CH1][RK0][RX] Best Vref B0 = 42, Window Min 73 at DQ4, Window Sum 642
+[1600][CH1][RK0][RX] Best Vref B1 = 42, Window Min 73 at DQ15, Window Sum 648
+[1600][CH1][RK1][TX] Best Vref 24 VrefRange 1, Window Min 28 at DQ8, Window Sum 468
+sync_frequency_calibration_params sync calibration params of frequency 800 to shu:6
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 800
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 12
+[0] MIN Duty = 4892%(X100), DQS PI = 46
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 32
+[0] MIN Duty = 4928%(X100), DQS PI = 20
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 180%
+CH0 DQS 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 22
+[0] MIN Duty = 4928%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 50
+[0] MIN Duty = 5000%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 144%
+CH0 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5144%(X100), DQS PI = 32
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 46
+[0] MIN Duty = 4964%(X100), DQS PI = 14
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 216%
+CH0 DQ 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5109%(X100), DQS PI = 34
+[0] MIN Duty = 4819%(X100), DQS PI = 2
+[0] AVG Duty = 4964%(X100)
+CH1 CLK Duty spec in!! Max-Min= 290%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4855%(X100), DQS PI = 50
+[-1] AVG Duty = 4981%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5036%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 253%
+CH1 DQS 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 8
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4964%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 24
+[1] MIN Duty = 4892%(X100), DQS PI = 52
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 144%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 32
+[0] MIN Duty = 4856%(X100), DQS PI = 0
+[0] AVG Duty = 4964%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 28
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 216%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3200][CH0][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 359
+[3200][CH0][RK1][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA0, Window Sum 361
+[3200][CH0][RK0][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ4, Window Sum 448
+[3200][CH0][RK0][RX] Best Vref B0 = 20, Window Min 33 at DQ6, Window Sum 299
+[3200][CH0][RK0][RX] Best Vref B1 = 20, Window Min 34 at DQ10, Window Sum 296
+[3200][CH0][RK1][TX] Best Vref 24 VrefRange 0, Window Min 26 at DQ4, Window Sum 436
+[3200][CH1][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 360
+[3200][CH1][RK1][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA3, Window Sum 360
+[3200][CH1][RK0][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ10, Window Sum 449
+[3200][CH1][RK0][RX] Best Vref B0 = 20, Window Min 31 at DQ2, Window Sum 291
+[3200][CH1][RK0][RX] Best Vref B1 = 22, Window Min 32 at DQ11, Window Sum 288
+[3200][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ8, Window Sum 445
+sync_frequency_calibration_params sync calibration params of frequency 1600 to shu:7
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1600
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4856%(X100), DQS PI = 48
+[0] AVG Duty = 4964%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 46
+[0] MIN Duty = 4892%(X100), DQS PI = 36
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 216%
+CH0 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 12
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 24
+[0] MIN Duty = 4964%(X100), DQS PI = 54
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 72%
+CH0 DQM 1 Duty spec in!! Max-Min= 181%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5000%(X100), DQS PI = 12
+[0] MIN Duty = 4856%(X100), DQS PI = 0
+[0] AVG Duty = 4928%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 48
+[0] MIN Duty = 4928%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 144%
+CH0 DQ 1 Duty spec in!! Max-Min= 217%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4746%(X100), DQS PI = 58
+[0] AVG Duty = 4909%(X100)
+CH1 CLK Duty spec in!! Max-Min= 326%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5072%(X100), DQS PI = 24
+[-1] MIN Duty = 4856%(X100), DQS PI = 0
+[-1] AVG Duty = 4964%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5181%(X100), DQS PI = 32
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5072%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 216%
+CH1 DQS 1 Duty spec in!! Max-Min= 217%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 0
+[0] AVG Duty = 4981%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 24
+[1] MIN Duty = 4892%(X100), DQS PI = 4
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 253%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 32
+[0] MIN Duty = 4819%(X100), DQS PI = 0
+[0] AVG Duty = 4945%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5144%(X100), DQS PI = 30
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5054%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 180%
+[3732][CH0][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 58 at CA1, Window Sum 361
+[3732][CH0][RK1][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 360
+[3732][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 25 at DQ1, Window Sum 436
+[3732][CH0][RK1][TX] Best Vref 26 VrefRange 0, Window Min 25 at DQ5, Window Sum 427
+[3732][CH0][RK0][RX] Best Vref B0 = 19, Window Min 30 at DQ3, Window Sum 254
+[3732][CH0][RK0][RX] Best Vref B1 = 19, Window Min 29 at DQ8, Window Sum 246
+[3732][CH0][RK1][RX] Best Vref B0 = 19, Window Min 29 at DQ3, Window Sum 240
+[3732][CH0][RK1][RX] Best Vref B1 = 19, Window Min 29 at DQ8, Window Sum 238
+[3732][CH1][RK0][CBT] Best Vref 22 VrefRange 0, Window Min 59 at CA1, Window Sum 358
+[3732][CH1][RK1][CBT] Best Vref 20 VrefRange 0, Window Min 60 at CA2, Window Sum 361
+[3732][CH1][RK0][TX] Best Vref 28 VrefRange 0, Window Min 26 at DQ1, Window Sum 445
+[3732][CH1][RK1][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ2, Window Sum 447
+[3732][CH1][RK0][RX] Best Vref B0 = 20, Window Min 29 at DQ5, Window Sum 252
+[3732][CH1][RK0][RX] Best Vref B1 = 21, Window Min 29 at DQ10, Window Sum 243
+[3732][CH1][RK1][RX] Best Vref B0 = 20, Window Min 30 at DQ2, Window Sum 251
+[3732][CH1][RK1][RX] Best Vref B1 = 21, Window Min 29 at DQ15, Window Sum 242
+sync_frequency_calibration_params sync calibration params of frequency 1866 to shu:0
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1866
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+sync common calibartion params.
+sync cbt_mode0:0, 1:0
+[DRAMC] rank_nr = 2
+0:dram_rank_size:100000000
+0:dram_rank_size:100000000
+1:dram_rank_size:100000000
+1:dram_rank_size:100000000
+sync rank num:2, rank0_size:0x100000000, rank1_size:0x100000000
+[freqGroup] freqGroup: 1866, Freq= 1792
+dram_init: dram init end (result: 0)
+^[[0m[INFO ]  DRAM-K: Full calibration passed in 2402 msecs^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x240000000) as     cacheable | read-write | non-secure | normal^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x40100000) as non-cacheable | read-write | non-secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x80000000) with new page table @0x00105000^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x40200000) with new page table @0x00106000^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[DEBUG]  CBMEM:^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xfffff000 254 entries.^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xffffec00 62 entries.^[[0m
+^[[0m[DEBUG]  FMAP: area RO_VPD found @ 3f8000 (32768 bytes)^[[0m
+^[[1;4m[WARN ]  RO_VPD is uninitialized or empty.^[[0m
+^[[0m[DEBUG]  FMAP: area RW_VPD found @ 577000 (16384 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/ramstage' @0xea80 size 0x105d7 in mcache @0x0010c0ac^[[0m
+^[[0m[DEBUG]  read SPI 0x2fb00 0x105d7: 5383 us, 12452 KB/s, 99.616 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 67031 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: romstage times (exec / console): total (unknown) / 1644 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 ramstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  Enumerating buses...^[[0m
+^[[0m[SPEW ]  Show all devs... Before device enumeration.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[SPEW ]  Compare with tree...^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]   CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  Root Device scanning...^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 enabled^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device done^[[0m
+^[[0m[DEBUG]  scan_bus: bus Root Device finished in 12 msecs^[[0m
+^[[0m[INFO ]  done^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE run times (exec / console): 0 / 51 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_MRC_CACHE found @ 57d000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE exit times (exec / console): 0 / 13 ms^[[0m
+^[[0m[INFO ]  Allocating resources...^[[0m
+^[[0m[INFO ]  Reading resources...^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0^[[0m
+^[[0m[INFO ]  dram size: 0x200000000^[[0m
+^[[0m[SPEW ]  dev: CPU_CLUSTER: 0, index: 0x0, base: 0x40000000, size: 0x200000000^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done reading resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After reading.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done setting resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After assigning values.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[INFO ]  Done allocating resources.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_RESOURCES run times (exec / console): 0 / 102 ms^[[0m
+^[[0m[INFO ]  Enabling resources...^[[0m
+^[[0m[INFO ]  done.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENABLE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[INFO ]  Initializing devices...^[[0m
+^[[0m[DEBUG]  Root Device init^[[0m
+^[[0m[DEBUG]  init hardware done!^[[0m
+^[[0m[DEBUG]  0x00000018: ctrlr->caps^[[0m
+^[[0m[DEBUG]  52.000 MHz: ctrlr->f_max^[[0m
+^[[0m[DEBUG]  0.400 MHz: ctrlr->f_min^[[0m
+^[[0m[DEBUG]  0x40ff8080: ctrlr->voltages^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  Early init status = 3^[[0m
+^[[0m[INFO ]  SD card init^[[0m
+^[[0m[INFO ]  [SSUSB] Setting up USB HOST controller...^[[0m
+^[[0m[INFO ]  [SSUSB] u3phy_ports_enable u2p:1, u3p:1^[[0m
+^[[0m[INFO ]  [SSUSB] phy power-on done.^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 cf 1f 01 00 00 08 00 06 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 7f 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 51 2b ^[[0m
+^[[0m[INFO ]  FW_CONFIG value from CBI is 0x2b51^[[0m
+^[[0m[INFO ]  fw_config match found: AUDIO_AMP=AMP_ALC1019^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'spm_firmware.bin' @0x2b440 size 0x249c in mcache @0xfffdc278^[[0m
+^[[0m[DEBUG]  read SPI 0x4c4a8 0x249c: 766 us, 12234 KB/s, 97.872 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 9372 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  SPM: binary array size = 0xbb8^[[0m
+^[[0m[INFO ]  SPM: spmfw (version pcm_suspend_mp_v1109            )^[[0m
+^[[0m[DEBUG]  spm_kick_im_to_fetch: ptr = 0x80000010, pmem/dmem words = 0xbb7/0x1^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) spm_firmware.bin in 47 msecs (12064 bytes)^[[0m
+^[[0m[INFO ]  SPM: spm_init done in 55 msecs, spm pc = 0x250^[[0m
+^[[0m[DEBUG]  out: cmd=0x6: 03 f7 06 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f9 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 02 00 ^[[0m
+^[[0m[INFO ]  mtk_display_init: Starting display initialization^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Init interface.^[[0m
+^[[0m[INFO ]  anx7625_disable_pd_protocol: Disabled PD feature.^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Firmware: ver 0x13, rev 0x0.^[[0m
+^[[0m[INFO ]  anx7625_start_dp_work: Secure OCM version=00^[[0m
+^[[0m[INFO ]  anx7625_hpd_change_detect: HPD received 0x7e:0x45=0x91^[[0m
+^[[0m[INFO ]  sp_tx_get_edid_block: EDID Block = 1^[[0m
+^[[0m[SPEW ]  Extracted contents:^[[0m
+^[[0m[SPEW ]  header:          00 ff ff ff ff ff ff 00^[[0m
+^[[0m[SPEW ]  serial number:   06 af 5c 63 00 00 00 00 00 1b^[[0m
+^[[0m[SPEW ]  version:         01 04^[[0m
+^[[0m[SPEW ]  basic params:    95 1a 0e 78 02^[[0m
+^[[0m[SPEW ]  chroma info:     99 85 95 55 56 92 28 22 50 54^[[0m
+^[[0m[SPEW ]  established:     00 00 00^[[0m
+^[[0m[SPEW ]  standard:        01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01^[[0m
+^[[0m[SPEW ]  descriptor 1:    66 1c 56 a0 50 00 19 30 30 20 46 00 00 90 10 00 00 18^[[0m
+^[[0m[SPEW ]  descriptor 2:    00 00 00 0f 00 00 00 00 00 00 00 00 00 00 00 00 00 20^[[0m
+^[[0m[SPEW ]  descriptor 3:    00 00 00 fe 00 41 55 4f 0a 20 20 20 20 20 20 20 20 20^[[0m
+^[[0m[SPEW ]  descriptor 4:    00 00 00 fe 00 42 31 31 36 58 41 4e 30 36 2e 33 20 0a^[[0m
+^[[0m[SPEW ]  extensions:      00^[[0m
+^[[0m[SPEW ]  checksum:        02^[[0m
+^[[0m
+^[[0m[SPEW ]  Manufacturer: AUO Model 635c Serial Number 0^[[0m
+^[[0m[SPEW ]  Made week 0 of 2017^[[0m
+^[[0m[SPEW ]  EDID version: 1.4^[[0m
+^[[0m[SPEW ]  Digital display^[[0m
+^[[0m[SPEW ]  6 bits per primary color channel^[[0m
+^[[0m[SPEW ]  DisplayPort interface^[[0m
+^[[0m[SPEW ]  Maximum image size: 26 cm x 14 cm^[[0m
+^[[0m[SPEW ]  Gamma: 220%^[[0m
+^[[0m[SPEW ]  Check DPMS levels^[[0m
+^[[0m[SPEW ]  Supported color formats: RGB 4:4:4^[[0m
+^[[0m[SPEW ]  First detailed timing is preferred timing^[[0m
+^[[0m[SPEW ]  Established timings supported:^[[0m
+^[[0m[SPEW ]  Standard timings supported:^[[0m
+^[[0m[SPEW ]  Detailed timings^[[0m
+^[[0m[SPEW ]  Hex of detail: 661c56a05000193030204600009010000018^[[0m
+^[[0m[SPEW ]  Detailed mode (IN HEX): Clock 72700 KHz, 100 mm x 90 mm^[[0m
+^[[0m[SPEW ]                 0556 0586 05a6 05f6 hborder 0^[[0m
+^[[0m[SPEW ]                 0300 0304 030a 0319 vborder 0^[[0m
+^[[0m[SPEW ]                 -hsync -vsync^[[0m
+^[[0m[SPEW ]  Did detailed timing^[[0m
+^[[0m[SPEW ]  Hex of detail: 0000000f0000000000000000000000000020^[[0m
+^[[0m[SPEW ]  Manufacturer-specified data, tag 15^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe0041554f0a202020202020202020^[[0m
+^[[0m[SPEW ]  ASCII string: AUO^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe004231313658414e30362e33200a^[[0m
+^[[0m[SPEW ]  ASCII string: B116XAN06.3 ^[[0m
+^[[0m[SPEW ]  Checksum^[[0m
+^[[0m[SPEW ]  Checksum: 0x2 (valid)^[[0m
+^[[0m[INFO ]  DSI data_rate: 436200000 bps^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: set default k value to 0x3d for panel^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: pixelclock(72700).^[[0m
+^[[0m[INFO ]   hactive(1366), hsync(32), hfp(48), hbp(80)^[[0m
+^[[0m[INFO ]   vactive(768), vsync(6), vfp(4), vbp(15)^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: config dsi.^[[0m
+^[[0m[INFO ]  anx7625_dsi_video_config: compute M(11911168), N(552960), divider(8).^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: success to config DSI^[[0m
+^[[0m[INFO ]  anx7625_dp_start: MIPI phy setup OK.^[[0m
+^[[0m[INFO ]  mtk_display_init: 'AUO B116XAN06.3 ' 1366x768@0Hz^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: display resolution: 1366x768@0 bpp 4^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: invalid vrefresh; setting to 60^[[0m
+^[[0m[INFO ]  framebuffer_info: bytes_per_line: 5464, bits_per_pixel: 32^[[0m
+^[[0m[INFO ]                     x_res x y_res: 1366 x 768, size: 4196352 at 0x0^[[0m
+^[[0m[DEBUG]  Root Device init finished in 725 msecs^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[INFO ]  CBFS: Found 'sspm.bin' @0x1f7c0 size 0xbc20 in mcache @0xfffdc218^[[0m
+^[[0m[DEBUG]  read SPI 0x40820 0xbc20: 3884 us, 12399 KB/s, 99.192 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 48160 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) sspm.bin in 30 msecs (134356 bytes)^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_0: 0x50100200^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_1: 0x43000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_2: 0x50000000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_3: 0x240000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_5: 0xc008f0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_0: 0xf3ffc3c3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_1: 0xffcc0fef^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_2: 0xff22ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_3: 0xffffffce^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_4: 0x2fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_7: 0xffc3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_8: 0x8ffff3ff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_0: 0xfcffcfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_1: 0xffffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_4: 0xfcc3fcc3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_5: 0xc300000f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_0: 0xfffff333^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_3: 0xffffffcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_5: 0xfcfffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_6: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_0: 0xf0fffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_1: 0xfcffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_4: 0xf0003fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_5: 0xf0fff3f3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_0: 0xf0fffffc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_9: 0xfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_7: 0xfff3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO)MAS_SEC_0: 0x200000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_6: 0x3fffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_7: 0x3fc00000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_20: 0xffc3ffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_20: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO)MAS_SEC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_2: 0x44^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_2: 0xcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)MAS_0: 0x6^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)SEC_0: 0x0^[[0m
+^[[0m[INFO ]  dfd_init: enable DFD (Design For Debug)^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init finished in 1194 msecs^[[0m
+^[[0m[INFO ]  Devices initialized^[[0m
+^[[0m[SPEW ]  Show all devs... After init.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_INIT run times (exec / console): 278 / 1676 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_ELOG found @ 57f000 (4096 bytes)^[[0m
+^[[0m[INFO ]  ELOG: NV offset 0x57f000 size 0x1000^[[0m
+^[[0m[DEBUG]  read SPI 0x57f000 0x1000: 363 us, 11283 KB/s, 90.264 Mbps^[[0m
+^[[0m[INFO ]  ELOG: area is 4096 bytes, full threshold 3842, shrink size 1024^[[0m
+^[[0m[INFO ]  ELOG: Event(17) added with size 13 at 2025-01-29 01:28:51 UTC^[[0m
+^[[0m[DEBUG]  out: cmd=0x121: 03 db 21 01 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 ad 00 00 2c 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 11 cd 08 00 01 00 00 00 02 04 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 08 00 00 00 58 c0 07 00 ^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() boot_mode=`Broken screen`^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() recovery_reason: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() fw_tried=`A` fw_try_count=0 fw_prev_tried=`A` fw_prev_result=`Unknown`.^[[0m
+^[[0m[INFO ]  ELOG: Event(B7) added with size 13 at 2025-01-29 01:28:51 UTC^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE entry times (exec / console): 2 / 84 ms^[[0m
+^[[0m[INFO ]  Finalize devices...^[[0m
+^[[0m[INFO ]  Devices finalized^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[DEBUG]  Writing coreboot table at 0xffec4000^[[0m
+^[[0m[DEBUG]   0. 0000000000100000-0000000000106fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   1. 0000000000108000-000000000010afff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   2. 0000000040000000-00000000400fffff: RAM^[[0m
+^[[0m[DEBUG]   3. 0000000040100000-0000000040330fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   4. 0000000040331000-00000000545fffff: RAM^[[0m
+^[[0m[DEBUG]   5. 0000000054600000-000000005465ffff: BL31^[[0m
+^[[0m[DEBUG]   6. 0000000054660000-0000000069ffffff: RAM^[[0m
+^[[0m[DEBUG]   7. 000000006a000000-000000006a0fffff: RESERVED^[[0m
+^[[0m[DEBUG]   8. 000000006a100000-00000000ffec3fff: RAM^[[0m
+^[[0m[DEBUG]   9. 00000000ffec4000-00000000ffffffff: CONFIGURATION TABLES^[[0m
+^[[0m[DEBUG]  10. 0000000100000000-000000023fffffff: RAM^[[0m
+^[[0m[INFO ]  Passing 4 GPIOs to payload:^[[0m
+^[[0m[INFO ]              NAME |       PORT | POLARITY |     VALUE^[[0m
+^[[0m[INFO ]      EC interrupt | 0x0000000d |      low | undefined^[[0m
+^[[0m[INFO ]          EC in RW | 0x0000000e |      low | undefined^[[0m
+^[[0m[INFO ]     TPM interrupt | 0x0000000f |     high | undefined^[[0m
+^[[0m[INFO ]    speaker enable | 0x00000096 |     high | undefined^[[0m
+^[[0m[DEBUG]  ADC[3]: Raw value=317871 ID=2^[[0m
+^[[0m[DEBUG]  ADC[2]: Raw value=67749 ID=0^[[0m
+^[[0m[DEBUG]  RAM Code: 0x20^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 d3 1f 01 00 00 08 00 02 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f7 00 00 04 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 00 00 02 00 ^[[0m
+^[[0m[DEBUG]  SKU Code: 0x20000^[[0m
+^[[0m[INFO ]  Board ID: 2^[[0m
+^[[0m[INFO ]  RAM code: 32^[[0m
+^[[0m[INFO ]  SKU ID: 131072^[[0m
+^[[0m[INFO ]  FW config: 0x2b51^[[0m
+^[[0m[DEBUG]  Wrote coreboot table at: 0xffec4000, 0x3cc bytes, checksum a5f9^[[0m
+^[[0m[DEBUG]  coreboot table: 996 bytes.^[[0m
+^[[0m[DEBUG]  IMD ROOT    0. 0xfffff000 0x00001000^[[0m
+^[[0m[DEBUG]  IMD SMALL   1. 0xffffe000 0x00001000^[[0m
+^[[0m[DEBUG]  CONSOLE     2. 0xfffde000 0x00020000^[[0m
+^[[0m[DEBUG]  RO MCACHE   3. 0xfffdc000 0x00001a3c^[[0m
+^[[0m[DEBUG]  FMAP        4. 0xfffdb000 0x0000047c^[[0m
+^[[0m[DEBUG]  TIME STAMP  5. 0xfffda000 0x00000910^[[0m
+^[[0m[DEBUG]  VBOOT WORK  6. 0xfffc6000 0x00014000^[[0m
+^[[0m[DEBUG]  RAMOOPS     7. 0xffec6000 0x00100000^[[0m
+^[[0m[DEBUG]  COREBOOT    8. 0xffec4000 0x00002000^[[0m
+^[[0m[DEBUG]  IMD small region:^[[0m
+^[[0m[DEBUG]    IMD ROOT    0. 0xffffec00 0x00000400^[[0m
+^[[0m[DEBUG]    VPD         1. 0xffffeba0 0x0000004c^[[0m
+^[[0m[DEBUG]    MEM CHIP INFO 2. 0xffffeb40 0x00000054^[[0m
+^[[0m[DEBUG]    MMC STATUS  3. 0xffffeb20 0x00000004^[[0m
+^[[0m[DEBUG]  BS: BS_WRITE_TABLES run times (exec / console): 2 / 217 ms^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[0m[INFO ]  Checking cr50 for pending updates^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Reading cr50 TPM mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD entry times (exec / console): 19505 / 212 ms^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/payload' @0x2dacc0 size 0x252ee in mcache @0xfffdd9a4^[[0m
+^[[0m[DEBUG]  read SPI 0x2fbd18 0x252ee: 12201 us, 12482 KB/s, 99.856 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 152302 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0xf1000000 memsize 0x21b26a0 srcaddr 0x40100038 filesize 0x252b6^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0xf1000000 memsz: 0x00000000021b26a0 filesz: 0x00000000000252b6^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0xf1000000, f1058238, 0xf31b26a0) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x00000000f1058238 memsz: 0x000000000215a468^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0xf1000000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD run times (exec / console): 36 / 88 ms^[[0m
+^[[0m[DEBUG]  Jumping to boot code at 0xf1000000(0xffec4000)^[[0m
+^[[0m[SPEW ]  CPU0: stack: 0x00108000 - 0x0010a800, lowest used address 0x00109d60, stack used: 2720 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/bl31' @0x424c0 size 0x72db in mcache @0xfffdc35c^[[0m
+^[[0m[DEBUG]  read SPI 0x63514 0x72db: 2376 us, 12375 KB/s, 99.000 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 29403 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0x54600000 memsize 0x2c000 srcaddr 0x40100038 filesize 0x72a3^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0x54600000 memsz: 0x000000000002c000 filesz: 0x00000000000072a3^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0x54600000, 54612aa8, 0x5462c000) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x0000000054612aa8 memsz: 0x0000000000019558^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0x54601000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+INFO:    MT8186 bl31_setup
+NOTICE:  BL31: v2.7(debug):v2.7.0-625-g5c5ee8798
+NOTICE:  BL31: Built : Tue May 14 10:29:19 UTC 2024
+INFO:    dcm_set_default: 1INFO:    GICv3 without legacy support detected.
+INFO:    ARM GICv3 driver initialized in EL3
+INFO:    Maximum SPI INTID supported: 511
+INFO:    [mt_systimer_init] systimer initialization
+NOTICE:  MT8186 spm_boot_init
+INFO:    BL31: Initializing runtime services
+INFO:    BL31: cortex_a55: CPU workaround for 1221012 was applied
+INFO:    BL31: cortex_a55: CPU workaround for 1530923 was applied
+INFO:    SPM: enable CPC mode
+INFO:    mcdi ready for mcusys-off-idle and system suspend
+INFO:    BL31: Preparing for EL3 exit to normal world
+INFO:    Entry point address = 0xf1000000
+INFO:    SPSR = 0x8
+Starting depthcharge on Steelix...
+fw_config match found: AUDIO_AMP=AMP_ALC1019
+[board_setup] Setup ALC1019
+Wipe memory regions:
+[0x00000040000000, 0x00000054600000)
+[0x00000054660000, 0x0000006a000000)
+[0x0000006a100000, 0x000000f1000000)
+[0x000000f31b26a0, 0x000000ffec4000)
+[0x00000100000000, 0x00000240000000)
+[Enter `^Ec?' for help]
+[DL] 00000000 00000000 010701
+F0: 102B 0000
+F1: 0000 0000
+V0: 0000 0000 [0001]
+00: 1027 0002
+01: 0000 0000
+BP: 0C00 0251 [0000]
+G0: 1182 0000
+EC: 0000 0000 [1000]
+T0: 0000 00C5 [1010]
+Jump to BL
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 bootblock starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x1000000000000) with new page table @0x00100000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00000000:0x200000000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x8000000000) with new page table @0x00101000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00100000:0x00110000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x40000000) with new page table @0x00102000^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x00200000) with new page table @0x00103000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00200000:0x00400000) with new page table @0x00104000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00107000:0x00108000) as non-cacheable | read-write |     secure | normal^[[0m
+^[[0m[INFO ]  WDT: Status = 0x0^[[0m
+^[[0m[INFO ]  WDT: Last reset was cold boot^[[0m
+^[[0m[DEBUG]  SPI1(PAD0) initialized at 2951351 Hz^[[0m
+^[[0m[DEBUG]  SPI2(PAD0) initialized at 992727 Hz^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  VBOOT: Loading verstage.^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 1148 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  FMAP: Found "FLASH" version 1.1 at 0x20000.^[[0m
+^[[0m[DEBUG]  FMAP: base = 0x0 size = 0x800000 #areas = 26^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 0 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[INFO ]  CBFS: mcache @0x0010c000 built for 68 files, used 0x1a3c of 0x2000 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/verstage' @0x49800 size 0xa7c2 in mcache @0x0010c3b0^[[0m
+^[[0m[DEBUG]  read SPI 0x6a880 0xa7c2: 3611 us, 11893 KB/s, 95.144 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 42946 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 verstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  FMAP: area RW_NVRAM found @ 57b000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  TPM ready after 2272 ms^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5ad9^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_send_startup: Startup return code is 0^[[0m
+^[[0m[INFO ]  TPM: setup succeeded^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1007 return code 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1008 return code 0^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  Reading cr50 boot mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Cr50 says boot_mode is VERIFIED_RW(0x00).^[[0m
+^[[0m[INFO ]  Phase 1^[[0m
+^[[0m[DEBUG]  FMAP: area GBB found @ 3f3000 (12032 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() Recovery reason from previous boot: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() We have a recovery request: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  Recovery requested (1009000e)^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: boot mode` into PCR 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: boot mode` to PCR 0 measured^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: GBB HWID` into PCR 1^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: GBB HWID` to PCR 1 measured^[[0m
+^[[0m[DEBUG]  VBOOT: Returning from verstage.^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/romstage' @0x80 size 0xe96a in mcache @0x0010c02c^[[0m
+^[[0m[DEBUG]  read SPI 0x21100 0xe96a: 5009 us, 11929 KB/s, 95.432 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 59754 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: bootblock times (exec / console): total (unknown) / 236 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 romstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  pmic_check_hwcid: ID = 0x6610^[[0m
+^[[0m[INFO ]  Check CPU freq: 1999968 KHz, cci: 1385006 KHz^[[0m
+^[[0m[INFO ]  [RTC]rtc_set_capid,243: read back capid: 0xe0^[[0m
+^[[0m[INFO ]  [RTC]rtc_enable_dcxo,50: con = 0x482, osc32con = 0xc272, sec = 0x200d^[[0m
+^[[0m[INFO ]  [RTC]rtc_check_state,173: con=482, pwrkey1=a357, pwrkey2=67d2^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,62: osc32con val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,20: PMIC_RG_FQMTR_CKSEL=0x4a^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0xf, output = 0x2d9^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x17, output = 0x393^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x13, output = 0x336^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x307^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x308^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31e^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,47: left: 17, middle: 17, right: 18^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,66: EOSC32 cali val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,202: RTC_STATE_REBOOT^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,220: irqsta=0, bbpu=9, con=482^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,319: rtc_write_trigger = 1^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,322: done BBPU = 0x9^[[0m
+^[[0m[INFO ]  CPU: 0x81861001^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[1;4m[WARN ]  DRAM-K: Invalid data in flash (size: 0xffffffffffffffff, expected: 0xf80)^[[0m
+^[[0m[INFO ]  DRAM-K: Running full calibration^[[0m
+^[[0m[INFO ]  DRAM-K: ddr_type: DSC, config_dvfs: 0, ddr_geometry: 2CH_2RK_4GB_2_2^[[0m
+^[[0m[INFO ]  header.status = 0x0^[[0m
+^[[0m[INFO ]  header.version = 0x1 (expected: 0x1)^[[0m
+^[[0m[INFO ]  header.size = 0xf80 (expected: 0xf80)^[[0m
+^[[0m[INFO ]  header.flags = 0x0^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/dram' @0x2d980 size 0x14ab1 in mcache @0x0010c2e0^[[0m
+^[[0m[DEBUG]  read SPI 0x4e9fc 0x14ab1: 6898 us, 12272 KB/s, 98.176 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 84657 bytes, hash algo 2, HW acceleration forbidden^[[0m
+dram_init: MediaTek DRAM firmware version: 0.1.0, accepting param version 1
+EMI_MPU_CTRL=0 1st
+EMI_MPU_CTRL=0 2nd
+Vm18 = 1800000
+Vdram = 0
+Vddq = 0
+Vmddr = 750000
+Will call Init_DRAM MDL_USED
+[EMI] CEN_CONA(0x3530154),CEN_CONF(0x421000),CEN_CONH(0x88880033),CEN_CONK(0x0),CHN_CONA(0x488005d)
+[DRAMC] type = 6
+[1600][CH0][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA0, Window Sum 368
+[1600][CH0][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA0, Window Sum 370
+[1600][CH0][RK0][TX] Best Vref 26 VrefRange 1, Window Min 28 at DQ4, Window Sum 470
+[1600][CH0][RK0][RX] Best Vref B0 = 42, Window Min 69 at DQ1, Window Sum 622
+[1600][CH0][RK0][RX] Best Vref B1 = 44, Window Min 73 at DQ8, Window Sum 626
+[1600][CH0][RK1][TX] Best Vref 24 VrefRange 1, Window Min 28 at DQ0, Window Sum 475
+[1600][CH1][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 63 at CA0, Window Sum 372
+[1600][CH1][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 63 at CA0, Window Sum 372
+[1600][CH1][RK0][TX] Best Vref 28 VrefRange 1, Window Min 28 at DQ6, Window Sum 475
+[1600][CH1][RK0][RX] Best Vref B0 = 42, Window Min 73 at DQ4, Window Sum 638
+[1600][CH1][RK0][RX] Best Vref B1 = 42, Window Min 73 at DQ15, Window Sum 646
+[1600][CH1][RK1][TX] Best Vref 26 VrefRange 1, Window Min 28 at DQ0, Window Sum 475
+sync_frequency_calibration_params sync calibration params of frequency 800 to shu:6
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 800
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 22
+[0] MIN Duty = 4892%(X100), DQS PI = 48
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 32
+[0] MIN Duty = 4928%(X100), DQS PI = 20
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 180%
+CH0 DQS 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 22
+[0] MIN Duty = 4928%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 36
+[0] MIN Duty = 5000%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 144%
+CH0 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5144%(X100), DQS PI = 30
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 38
+[0] MIN Duty = 4964%(X100), DQS PI = 14
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 216%
+CH0 DQ 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5109%(X100), DQS PI = 34
+[0] MIN Duty = 4819%(X100), DQS PI = 2
+[0] AVG Duty = 4964%(X100)
+CH1 CLK Duty spec in!! Max-Min= 290%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4855%(X100), DQS PI = 50
+[-1] AVG Duty = 4981%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 24
+[0] MIN Duty = 4964%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 253%
+CH1 DQS 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 0
+[0] AVG Duty = 4963%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 22
+[1] MIN Duty = 4892%(X100), DQS PI = 52
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 217%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5181%(X100), DQS PI = 30
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5054%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3200][CH0][RK0][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 360
+[3200][CH0][RK1][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA0, Window Sum 361
+[3200][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ2, Window Sum 449
+[3200][CH0][RK0][RX] Best Vref B0 = 20, Window Min 33 at DQ6, Window Sum 299
+[3200][CH0][RK0][RX] Best Vref B1 = 20, Window Min 34 at DQ10, Window Sum 295
+[3200][CH0][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ9, Window Sum 435
+[3200][CH1][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 360
+[3200][CH1][RK1][CBT] Best Vref 20 VrefRange 0, Window Min 60 at CA3, Window Sum 360
+[3200][CH1][RK0][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ1, Window Sum 456
+[3200][CH1][RK0][RX] Best Vref B0 = 20, Window Min 31 at DQ2, Window Sum 291
+[3200][CH1][RK0][RX] Best Vref B1 = 22, Window Min 32 at DQ11, Window Sum 288
+[3200][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ0, Window Sum 453
+sync_frequency_calibration_params sync calibration params of frequency 1600 to shu:7
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1600
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5036%(X100), DQS PI = 0
+[1] MIN Duty = 5036%(X100), DQS PI = 0
+[1] AVG Duty = 5036%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 46
+[0] AVG Duty = 4963%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 46
+[0] MIN Duty = 4892%(X100), DQS PI = 36
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 217%
+CH0 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5018%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 24
+[0] MIN Duty = 4964%(X100), DQS PI = 54
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 108%
+CH0 DQM 1 Duty spec in!! Max-Min= 181%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 12
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 48
+[0] MIN Duty = 4892%(X100), DQS PI = 58
+[0] AVG Duty = 5018%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 144%
+CH0 DQ 1 Duty spec in!! Max-Min= 253%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 24
+[0] MIN Duty = 4746%(X100), DQS PI = 58
+[0] AVG Duty = 4909%(X100)
+CH1 CLK Duty spec in!! Max-Min= 326%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5072%(X100), DQS PI = 28
+[-1] MIN Duty = 4892%(X100), DQS PI = 0
+[-1] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5144%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 180%
+CH1 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 0
+[0] AVG Duty = 4981%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5036%(X100), DQS PI = 30
+[1] MIN Duty = 4928%(X100), DQS PI = 52
+[1] AVG Duty = 4982%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 253%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 32
+[0] MIN Duty = 4819%(X100), DQS PI = 0
+[0] AVG Duty = 4945%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3732][CH0][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 58 at CA1, Window Sum 361
+[3732][CH0][RK1][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 360
+[3732][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 26 at DQ1, Window Sum 437
+[3732][CH0][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ1, Window Sum 430
+[3732][CH0][RK0][RX] Best Vref B0 = 19, Window Min 30 at DQ3, Window Sum 254
+[3732][CH0][RK0][RX] Best Vref B1 = 19, Window Min 30 at DQ11, Window Sum 249
+[3732][CH0][RK1][RX] Best Vref B0 = 19, Window Min 29 at DQ3, Window Sum 240
+[3732][CH0][RK1][RX] Best Vref B1 = 19, Window Min 29 at DQ8, Window Sum 239
+[3732][CH1][RK0][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA1, Window Sum 359
+[3732][CH1][RK1][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA4, Window Sum 360
+[3732][CH1][RK0][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ1, Window Sum 445
+[3732][CH1][RK1][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ2, Window Sum 444
+[3732][CH1][RK0][RX] Best Vref B0 = 20, Window Min 28 at DQ5, Window Sum 249
+[3732][CH1][RK0][RX] Best Vref B1 = 21, Window Min 30 at DQ8, Window Sum 245
+[3732][CH1][RK1][RX] Best Vref B0 = 20, Window Min 30 at DQ2, Window Sum 249
+[3732][CH1][RK1][RX] Best Vref B1 = 21, Window Min 30 at DQ8, Window Sum 243
+sync_frequency_calibration_params sync calibration params of frequency 1866 to shu:0
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1866
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+sync common calibartion params.
+sync cbt_mode0:0, 1:0
+[DRAMC] rank_nr = 2
+0:dram_rank_size:100000000
+0:dram_rank_size:100000000
+1:dram_rank_size:100000000
+1:dram_rank_size:100000000
+sync rank num:2, rank0_size:0x100000000, rank1_size:0x100000000
+[freqGroup] freqGroup: 1866, Freq= 1792
+dram_init: dram init end (result: 0)
+^[[0m[INFO ]  DRAM-K: Full calibration passed in 2396 msecs^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x240000000) as     cacheable | read-write | non-secure | normal^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x40100000) as non-cacheable | read-write | non-secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x80000000) with new page table @0x00105000^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x40200000) with new page table @0x00106000^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[DEBUG]  CBMEM:^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xfffff000 254 entries.^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xffffec00 62 entries.^[[0m
+^[[0m[DEBUG]  FMAP: area RO_VPD found @ 3f8000 (32768 bytes)^[[0m
+^[[1;4m[WARN ]  RO_VPD is uninitialized or empty.^[[0m
+^[[0m[DEBUG]  FMAP: area RW_VPD found @ 577000 (16384 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/ramstage' @0xea80 size 0x105d7 in mcache @0x0010c0ac^[[0m
+^[[0m[DEBUG]  read SPI 0x2fb00 0x105d7: 5375 us, 12470 KB/s, 99.760 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 67031 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: romstage times (exec / console): total (unknown) / 1645 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 ramstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  Enumerating buses...^[[0m
+^[[0m[SPEW ]  Show all devs... Before device enumeration.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[SPEW ]  Compare with tree...^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]   CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  Root Device scanning...^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 enabled^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device done^[[0m
+^[[0m[DEBUG]  scan_bus: bus Root Device finished in 12 msecs^[[0m
+^[[0m[INFO ]  done^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE run times (exec / console): 0 / 51 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_MRC_CACHE found @ 57d000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE exit times (exec / console): 0 / 13 ms^[[0m
+^[[0m[INFO ]  Allocating resources...^[[0m
+^[[0m[INFO ]  Reading resources...^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0^[[0m
+^[[0m[INFO ]  dram size: 0x200000000^[[0m
+^[[0m[SPEW ]  dev: CPU_CLUSTER: 0, index: 0x0, base: 0x40000000, size: 0x200000000^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done reading resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After reading.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done setting resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After assigning values.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[INFO ]  Done allocating resources.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_RESOURCES run times (exec / console): 0 / 102 ms^[[0m
+^[[0m[INFO ]  Enabling resources...^[[0m
+^[[0m[INFO ]  done.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENABLE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[INFO ]  Initializing devices...^[[0m
+^[[0m[DEBUG]  Root Device init^[[0m
+^[[0m[DEBUG]  init hardware done!^[[0m
+^[[0m[DEBUG]  0x00000018: ctrlr->caps^[[0m
+^[[0m[DEBUG]  52.000 MHz: ctrlr->f_max^[[0m
+^[[0m[DEBUG]  0.400 MHz: ctrlr->f_min^[[0m
+^[[0m[DEBUG]  0x40ff8080: ctrlr->voltages^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  Early init status = 3^[[0m
+^[[0m[INFO ]  SD card init^[[0m
+^[[0m[INFO ]  [SSUSB] Setting up USB HOST controller...^[[0m
+^[[0m[INFO ]  [SSUSB] u3phy_ports_enable u2p:1, u3p:1^[[0m
+^[[0m[INFO ]  [SSUSB] phy power-on done.^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 cf 1f 01 00 00 08 00 06 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 7f 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 51 2b ^[[0m
+^[[0m[INFO ]  FW_CONFIG value from CBI is 0x2b51^[[0m
+^[[0m[INFO ]  fw_config match found: AUDIO_AMP=AMP_ALC1019^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'spm_firmware.bin' @0x2b440 size 0x249c in mcache @0xfffdc278^[[0m
+^[[0m[DEBUG]  read SPI 0x4c4a8 0x249c: 765 us, 12250 KB/s, 98.000 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 9372 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  SPM: binary array size = 0xbb8^[[0m
+^[[0m[INFO ]  SPM: spmfw (version pcm_suspend_mp_v1109            )^[[0m
+^[[0m[DEBUG]  spm_kick_im_to_fetch: ptr = 0x80000010, pmem/dmem words = 0xbb7/0x1^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) spm_firmware.bin in 47 msecs (12064 bytes)^[[0m
+^[[0m[INFO ]  SPM: spm_init done in 55 msecs, spm pc = 0x250^[[0m
+^[[0m[DEBUG]  out: cmd=0x6: 03 f7 06 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f9 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 02 00 ^[[0m
+^[[0m[INFO ]  mtk_display_init: Starting display initialization^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Init interface.^[[0m
+^[[0m[INFO ]  anx7625_disable_pd_protocol: Disabled PD feature.^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Firmware: ver 0x13, rev 0x0.^[[0m
+^[[0m[INFO ]  anx7625_start_dp_work: Secure OCM version=00^[[0m
+^[[0m[INFO ]  anx7625_hpd_change_detect: HPD received 0x7e:0x45=0x91^[[0m
+^[[0m[INFO ]  sp_tx_get_edid_block: EDID Block = 1^[[0m
+^[[0m[SPEW ]  Extracted contents:^[[0m
+^[[0m[SPEW ]  header:          00 ff ff ff ff ff ff 00^[[0m
+^[[0m[SPEW ]  serial number:   06 af 5c 63 00 00 00 00 00 1b^[[0m
+^[[0m[SPEW ]  version:         01 04^[[0m
+^[[0m[SPEW ]  basic params:    95 1a 0e 78 02^[[0m
+^[[0m[SPEW ]  chroma info:     99 85 95 55 56 92 28 22 50 54^[[0m
+^[[0m[SPEW ]  established:     00 00 00^[[0m
+^[[0m[SPEW ]  standard:        01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01^[[0m
+^[[0m[SPEW ]  descriptor 1:    66 1c 56 a0 50 00 19 30 30 20 46 00 00 90 10 00 00 18^[[0m
+^[[0m[SPEW ]  descriptor 2:    00 00 00 0f 00 00 00 00 00 00 00 00 00 00 00 00 00 20^[[0m
+^[[0m[SPEW ]  descriptor 3:    00 00 00 fe 00 41 55 4f 0a 20 20 20 20 20 20 20 20 20^[[0m
+^[[0m[SPEW ]  descriptor 4:    00 00 00 fe 00 42 31 31 36 58 41 4e 30 36 2e 33 20 0a^[[0m
+^[[0m[SPEW ]  extensions:      00^[[0m
+^[[0m[SPEW ]  checksum:        02^[[0m
+^[[0m
+^[[0m[SPEW ]  Manufacturer: AUO Model 635c Serial Number 0^[[0m
+^[[0m[SPEW ]  Made week 0 of 2017^[[0m
+^[[0m[SPEW ]  EDID version: 1.4^[[0m
+^[[0m[SPEW ]  Digital display^[[0m
+^[[0m[SPEW ]  6 bits per primary color channel^[[0m
+^[[0m[SPEW ]  DisplayPort interface^[[0m
+^[[0m[SPEW ]  Maximum image size: 26 cm x 14 cm^[[0m
+^[[0m[SPEW ]  Gamma: 220%^[[0m
+^[[0m[SPEW ]  Check DPMS levels^[[0m
+^[[0m[SPEW ]  Supported color formats: RGB 4:4:4^[[0m
+^[[0m[SPEW ]  First detailed timing is preferred timing^[[0m
+^[[0m[SPEW ]  Established timings supported:^[[0m
+^[[0m[SPEW ]  Standard timings supported:^[[0m
+^[[0m[SPEW ]  Detailed timings^[[0m
+^[[0m[SPEW ]  Hex of detail: 661c56a05000193030204600009010000018^[[0m
+^[[0m[SPEW ]  Detailed mode (IN HEX): Clock 72700 KHz, 100 mm x 90 mm^[[0m
+^[[0m[SPEW ]                 0556 0586 05a6 05f6 hborder 0^[[0m
+^[[0m[SPEW ]                 0300 0304 030a 0319 vborder 0^[[0m
+^[[0m[SPEW ]                 -hsync -vsync^[[0m
+^[[0m[SPEW ]  Did detailed timing^[[0m
+^[[0m[SPEW ]  Hex of detail: 0000000f0000000000000000000000000020^[[0m
+^[[0m[SPEW ]  Manufacturer-specified data, tag 15^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe0041554f0a202020202020202020^[[0m
+^[[0m[SPEW ]  ASCII string: AUO^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe004231313658414e30362e33200a^[[0m
+^[[0m[SPEW ]  ASCII string: B116XAN06.3 ^[[0m
+^[[0m[SPEW ]  Checksum^[[0m
+^[[0m[SPEW ]  Checksum: 0x2 (valid)^[[0m
+^[[0m[INFO ]  DSI data_rate: 436200000 bps^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: set default k value to 0x3d for panel^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: pixelclock(72700).^[[0m
+^[[0m[INFO ]   hactive(1366), hsync(32), hfp(48), hbp(80)^[[0m
+^[[0m[INFO ]   vactive(768), vsync(6), vfp(4), vbp(15)^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: config dsi.^[[0m
+^[[0m[INFO ]  anx7625_dsi_video_config: compute M(11911168), N(552960), divider(8).^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: success to config DSI^[[0m
+^[[0m[INFO ]  anx7625_dp_start: MIPI phy setup OK.^[[0m
+^[[0m[INFO ]  mtk_display_init: 'AUO B116XAN06.3 ' 1366x768@0Hz^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: display resolution: 1366x768@0 bpp 4^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: invalid vrefresh; setting to 60^[[0m
+^[[0m[INFO ]  framebuffer_info: bytes_per_line: 5464, bits_per_pixel: 32^[[0m
+^[[0m[INFO ]                     x_res x y_res: 1366 x 768, size: 4196352 at 0x0^[[0m
+^[[0m[DEBUG]  Root Device init finished in 725 msecs^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[INFO ]  CBFS: Found 'sspm.bin' @0x1f7c0 size 0xbc20 in mcache @0xfffdc218^[[0m
+^[[0m[DEBUG]  read SPI 0x40820 0xbc20: 3879 us, 12415 KB/s, 99.320 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 48160 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) sspm.bin in 30 msecs (134356 bytes)^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_0: 0x50100200^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_1: 0x43000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_2: 0x50000000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_3: 0x240000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_5: 0xc008f0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_0: 0xf3ffc3c3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_1: 0xffcc0fef^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_2: 0xff22ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_3: 0xffffffce^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_4: 0x2fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_7: 0xffc3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_8: 0x8ffff3ff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_0: 0xfcffcfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_1: 0xffffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_4: 0xfcc3fcc3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_5: 0xc300000f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_0: 0xfffff333^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_3: 0xffffffcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_5: 0xfcfffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_6: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_0: 0xf0fffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_1: 0xfcffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_4: 0xf0003fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_5: 0xf0fff3f3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_0: 0xf0fffffc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_9: 0xfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_7: 0xfff3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO)MAS_SEC_0: 0x200000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_6: 0x3fffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_7: 0x3fc00000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_20: 0xffc3ffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_20: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO)MAS_SEC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_2: 0x44^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_2: 0xcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)MAS_0: 0x6^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)SEC_0: 0x0^[[0m
+^[[0m[INFO ]  dfd_init: enable DFD (Design For Debug)^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init finished in 1194 msecs^[[0m
+^[[0m[INFO ]  Devices initialized^[[0m
+^[[0m[SPEW ]  Show all devs... After init.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_INIT run times (exec / console): 279 / 1676 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_ELOG found @ 57f000 (4096 bytes)^[[0m
+^[[0m[INFO ]  ELOG: NV offset 0x57f000 size 0x1000^[[0m
+^[[0m[DEBUG]  read SPI 0x57f000 0x1000: 363 us, 11283 KB/s, 90.264 Mbps^[[0m
+^[[0m[INFO ]  ELOG: area is 4096 bytes, full threshold 3842, shrink size 1024^[[0m
+^[[0m[INFO ]  ELOG: Event(17) added with size 13 at 2025-01-29 01:30:29 UTC^[[0m
+^[[0m[DEBUG]  out: cmd=0x121: 03 db 21 01 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 90 00 00 2c 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 1d 0d 01 00 00 00 00 00 02 04 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() boot_mode=`Broken screen`^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() recovery_reason: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() fw_tried=`A` fw_try_count=0 fw_prev_tried=`A` fw_prev_result=`Unknown`.^[[0m
+^[[0m[INFO ]  ELOG: Event(B7) added with size 13 at 2025-01-29 01:30:29 UTC^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE entry times (exec / console): 2 / 84 ms^[[0m
+^[[0m[INFO ]  Finalize devices...^[[0m
+^[[0m[INFO ]  Devices finalized^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[DEBUG]  Writing coreboot table at 0xffec4000^[[0m
+^[[0m[DEBUG]   0. 0000000000100000-0000000000106fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   1. 0000000000108000-000000000010afff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   2. 0000000040000000-00000000400fffff: RAM^[[0m
+^[[0m[DEBUG]   3. 0000000040100000-0000000040330fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   4. 0000000040331000-00000000545fffff: RAM^[[0m
+^[[0m[DEBUG]   5. 0000000054600000-000000005465ffff: BL31^[[0m
+^[[0m[DEBUG]   6. 0000000054660000-0000000069ffffff: RAM^[[0m
+^[[0m[DEBUG]   7. 000000006a000000-000000006a0fffff: RESERVED^[[0m
+^[[0m[DEBUG]   8. 000000006a100000-00000000ffec3fff: RAM^[[0m
+^[[0m[DEBUG]   9. 00000000ffec4000-00000000ffffffff: CONFIGURATION TABLES^[[0m
+^[[0m[DEBUG]  10. 0000000100000000-000000023fffffff: RAM^[[0m
+^[[0m[INFO ]  Passing 4 GPIOs to payload:^[[0m
+^[[0m[INFO ]              NAME |       PORT | POLARITY |     VALUE^[[0m
+^[[0m[INFO ]      EC interrupt | 0x0000000d |      low | undefined^[[0m
+^[[0m[INFO ]          EC in RW | 0x0000000e |      low | undefined^[[0m
+^[[0m[INFO ]     TPM interrupt | 0x0000000f |     high | undefined^[[0m
+^[[0m[INFO ]    speaker enable | 0x00000096 |     high | undefined^[[0m
+^[[0m[DEBUG]  ADC[3]: Raw value=317871 ID=2^[[0m
+^[[0m[DEBUG]  ADC[2]: Raw value=67749 ID=0^[[0m
+^[[0m[DEBUG]  RAM Code: 0x20^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 d3 1f 01 00 00 08 00 02 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f7 00 00 04 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 00 00 02 00 ^[[0m
+^[[0m[DEBUG]  SKU Code: 0x20000^[[0m
+^[[0m[INFO ]  Board ID: 2^[[0m
+^[[0m[INFO ]  RAM code: 32^[[0m
+^[[0m[INFO ]  SKU ID: 131072^[[0m
+^[[0m[INFO ]  FW config: 0x2b51^[[0m
+^[[0m[DEBUG]  Wrote coreboot table at: 0xffec4000, 0x3cc bytes, checksum a5f9^[[0m
+^[[0m[DEBUG]  coreboot table: 996 bytes.^[[0m
+^[[0m[DEBUG]  IMD ROOT    0. 0xfffff000 0x00001000^[[0m
+^[[0m[DEBUG]  IMD SMALL   1. 0xffffe000 0x00001000^[[0m
+^[[0m[DEBUG]  CONSOLE     2. 0xfffde000 0x00020000^[[0m
+^[[0m[DEBUG]  RO MCACHE   3. 0xfffdc000 0x00001a3c^[[0m
+^[[0m[DEBUG]  FMAP        4. 0xfffdb000 0x0000047c^[[0m
+^[[0m[DEBUG]  TIME STAMP  5. 0xfffda000 0x00000910^[[0m
+^[[0m[DEBUG]  VBOOT WORK  6. 0xfffc6000 0x00014000^[[0m
+^[[0m[DEBUG]  RAMOOPS     7. 0xffec6000 0x00100000^[[0m
+^[[0m[DEBUG]  COREBOOT    8. 0xffec4000 0x00002000^[[0m
+^[[0m[DEBUG]  IMD small region:^[[0m
+^[[0m[DEBUG]    IMD ROOT    0. 0xffffec00 0x00000400^[[0m
+^[[0m[DEBUG]    VPD         1. 0xffffeba0 0x0000004c^[[0m
+^[[0m[DEBUG]    MEM CHIP INFO 2. 0xffffeb40 0x00000054^[[0m
+^[[0m[DEBUG]    MMC STATUS  3. 0xffffeb20 0x00000004^[[0m
+^[[0m[DEBUG]  BS: BS_WRITE_TABLES run times (exec / console): 2 / 217 ms^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[0m[INFO ]  Checking cr50 for pending updates^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Reading cr50 TPM mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD entry times (exec / console): 19505 / 212 ms^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/payload' @0x2dacc0 size 0x252ee in mcache @0xfffdd9a4^[[0m
+^[[0m[DEBUG]  read SPI 0x2fbd18 0x252ee: 12186 us, 12498 KB/s, 99.984 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 152302 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0xf1000000 memsize 0x21b26a0 srcaddr 0x40100038 filesize 0x252b6^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0xf1000000 memsz: 0x00000000021b26a0 filesz: 0x00000000000252b6^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0xf1000000, f1058238, 0xf31b26a0) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x00000000f1058238 memsz: 0x000000000215a468^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0xf1000000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD run times (exec / console): 36 / 88 ms^[[0m
+^[[0m[DEBUG]  Jumping to boot code at 0xf1000000(0xffec4000)^[[0m
+^[[0m[SPEW ]  CPU0: stack: 0x00108000 - 0x0010a800, lowest used address 0x00109d60, stack used: 2720 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/bl31' @0x424c0 size 0x72db in mcache @0xfffdc35c^[[0m
+^[[0m[DEBUG]  read SPI 0x63514 0x72db: 2372 us, 12395 KB/s, 99.160 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 29403 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0x54600000 memsize 0x2c000 srcaddr 0x40100038 filesize 0x72a3^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0x54600000 memsz: 0x000000000002c000 filesz: 0x00000000000072a3^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0x54600000, 54612aa8, 0x5462c000) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x0000000054612aa8 memsz: 0x0000000000019558^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0x54601000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+INFO:    MT8186 bl31_setup
+NOTICE:  BL31: v2.7(debug):v2.7.0-625-g5c5ee8798
+NOTICE:  BL31: Built : Tue May 14 10:29:19 UTC 2024
+INFO:    dcm_set_default: 1INFO:    GICv3 without legacy support detected.
+INFO:    ARM GICv3 driver initialized in EL3
+INFO:    Maximum SPI INTID supported: 511
+INFO:    [mt_systimer_init] systimer initialization
+NOTICE:  MT8186 spm_boot_init
+INFO:    BL31: Initializing runtime services
+INFO:    BL31: cortex_a55: CPU workaround for 1221012 was applied
+INFO:    BL31: cortex_a55: CPU workaround for 1530923 was applied
+INFO:    SPM: enable CPC mode
+INFO:    mcdi ready for mcusys-off-idle and system suspend
+INFO:    BL31: Preparing for EL3 exit to normal world
+INFO:    Entry point address = 0xf1000000
+INFO:    SPSR = 0x8
+Starting depthcharge on Steelix...
+fw_config match found: AUDIO_AMP=AMP_ALC1019
+[board_setup] Setup ALC1019
+Wipe memory regions:
+[0x00000040000000, 0x00000054600000)
+[0x00000054660000, 0x0000006a000000)
+[0x0000006a100000, 0x000000f1000000)
+[0x000000f31b26a0, 0x000000ffec4000)
+[0x00000100000000, 0x00000240000000)
+Initializing XHCI USB controller at 0x11280000.
+R8152: Initializing
+Version 9 (ocp_data = 6010)
+R8152: Done initializing
+Adding net device
+Adding net device
+[firmware-corsola-15194.B-collabora] Jun 25 2024 16:04:16
+corsola: tftpboot 192.168.201.1 17544617/tftp-deploy-m3hxdhxm/kernel/image.itb 17544617/tftp-deploy-m3hxdhxm/kernel/cmdline
+Waiting for link
+done.
+MAC: 78:2d:7e:14:04:fa
+Sending DHCP discover... done.
+Waiting for reply... Receive failed.
+done.
+Sending DHCP request... done.
+Waiting for reply... done.
+My ip is 192.168.201.18
+The DHCP server ip is 192.168.201.1
+TFTP server IP predefined by user: 192.168.201.1
+Bootfile predefined by user: 17544617/tftp-deploy-m3hxdhxm/kernel/image.itb
+Sending tftp read request... done.
+Waiting for the transfer...
+00000000 ################################################################
+00080000 ################################################################
+00100000 ################################################################
+00180000 ################################################################
+00200000 ################################################################
+00280000 ################################################################
+00300000 ################################################################
+00380000 ################################################################
+00400000 ################################################################
+00480000 ################################################################
+00500000 ################################################################
+00580000 ################################################################
+00600000 ################################################################
+00680000 ################################################################
+00700000 ################################################################
+00780000 ################################################################
+00800000 ################################################################
+00880000 ################################################################
+00900000 ################################################################
+00980000 ################################################################
+00a00000 ################################################################
+00a80000 ################################################################
+00b00000 ################################################################
+00b80000 ################################################################
+00c00000 ################################################################
+00c80000 ################################################################
+00d00000 ################################################################
+00d80000 ################################################################
+00e00000 ################################################################
+00e80000 ################################################################
+00f00000 ################################################################
+00f80000 ################################################################
+01000000 ################################################################
+01080000 ################################################################
+01100000 ################################################################
+01180000 ################################################################
+01200000 ################################################################
+01280000 ################################################################
+01300000 ################################################################
+01380000 ################################################################
+01400000 ################################################################
+01480000 ################################################################
+01500000 ################################################################
+01580000 ################################################################
+01600000 ################################################################
+01680000 ################################################################
+01700000 ################################################################
+01780000 ################ done.
+The bootfile was 24772166 bytes long.
+Sending tftp read request... done.
+Waiting for the transfer...
+00000000 # done.
+Command line loaded dynamically from TFTP file: 17544617/tftp-deploy-m3hxdhxm/kernel/cmdline
+The command line is: console=ttyS0,115200n8 root=/dev/nfs rw nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1
+Loading FIT.
+Image ramdisk-1 has 12893723 bytes.
+Image fdt-1 has 68885 bytes.
+Image kernel-1 has 11807514 bytes.
+Compat preference: google,steelix-rev2-sku131072 google,steelix-rev2 google,steelix-sku131072 google,steelix
+Config conf-1 (default), kernel kernel-1, fdt fdt-1, ramdisk ramdisk-1, compat google,steelix-sku131072 (match) google,steelix mediatek,mt8186
+Choosing best match conf-1 for compat google,steelix-sku131072.
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Connected to device vid:did:rid of 6666:504a:53
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+exceeded tpm wait in burst loop
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+Timeout wait for tpm irq!
+failed to get expected status 0x90
+W d40024: 80 01 00 00 00 0c 00 00 01 7b 00 40
+tpm_get_response: tpm transaction failed for 0x17b with error 0x5004
+TPM failed to populate kASLR seed buffer.
+ec_init: CrosEC protocol v3 supported (544, 544)
+LPDDR4 chan0(x16) rank0: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan0(x16) rank1: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan1(x16) rank0: density 16384mbits x16, MF ff rev 0700
+LPDDR4 chan1(x16) rank1: density 16384mbits x16, MF ff rev 0700
+tpm_cleanup: add release locality here.
+Shutting down all USB controllers.
+Removing current net device
+Exiting depthcharge with code 4 at timestamp: 238706843
+LZMA decompressing kernel-1 to 0xf31b1b48
+LZMA decompressing kernel-1 to 0x40000000
+jumping to kernel
+[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd050]
+[    0.000000] Linux version 6.13.0 (kernelci@kci-67996a1265fae3351e2f0137-kbuild-gcc-12-arm64-chro-0blthcbts) (aarch64-linux-gnu-gcc (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT Wed Jan 29 00:24:19 UTC 2025
+[    0.000000] KASLR enabled
+[    0.000000] random: crng init done
+[    0.000000] Machine model: Google Steelix board
+[    0.000000] OF: reserved mem: 0x00000000ffec6000..0x00000000fffc5fff (1024 KiB) map non-reusable ramoops
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000061000000, size 1 MiB
+[    0.000000] OF: reserved mem: initialized node memory@61000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000061000000..0x00000000610fffff (1024 KiB) nomap non-reusable memory@61000000
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000060000000, size 16 MiB
+[    0.000000] OF: reserved mem: initialized node memory@60000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000060000000..0x0000000060ffffff (16384 KiB) nomap non-reusable memory@60000000
+[    0.000000] Reserved memory: created DMA memory pool at 0x0000000050000000, size 16 MiB
+[    0.000000] OF: reserved mem: initialized node memory@50000000, compatible id shared-dma-pool
+[    0.000000] OF: reserved mem: 0x0000000050000000..0x000000005109ffff (17024 KiB) nomap non-reusable memory@50000000
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000040000000-0x00000000ffffffff]
+[    0.000000]   DMA32    empty
+[    0.000000]   Normal   [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000040000000-0x000000004fffffff]
+[    0.000000]   node   0: [mem 0x0000000050000000-0x000000005109ffff]
+[    0.000000]   node   0: [mem 0x00000000510a0000-0x00000000545fffff]
+[    0.000000]   node   0: [mem 0x0000000054700000-0x000000005fffffff]
+[    0.000000]   node   0: [mem 0x0000000060000000-0x00000000610fffff]
+[    0.000000]   node   0: [mem 0x0000000061100000-0x0000000069ffffff]
+[    0.000000]   node   0: [mem 0x000000006a100000-0x00000000ffdfffff]
+[    0.000000]   node   0: [mem 0x0000000100000000-0x000000023fffffff]
+[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000023fffffff]
+[    0.000000] On node 0, zone DMA: 256 pages in unavailable ranges
+[    0.000000] On node 0, zone DMA: 256 pages in unavailable ranges
+[    0.000000] On node 0, zone Normal: 512 pages in unavailable ranges
+[    0.000000] psci: probing for conduit method from DT.
+[    0.000000] psci: PSCIv1.1 detected in firmware.
+[    0.000000] psci: Using standard PSCI v0.2 function IDs
+[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
+[    0.000000] psci: SMC Calling Convention v1.2
+[    0.000000] percpu: Embedded 33 pages/cpu s97704 r8192 d29272 u135168
+[    0.000000] Detected VIPT I-cache on CPU0
+[    0.000000] CPU features: detected: GIC system register CPU interface
+[    0.000000] CPU features: detected: Virtualization Host Extensions
+[    0.000000] CPU features: kernel page table isolation forced ON by KASLR
+[    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
+[    0.000000] CPU features: detected: ARM errata 1165522, 1319367, or 1530923
+[    0.000000] alternatives: applying boot alternatives
+[    0.000000] Kernel command line: console=ttyS0,115200n8 root=/dev/nfs rw nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1
+[    0.000000] Unknown kernel command line parameters "nfsroot=192.168.201.1:/var/lib/lava/dispatcher/tmp/17544617/extract-nfsrootfs-vretplj3,tcp,hard,v3 ip=dhcp tftpserverip=192.168.201.1", will be passed to user space.
+[    0.000000] printk: log buffer data + meta data: 262144 + 917504 = 1179648 bytes
+[    0.000000] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes, linear)
+[    0.000000] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes, linear)
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2096128
+[    0.000000] mem auto-init: stack:all(zero), heap alloc:on, heap free:off
+[    0.000000] software IO TLB: area num 8.
+[    0.000000] software IO TLB: mapped [mem 0x00000000fbe00000-0x00000000ffe00000] (64MB)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.000000] ftrace: allocating 51171 entries in 200 pages
+[    0.000000] ftrace: allocated 200 pages with 3 groups
+[    0.000000] rcu: Preemptible hierarchical RCU implementation.
+[    0.000000] ?Trampoline variant of Tasks RCU enabled.
+[    0.000000] ?Rude variant of Tasks RCU enabled.
+[    0.000000] ?Tracing variant of Tasks RCU enabled.
+[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
+[    0.000000] RCU Tasks: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] RCU Tasks Rude: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] RCU Tasks Trace: Setting shift to 3 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=8.
+[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
+[    0.000000] GICv3: 480 SPIs implemented
+[    0.000000] GICv3: 0 Extended SPIs implemented
+[    0.000000] Root IRQ handler: gic_handle_irq
+[    0.000000] GICv3: GICv3 features: 16 PPIs
+[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
+[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c040000
+[    0.000000] GICv3: GIC: PPI partition interrupt-partition-0[0] { /cpus/cpu@0[0] /cpus/cpu@100[1] /cpus/cpu@200[2] /cpus/cpu@300[3] /cpus/cpu@400[4] /cpus/cpu@500[5] }
+[    0.000000] GICv3: GIC: PPI partition interrupt-partition-1[1] { /cpus/cpu@600[6] /cpus/cpu@700[7] }
+[    0.000000] rcu: ?Offload RCU callbacks from CPUs: 0-7.
+[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
+[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
+[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
+[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
+[    0.000453] kfence: initialized - using 2097152 bytes for 255 objects at 0x(____ptrval____)-0x(____ptrval____)
+[    0.000561] Console: colour dummy device 80x25
+[    0.000595] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=13000)
+[    0.000600] pid_max: default: 32768 minimum: 301
+[    0.000670] LSM: initializing lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf
+[    0.000776] landlock: Up and running.
+[    0.000778] Yama: becoming mindful.
+[    0.000792] LoadPin: ready to pin (currently not enforcing)
+[    0.000810] SELinux:  Initializing.
+[    0.001543] LSM support for eBPF active
+[    0.001612] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.001628] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.005012] rcu: Hierarchical SRCU implementation.
+[    0.005016] rcu: ?Max phase no-delay instances is 400.
+[    0.006078] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
+[    0.008021] smp: Bringing up secondary CPUs ...
+[    0.012245] Detected VIPT I-cache on CPU1
+[    0.012302] GICv3: CPU1: found redistributor 100 region 0:0x000000000c060000
+[    0.012330] CPU1: Booted secondary processor 0x0000000100 [0x411fd050]
+[    0.016319] Detected VIPT I-cache on CPU2
+[    0.016368] GICv3: CPU2: found redistributor 200 region 0:0x000000000c080000
+[    0.016390] CPU2: Booted secondary processor 0x0000000200 [0x411fd050]
+[    0.019224] Detected VIPT I-cache on CPU3
+[    0.019268] GICv3: CPU3: found redistributor 300 region 0:0x000000000c0a0000
+[    0.019288] CPU3: Booted secondary processor 0x0000000300 [0x411fd050]
+[    0.023294] Detected VIPT I-cache on CPU4
+[    0.023337] GICv3: CPU4: found redistributor 400 region 0:0x000000000c0c0000
+[    0.023356] CPU4: Booted secondary processor 0x0000000400 [0x411fd050]
+[    0.025357] Detected VIPT I-cache on CPU5
+[    0.025400] GICv3: CPU5: found redistributor 500 region 0:0x000000000c0e0000
+[    0.025419] CPU5: Booted secondary processor 0x0000000500 [0x411fd050]
+[    0.028382] CPU features: detected: Spectre-v4
+[    0.028387] CPU features: detected: Spectre-BHB
+[    0.028389] CPU features: detected: ARM erratum 1418040
+[    0.028391] CPU features: detected: ARM erratum 1463225
+[    0.028394] CPU features: detected: SSBS not fully self-synchronizing
+[    0.028396] Detected PIPT I-cache on CPU6
+[    0.028436] GICv3: CPU6: found redistributor 600 region 0:0x000000000c100000
+[    0.028443] arch_timer: Enabling local workaround for ARM erratum 1418040
+[    0.028454] CPU6: Booted secondary processor 0x0000000600 [0x413fd0b0]
+[    0.031381] Detected PIPT I-cache on CPU7
+[    0.031425] GICv3: CPU7: found redistributor 700 region 0:0x000000000c120000
+[    0.031431] arch_timer: Enabling local workaround for ARM erratum 1418040
+[    0.031441] CPU7: Booted secondary processor 0x0000000700 [0x413fd0b0]
+[    0.031508] smp: Brought up 1 node, 8 CPUs
+[    0.031512] SMP: Total of 8 processors activated.
+[    0.031514] CPU: All CPU(s) started at EL2
+[    0.031517] CPU features: detected: 32-bit EL0 Support
+[    0.031520] CPU features: detected: Data cache clean to the PoU not required for I/D coherence
+[    0.031522] CPU features: detected: Common not Private translations
+[    0.031525] CPU features: detected: CRC32 instructions
+[    0.031530] CPU features: detected: RCpc load-acquire (LDAPR)
+[    0.031532] CPU features: detected: LSE atomic instructions
+[    0.031534] CPU features: detected: Privileged Access Never
+[    0.031535] CPU features: detected: RAS Extension Support
+[    0.031539] CPU features: detected: Speculative Store Bypassing Safe (SSBS)
+[    0.031583] alternatives: applying system-wide alternatives
+[    0.034125] CPU features: detected: Hardware dirty bit management on CPU6-7
+[    0.034312] Memory: 8052028K/8384512K available (15680K kernel code, 2998K rwdata, 23036K rodata, 6848K init, 689K bss, 326456K reserved, 0K cma-reserved)
+[    0.035499] devtmpfs: initialized
+[    0.041102] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275000 ns
+[    0.041127] futex hash table entries: 2048 (order: 5, 131072 bytes, linear)
+[    0.041180] 2G module region forced by RANDOMIZE_MODULE_REGION_FULL
+[    0.041182] 0 pages in range for non-PLT usage
+[    0.041183] 511920 pages in range for PLT usage
+[    0.041301] pinctrl core: initialized pinctrl subsystem
+[    0.041684] NET: Registered PF_NETLINK/PF_ROUTE protocol family
+[    0.042220] DMA: preallocated 1024 KiB GFP_KERNEL pool for atomic allocations
+[    0.042378] DMA: preallocated 1024 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
+[    0.042529] DMA: preallocated 1024 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
+[    0.042548] audit: initializing netlink subsys (disabled)
+[    0.042654] audit: type=2000 audit(0.040:1): state=initialized audit_enabled=0 res=1
+[    0.042985] thermal_sys: Registered thermal governor 'step_wise'
+[    0.042987] thermal_sys: Registered thermal governor 'user_space'
+[    0.042989] thermal_sys: Registered thermal governor 'power_allocator'
+[    0.043025] cpuidle: using governor ladder
+[    0.043043] cpuidle: using governor menu
+[    0.043077] NET: Registered PF_QIPCRTR protocol family
+[    0.043198] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
+[    0.043313] ASID allocator initialised with 32768 entries
+[    0.044240] pstore: Using crash dump compression: deflate
+[    0.044247] printk: legacy console [ramoops-1] enabled
+[    0.044664] pstore: Registered ramoops as persistent store backend
+[    0.044669] ramoops: using 0x100000@0xffec6000, ecc: 0
+[    0.048736] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
+[    0.048869] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58/aux-bus/panel
+[    0.048884] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.048902] /soc/i2c@11007000/anx7625@58/aux-bus/panel: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.049064] /soc/dsi@14013000: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.053935] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58/aux-bus/panel
+[    0.053956] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.053973] /soc/i2c@11007000/anx7625@58/aux-bus/panel: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.057176] /soc/i2c@11007000/anx7625@58: Fixed dependency cycle(s) with /soc/dsi@14013000
+[    0.057217] /soc/dsi@14013000: Fixed dependency cycle(s) with /soc/i2c@11007000/anx7625@58
+[    0.062361] cryptd: max_cpu_qlen set to 1000
+[    0.062933] iommu: Default domain type: Translated
+[    0.062941] iommu: DMA domain TLB invalidation policy: strict mode
+[    0.065611] SCSI subsystem initialized
+[    0.065685] usbcore: registered new interface driver usbfs
+[    0.065700] usbcore: registered new interface driver hub
+[    0.065715] usbcore: registered new device driver usb
+[    0.065756] mc: Linux media interface: v0.10
+[    0.065775] videodev: Linux video capture interface: v2.00
+[    0.066639] Advanced Linux Sound Architecture Driver Initialized.
+[    0.067213] vgaarb: loaded
+[    0.067411] clocksource: Switched to clocksource arch_sys_counter
+[    0.067648] VFS: Disk quotas dquot_6.6.0
+[    0.067670] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.072136] NET: Registered PF_INET protocol family
+[    0.072272] IP idents hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+[    0.102094] tcp_listen_portaddr_hash hash table entries: 4096 (order: 5, 131072 bytes, linear)
+[    0.102207] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
+[    0.102256] TCP established hash table entries: 65536 (order: 7, 524288 bytes, linear)
+[    0.102947] TCP bind hash table entries: 65536 (order: 10, 4194304 bytes, linear)
+[    0.105278] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.105452] UDP hash table entries: 4096 (order: 7, 655360 bytes, linear)
+[    0.105808] UDP-Lite hash table entries: 4096 (order: 7, 655360 bytes, linear)
+[    0.106176] NET: Registered PF_UNIX/PF_LOCAL protocol family
+[    0.106467] RPC: Registered named UNIX socket transport module.
+[    0.106475] RPC: Registered udp transport module.
+[    0.106479] RPC: Registered tcp transport module.
+[    0.106482] RPC: Registered tcp-with-tls transport module.
+[    0.106486] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[    0.106494] PCI: CLS 0 bytes, default 64
+[    0.106698] Unpacking initramfs...
+[    0.113869] kvm [1]: nv: 566 coarse grained trap handlers
+[    0.114093] kvm [1]: IPA Size Limit: 40 bits
+[    0.114111] kvm [1]: GICv3: no GICV resource entry
+[    0.114116] kvm [1]: disabling GICv2 emulation
+[    0.114137] kvm [1]: GIC system register CPU interface enabled
+[    0.114153] kvm [1]: vgic interrupt IRQ18
+[    0.114175] kvm [1]: VHE mode initialized successfully
+[    0.342723] Initialise system trusted keyrings
+[    0.342887] workingset: timestamp_bits=62 max_order=21 bucket_order=0
+[    0.343301] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.343578] NFS: Registering the id_resolver key type
+[    0.343593] Key type id_resolver registered
+[    0.343597] Key type id_legacy registered
+[    0.372445] Key type asymmetric registered
+[    0.372455] Asymmetric key parser 'x509' registered
+[    0.372497] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 245)
+[    0.372594] io scheduler mq-deadline registered
+[    0.372600] io scheduler kyber registered
+[    0.372621] io scheduler bfq registered
+[    0.378115] Cannot find regmap for /soc/clock-controller@1a000000: -EINVAL
+[    0.378133] clk-mt8186-cam 1a000000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.378167] Cannot find regmap for /soc/clock-controller@1a04f000: -EINVAL
+[    0.378175] clk-mt8186-cam 1a04f000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.378200] Cannot find regmap for /soc/clock-controller@1a06f000: -EINVAL
+[    0.378207] clk-mt8186-cam 1a06f000.clock-controller: probe with driver clk-mt8186-cam failed with error -22
+[    0.378301] Cannot find regmap for /soc/clock-controller@15020000: -EINVAL
+[    0.378308] clk-mt8186-img 15020000.clock-controller: probe with driver clk-mt8186-img failed with error -22
+[    0.378334] Cannot find regmap for /soc/clock-controller@15820000: -EINVAL
+[    0.378341] clk-mt8186-img 15820000.clock-controller: probe with driver clk-mt8186-img failed with error -22
+[    0.378417] Cannot find regmap for /soc/clock-controller@11017000: -EINVAL
+[    0.378426] clk-mt8186-imp_iic_wrap 11017000.clock-controller: probe with driver clk-mt8186-imp_iic_wrap failed with error -22
+[    0.378528] Cannot find regmap for /soc/clock-controller@1c000000: -EINVAL
+[    0.378535] clk-mt8186-ipe 1c000000.clock-controller: probe with driver clk-mt8186-ipe failed with error -22
+[    0.378744] Cannot find regmap for /soc/clock-controller@1b000000: -EINVAL
+[    0.378752] clk-mt8186-mdp 1b000000.clock-controller: probe with driver clk-mt8186-mdp failed with error -22
+[    0.378813] Cannot find regmap for /soc/clock-controller@13000000: -EINVAL
+[    0.378820] clk-mt8186-mfg 13000000.clock-controller: probe with driver clk-mt8186-mfg failed with error -22
+[    0.378928] Cannot find regmap for /soc/clock-controller@1602f000: -EINVAL
+[    0.378936] clk-mt8186-vdec 1602f000.clock-controller: probe with driver clk-mt8186-vdec failed with error -22
+[    0.379011] Cannot find regmap for /soc/clock-controller@17000000: -EINVAL
+[    0.379018] clk-mt8186-venc 17000000.clock-controller: probe with driver clk-mt8186-venc failed with error -22
+[    0.379091] Cannot find regmap for /soc/clock-controller@14020000: -EINVAL
+[    0.379097] clk-mt8186-wpe 14020000.clock-controller: probe with driver clk-mt8186-wpe failed with error -22
+[    0.383689] mtk-socinfo mtk-socinfo.0.auto: MediaTek Kompanio 520 (MT8186) SoC detected.
+[    0.384607] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+[    0.385673] printk: legacy console [ttyS0] disabled
+[    0.405904] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 245, base_baud = 1625000) is a ST16650V2
+[    0.405944] printk: legacy console [ttyS0] enabled
+[    0.495616] Freeing initrd memory: 12588K
+[    0.508255] usbcore: registered new interface driver udl
+[    2.075641] loop: module loaded
+[    2.078840] lkdtm: No crash points registered, enable through debugfs
+[    2.085858] mt6359-auxadc: Failed to locate of_node [id: -1]
+[    2.091720] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vs2
+[    2.102510] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vdram1
+[    2.113551] /soc/pwrap@1000d000/pmic/regulators: Fixed dependency cycle(s) with /soc/pwrap@1000d000/pmic/regulators/vs1
+[    2.124972] mt6358-keys: Failed to locate of_node [id: -1]
+[    2.133461] spi-nor spi2.0: supply vcc not found, using dummy regulator
+[    2.141484] mtk-spi-nor 11000000.spi: spi frequency: 39000000 Hz
+[    2.147989] PPP generic driver version 2.4.2
+[    2.152389] PPP MPPE Compression module registered
+[    2.157188] tpm_tis_spi spi1.0: IRQ not confirmed - will use delays
+[    2.158044] usbcore: registered new interface driver cdc_acm
+[    2.169113] cdc_acm: USB Abstract Control Model driver for USB modems and ISDN adapters
+[    2.177224] usbcore: registered new interface driver uas
+[    2.182551] usbcore: registered new interface driver usb-storage
+[    2.188563] usbcore: registered new device driver onboard-usb-dev
+[    2.195858] mt6397-rtc mt6358-rtc: registered as rtc0
+[    2.201080] mt6397-rtc mt6358-rtc: setting system clock to 2025-01-29T01:33:23 UTC (1738114403)
+[    2.209820] i2c_dev: i2c /dev entries driver
+[    2.214822] device-mapper: ioctl: 4.49.0-ioctl (2025-01-17) initialised: dm-devel@lists.linux.dev
+[    2.224886] sdhci: Secure Digital Host Controller Interface driver
+[    2.231072] sdhci: Copyright(c) Pierre Ossman
+[    2.235711] sdhci-pltfm: SDHCI platform and OF driver helper
+[    2.241446] coreboot_table firmware:coreboot: probe with driver coreboot_table failed with error -22
+[    2.250689] SMCCC: SOC_ID: ID = jep106:0426:8186 Revision = 0x00000000
+[    2.257238] hid: raw HID events driver (C) Jiri Kosina
+[    2.262618] usbcore: registered new interface driver usbhid
+[    2.268211] usbhid: USB HID core driver
+[    2.272506] spi_master spi0: will run message pump with realtime priority
+[    2.279772] hw perfevents: enabled with armv8_cortex_a55 PMU driver, 7 (0,8000003f) counters available
+[    2.289964] hw perfevents: enabled with armv8_cortex_a76 PMU driver, 7 (0,8000003f) counters available
+[    2.303100] GACT probability NOT on
+[    2.306694] xt_time: kernel timezone is -0000
+[    2.311166] Initializing XFRM netlink socket
+[    2.315505] NET: Registered PF_INET6 protocol family
+[    2.315885] tpm_tis_spi spi1.0: 2.0 TPM (device-id 0x504A, rev-id 83)
+[    2.321134] Segment Routing with IPv6
+[    2.330595] In-situ OAM (IOAM) with IPv6
+[    2.334576] NET: Registered PF_PACKET protocol family
+[    2.339635] NET: Registered PF_KEY protocol family
+[    2.344434] Key type dns_resolver registered
+[    2.348942] NET: Registered PF_VSOCK protocol family
+[    2.358118] registered taskstats version 1
+[    2.362450] Loading compiled-in X.509 certificates
+[    2.363985] thermal thermal_zone0: power_allocator: sustainable_power will be estimated
+[    2.372079] Key type .fscrypt registered
+[    2.375350] sbs-battery 6-000b: sbs-battery: battery gas gauge device registered
+[    2.379162] Key type fscrypt-provisioning registered
+[    2.391653] Key type encrypted registered
+[    2.410259] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ovl@14005000
+[    2.418726] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ovl@14006000
+[    2.427145] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/rdma@14007000
+[    2.435646] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/color@14009000
+[    2.444241] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/ccorr@1400b000
+[    2.452912] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/aal@1400c000
+[    2.461310] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/gamma@1400d000
+[    2.469926] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/dsi@14013000
+[    2.478309] mediatek-drm mediatek-drm.15.auto: Adding component match for /soc/rdma@1401f000
+[    2.500888] cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 1999998 kHz, changing to: 2000000 kHz
+[    2.506352] pp3300_vcn33_x: Bringing 3500000uV into 3300000-3300000uV
+[    2.512086] cpu cpu0: EM: created perf domain
+[    2.518962] pp2760_vsim2_x: Bringing 1860000uV into 2700000-2700000uV
+[    2.522956] cpufreq: cpufreq_online: CPU6: Running at unlisted initial frequency: 1084999 kHz, changing to: 1085000 kHz
+[    2.528942] sbs-battery 6-000b: I2C adapter does not support I2C_FUNC_SMBUS_READ_BLOCK_DATA.
+[    2.528942] Fallback method does not support PEC.
+[    2.540131] cpu cpu6: EM: created perf domain
+[    2.547145] input: cros_ec as /devices/platform/soc/11010000.spi/spi_master/spi0/spi0.0/11010000.spi:ec@0:keyboard-controller/input/input0
+[    2.552678] input: cros_ec_buttons as /devices/platform/soc/11010000.spi/spi_master/spi0/spi0.0/11010000.spi:ec@0:keyboard-controller/input/input1
+[    2.559648] cros-ec-spi spi0.0: Chrome EC device registered
+[    2.571727] mtk-msdc 11240000.mmc: allocated mmc-pwrseq
+[    2.572431] mt6358-sound mt6358-sound: mt6358_platform_driver_probe(), dev name mt6358-sound
+[    2.577866] input: gpio-keys as /devices/platform/gpio-keys/input/input2
+[    2.578257] input: wifi-wakeup as /devices/platform/wifi-wakeup/input/input3
+[    2.600838] clk: Disabling unused clocks
+[    2.608942] PM: genpd: Disabling unused power domains
+[    2.619702] ALSA device list:
+[    2.627714]   No soundcards found.
+[    2.631902] mmc0: CQHCI version 5.10
+[    2.648671] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=00000C00; host->error=0x00000002
+[    2.658277] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=80000C08; host->error=0x00000002
+[    2.693025] mmc1: new UHS-I speed SDR104 SDIO card at address 0001
+[    2.814267] mtk-msdc 11230000.mmc: Final PAD_DS_TUNE: 0x11814
+[    2.821188] mmc0: Command Queue Engine enabled
+[    2.825643] mmc0: new HS400 MMC card at address 0001
+[    2.830918] mmcblk0: mmc0:0001 MMC64G 58.3 GiB
+[    2.837786]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12
+[    2.844430] mmcblk0boot0: mmc0:0001 MMC64G 4.00 MiB
+[    2.849629] mmcblk0boot1: mmc0:0001 MMC64G 4.00 MiB
+[    2.854882] mmcblk0rpmb: mmc0:0001 MMC64G 16.0 MiB, chardev (241:0)
+[    2.897799] tpm_tis_spi spi1.0: Cr50 firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5a
+[    2.911150] Freeing unused kernel memory: 6848K
+[    2.915725] Run /init as init process
+Loading, please wait...
+Starting systemd-udevd version 252.22-1~deb12u1
+[    3.103813] LoadPin: mnt_sb lacks block device, treating as: writable
+[    3.110336] LoadPin: kernel-module pinned obj="/usr/lib/modules/6.13.0/kernel/drivers/watchdog/mtk_wdt.ko" pid=160 cmdline="(udev-worker)"
+[    3.130732] mtk-wdt 10007000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
+[    3.132928] mtk-lvts-thermal 1100b000.thermal-sensor: fake golden temp=50
+[    3.146201] thermal thermal_zone1: power_allocator: sustainable_power will be estimated
+[    3.147501] mt8186-audio 11210000.audio-controller: mtk_afe_combine_sub_dai(), num of dai 41
+[    3.154964] thermal thermal_zone2: power_allocator: sustainable_power will be estimated
+[    3.162918] mt8186-audio 11210000.audio-controller: No cache defaults, reading back from HW
+[    3.171539] thermal thermal_zone3: power_allocator: sustainable_power will be estimated
+[    3.188123] thermal thermal_zone4: power_allocator: sustainable_power will be estimated
+[    3.188186] mtk-scp 10500000.scp: assigned reserved memory node memory@50000000
+[    3.197132] thermal thermal_zone5: power_allocator: sustainable_power will be estimated
+[    3.204378] remoteproc remoteproc0: scp is available
+[    3.212142] thermal thermal_zone6: power_allocator: sustainable_power will be estimated
+[    3.216748] remoteproc remoteproc0: powering up scp
+[    3.225444] thermal thermal_zone7: power_allocator: sustainable_power will be estimated
+[    3.229278] remoteproc remoteproc0: Booting fw image mediatek/mt8186/scp.img, size 419488
+[    3.237955] thermal thermal_zone8: power_allocator: sustainable_power will be estimated
+[    3.245427] mtk-scp 10500000.scp: IPI buf addr 0x0003bdb0
+[    3.254073] thermal thermal_zone9: power_allocator: sustainable_power will be estimated
+[    3.348218] mtk-scp 10500000.scp: creating channel cros-ec-rpmsg addr 0xd
+[    3.348688] mtk-scp 10500000.scp: SCP is ready. FW version corsola_scp_v2.0.18944-70c8f752
+[    3.353711] Bluetooth: Core ver 2.22
+[    3.354653] NET: Registered PF_BLUETOOTH protocol family
+[    3.354658] Bluetooth: HCI device and connection manager initialized
+[    3.354677] Bluetooth: HCI socket layer initialized
+[    3.354684] Bluetooth: L2CAP socket layer initialized
+[    3.354705] Bluetooth: SCO socket layer initialized
+[    3.355532] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+[    3.358166] cros-ec-dev cros-ec-dev.20.auto: CrOS System Control Processor MCU detected
+[    3.363307] remoteproc remoteproc0: remote processor scp is now up
+[    3.366912] cfg80211: failed to load regulatory.db
+[    3.407765] cros-ec-rpmsg 10500000.scp.cros-ec-rpmsg.13.-1: Chrome EC device registered
+[    3.424913] bluetooth hci0: Direct firmware load for mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin failed with error -2
+[    3.439264] Bluetooth: hci0: Failed to load firmware file (-2)
+[    3.445118] Bluetooth: hci0: Failed to setup 79xx firmware (-2)
+[    3.470477] mt7921s mmc1:0001:1: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a
+[    3.470477]
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/nfs-top ... done.
+Begin: Running /scripts/nfs-premount ... Waiting up to 60 secs for any ethernet to become available
+[    3.748009] mt7921s mmc1:0001:1: WM Firmware Version: ____010000, Build Time: 20241106151045
+Device /sys/class/net/wlan0 found
+done.
+Begin: Waiting up to 180 secs for any network device to become available ... done.
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 2 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 3 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+[   13.803955] mtk-vcodec-dec 16000000.video-decoder: deferred probe timeout, ignoring dependency
+[   13.826750] platform 14005000.ovl: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.837647] platform 14006000.ovl: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.848511] platform 16025000.video-codec: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.860078] platform 14007000.rdma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.871029] platform 1401f000.rdma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.881979] platform 14013000.dsi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.892842] platform 13040000.gpu: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.903705] platform 11201000.usb: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.914568] platform 11281000.usb: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.925431] platform 11007000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.935687] platform 11008000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.945948] platform 11009000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.956205] platform 1100f000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.966461] platform 11016000.i2c: deferred probe pending: platform: supplier 11017000.clock-controller not ready
+[   13.976718] platform 14002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.987580] platform 14003000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   13.998443] platform 14004000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.009306] platform 14023000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.020169] platform 10680000.adsp: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.031118] platform 1502e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.041981] platform 1582e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.052843] platform 1602e000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.063706] platform 17010000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.074575] platform 1a001000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.085437] platform 1a002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.096300] platform 1a00f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.107164] platform 1a010000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.118033] platform 1b002000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.128897] platform 1100bc00.svs: deferred probe pending: mtk-svs: failed to get OPP device for bank 4
+[   14.138285] platform 1c00f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.149150] platform 1c10f000.smi: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.160014] platform sound: deferred probe pending: mt8186_mt6366: I2S0: codec dai not found
+[   14.168447] platform 14001000.mutex: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.179483] platform 10006000.syscon:power-controller: deferred probe pending: mtk-power-controller: /soc/syscon@10006000/power-controller/power-domain@6/power-domain@14: failed to get child domain id
+[   14.197298] platform 14016000.iommu: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.208341] platform 1400c000.aal: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.219204] platform 1400b000.ccorr: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.230242] platform 14009000.color: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.241277] platform 1400d000.gamma: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.252317] platform 17020000.video-encoder: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+[   14.264047] platform 17030000.jpeg-encoder: deferred probe pending: platform: supplier 10006000.syscon:power-controller not ready
+IP-Config: no response after 4 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 6 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+IP-Config: no response after 9 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+[   32.737636] pp1000_edpbrdg: disabling
+[   32.741336] pp3300_edp_dx: disabling
+[   32.744946] ppvar_dvdd_vgpu: disabling
+[   32.748724] pp3300_disp_x: disabling
+[   32.752457] pp0900_dvdd_sram_gpu: disabling
+[   32.756707] pp1840_vaux18: disabling
+[   32.760460] pp2800_vaud28: disabling
+[   32.764081] pp1800_edpbrdg_dx: disabling
+IP-Config: no response after 16 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+[   62.434800] PDLOG 2025/01/29 01:29:24.582 P0 SNK Charger ??? 4975mV max 5000mV / 500mA
+[   62.444247] PDLOG 2025/01/29 01:29:24.756 P0 SNK Charger ??? 4975mV max 20000mV / 3250mA
+[   62.453693] PDLOG 2025/01/29 01:29:47.013 P0 SNK Charger ??? 11800mV max 20000mV / 3250mA
+IP-Config: no response after 25 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+#
+#
+IP-Config: no response after 36 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+IP-Config: no response after 64 secs - giving up
+IP-Config: wlan0 hardware address 10:b1:df:8a:a8:b1 mtu 1500 DHCP
+#
+#
+#
+#
+#
+IP-Config: no response after 100 secs - giving up
+/init: 384: .: C[  271.381023] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
+[  271.390062] CPU: 6 UID: 0 PID: 1 Comm: init Not tainted 6.13.0 #1 865d6bb48e84b69528fd174092f0d34c61cedaf4
+[  271.399703] Hardware name: Google Steelix board (DT)
+[  271.404654] Call trace:
+[  271.407089]  show_stack+0x20/0x38 (C)
+[  271.410743]  dump_stack_lvl+0xc8/0xf8
+[  271.414395]  dump_stack+0x18/0x28
+[  271.417699]  panic+0x3d0/0x438
+[  271.420743]  do_exit+0x84c/0xa28
+[  271.423960]  __arm64_sys_exit+0x20/0x28
+[  271.427786]  invoke_syscall+0x70/0x100
+[  271.431524]  el0_svc_common.constprop.0+0x48/0xf0
+[  271.436218]  do_el0_svc+0x24/0x38
+[  271.439522]  el0_svc+0x34/0xf0
+[  271.442566]  el0t_64_sync_handler+0x10c/0x138
+[  271.446912]  el0t_64_sync+0x1b0/0x1b8
+[  271.450562] SMP: stopping secondary CPUs
+[  271.454548] Kernel Offset: 0x39ad61a00000 from 0xffff800080000000
+[  271.460627] PHYS_OFFSET: 0xfff0826440000000
+[  271.464796] CPU features: 0x300,00006170,00901250,8200720b
+[  271.470268] Memory Limit: none
+[DL] 00000000 00000000 010701
+F0: 102B 0000
+F1: 0000 0000
+V0: 0000 0000 [0001]
+00: 1027 0002
+01: 0000 0000
+BP: 0C00 0251 [0000]
+G0: 1182 0000
+EC: 0000 0000 [1000]
+T0: 0000 00C5 [1010]
+Jump to BL
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 bootblock starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x1000000000000) with new page table @0x00100000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00000000:0x200000000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x8000000000) with new page table @0x00101000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00100000:0x00110000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x40000000) with new page table @0x00102000^[[0m
+^[[0m[DEBUG]  Backing address range [0x00000000:0x00200000) with new page table @0x00103000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x00200000:0x00400000) with new page table @0x00104000^[[0m
+^[[0m[INFO ]  Mapping address range [0x00107000:0x00108000) as non-cacheable | read-write |     secure | normal^[[0m
+^[[0m[INFO ]  WDT: Status = 0x0^[[0m
+^[[0m[INFO ]  WDT: Last reset was cold boot^[[0m
+^[[0m[DEBUG]  SPI1(PAD0) initialized at 2951351 Hz^[[0m
+^[[0m[DEBUG]  SPI2(PAD0) initialized at 992727 Hz^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  mtk_snfc_init: got pin drive: 0x3^[[0m
+^[[0m[DEBUG]  VBOOT: Loading verstage.^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 1148 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  FMAP: Found "FLASH" version 1.1 at 0x20000.^[[0m
+^[[0m[DEBUG]  FMAP: base = 0x0 size = 0x800000 #areas = 26^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 0 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[INFO ]  CBFS: mcache @0x0010c000 built for 68 files, used 0x1a3c of 0x2000 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/verstage' @0x49800 size 0xa7c2 in mcache @0x0010c3b0^[[0m
+^[[0m[DEBUG]  read SPI 0x6a880 0xa7c2: 3611 us, 11893 KB/s, 95.144 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 42946 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 verstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[DEBUG]  FMAP: area RW_NVRAM found @ 57b000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  TPM ready after 2272 ms^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Firmware version: Ti50/D3C1 RO_B:0.0.34/- RW_B:0.22.9/ti50_common:v0.0.2510-ff8e5ad9^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_send_startup: Startup return code is 0^[[0m
+^[[0m[INFO ]  TPM: setup succeeded^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1007 return code 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  src/security/tpm/tss/tcg-2.0/tss.c:231 index 0x1008 return code 0^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  Reading cr50 boot mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Cr50 says boot_mode is VERIFIED_RW(0x00).^[[0m
+^[[0m[INFO ]  Phase 1^[[0m
+^[[0m[DEBUG]  FMAP: area GBB found @ 3f3000 (12032 bytes)^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() Recovery reason from previous boot: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2_check_recovery() We have a recovery request: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  Recovery requested (1009000e)^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: boot mode` into PCR 0^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: boot mode` to PCR 0 measured^[[0m
+^[[0m[DEBUG]  TPM: Extending digest for `VBOOT: GBB HWID` into PCR 1^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  tlcl_extend: response is 0^[[0m
+^[[0m[DEBUG]  TPM: Digest of `VBOOT: GBB HWID` to PCR 1 measured^[[0m
+^[[0m[DEBUG]  VBOOT: Returning from verstage.^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/romstage' @0x80 size 0xe96a in mcache @0x0010c02c^[[0m
+^[[0m[DEBUG]  read SPI 0x21100 0xe96a: 5010 us, 11926 KB/s, 95.408 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 59754 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: bootblock times (exec / console): total (unknown) / 236 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 romstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  pmic_check_hwcid: ID = 0x6610^[[0m
+^[[0m[INFO ]  Check CPU freq: 1999968 KHz, cci: 1385006 KHz^[[0m
+^[[0m[INFO ]  [RTC]rtc_set_capid,243: read back capid: 0xe0^[[0m
+^[[0m[INFO ]  [RTC]rtc_enable_dcxo,50: con = 0x482, osc32con = 0xc272, sec = 0x200d^[[0m
+^[[0m[INFO ]  [RTC]rtc_check_state,173: con=482, pwrkey1=a357, pwrkey2=67d2^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,62: osc32con val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,20: PMIC_RG_FQMTR_CKSEL=0x4a^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0xf, output = 0x2d7^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x17, output = 0x394^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x13, output = 0x336^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x307^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x11, output = 0x306^[[0m
+^[[0m[INFO ]  [RTC]rtc_get_frequency_meter,145: input = 0x12, output = 0x31f^[[0m
+^[[0m[INFO ]  [RTC]rtc_eosc_cali,47: left: 17, middle: 17, right: 18^[[0m
+^[[0m[INFO ]  [RTC]rtc_osc_init,66: EOSC32 cali val = 0xc272^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,202: RTC_STATE_REBOOT^[[0m
+^[[0m[INFO ]  [RTC]rtc_boot_common,220: irqsta=0, bbpu=9, con=482^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,319: rtc_write_trigger = 1^[[0m
+^[[0m[INFO ]  [RTC]rtc_bbpu_power_on,322: done BBPU = 0x9^[[0m
+^[[0m[INFO ]  CPU: 0x81861001^[[0m
+^[[0m[DEBUG]  out: cmd=0xd: 03 f0 0d 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 6c 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: e2 e0 47 07 77 02 00 00 ^[[0m
+^[[0m[DEBUG]  Chrome EC: UHEPI supported^[[0m
+^[[0m[DEBUG]  out: cmd=0xa4: 03 4c a4 00 00 00 0c 00 00 01 00 00 00 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 e5 00 00 08 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 88 20 60 08 00 00 00 00 ^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[1;4m[WARN ]  DRAM-K: Invalid data in flash (size: 0xffffffffffffffff, expected: 0xf80)^[[0m
+^[[0m[INFO ]  DRAM-K: Running full calibration^[[0m
+^[[0m[INFO ]  DRAM-K: ddr_type: DSC, config_dvfs: 0, ddr_geometry: 2CH_2RK_4GB_2_2^[[0m
+^[[0m[INFO ]  header.status = 0x0^[[0m
+^[[0m[INFO ]  header.version = 0x1 (expected: 0x1)^[[0m
+^[[0m[INFO ]  header.size = 0xf80 (expected: 0xf80)^[[0m
+^[[0m[INFO ]  header.flags = 0x0^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/dram' @0x2d980 size 0x14ab1 in mcache @0x0010c2e0^[[0m
+^[[0m[DEBUG]  read SPI 0x4e9fc 0x14ab1: 6899 us, 12270 KB/s, 98.160 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 84657 bytes, hash algo 2, HW acceleration forbidden^[[0m
+dram_init: MediaTek DRAM firmware version: 0.1.0, accepting param version 1
+EMI_MPU_CTRL=0 1st
+EMI_MPU_CTRL=0 2nd
+Vm18 = 1800000
+Vdram = 0
+Vddq = 0
+Vmddr = 750000
+Will call Init_DRAM MDL_USED
+[EMI] CEN_CONA(0x3530154),CEN_CONF(0x421000),CEN_CONH(0x88880033),CEN_CONK(0x0),CHN_CONA(0x488005d)
+[DRAMC] type = 6
+[1600][CH0][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA0, Window Sum 368
+[1600][CH0][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA0, Window Sum 368
+[1600][CH0][RK0][TX] Best Vref 24 VrefRange 1, Window Min 28 at DQ2, Window Sum 469
+[1600][CH0][RK0][RX] Best Vref B0 = 42, Window Min 71 at DQ1, Window Sum 624
+[1600][CH0][RK0][RX] Best Vref B1 = 44, Window Min 73 at DQ8, Window Sum 626
+[1600][CH0][RK1][TX] Best Vref 24 VrefRange 1, Window Min 28 at DQ0, Window Sum 471
+[1600][CH1][RK0][CBT] Best Vref 22 VrefRange 1, Window Min 62 at CA0, Window Sum 366
+[1600][CH1][RK1][CBT] Best Vref 22 VrefRange 1, Window Min 61 at CA3, Window Sum 365
+[1600][CH1][RK0][TX] Best Vref 26 VrefRange 1, Window Min 28 at DQ8, Window Sum 478
+[1600][CH1][RK0][RX] Best Vref B0 = 42, Window Min 73 at DQ4, Window Sum 638
+[1600][CH1][RK0][RX] Best Vref B1 = 42, Window Min 73 at DQ15, Window Sum 646
+[1600][CH1][RK1][TX] Best Vref 24 VrefRange 1, Window Min 28 at DQ8, Window Sum 470
+sync_frequency_calibration_params sync calibration params of frequency 800 to shu:6
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 800
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : NO K
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 18
+[0] MIN Duty = 4892%(X100), DQS PI = 46
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5000%(X100), DQS PI = 14
+[0] MIN Duty = 4928%(X100), DQS PI = 20
+[0] AVG Duty = 4964%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 180%
+CH0 DQS 1 Duty spec in!! Max-Min= 72%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 22
+[0] MIN Duty = 4928%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 36
+[0] MIN Duty = 5000%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 144%
+CH0 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5144%(X100), DQS PI = 30
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 38
+[0] MIN Duty = 4964%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 216%
+CH0 DQ 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5109%(X100), DQS PI = 34
+[0] MIN Duty = 4819%(X100), DQS PI = 4
+[0] AVG Duty = 4964%(X100)
+CH1 CLK Duty spec in!! Max-Min= 290%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 30
+[-1] MIN Duty = 4855%(X100), DQS PI = 50
+[-1] AVG Duty = 4981%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 2
+[0] AVG Duty = 5036%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 253%
+CH1 DQS 1 Duty spec in!! Max-Min= 144%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 24
+[1] MIN Duty = 4892%(X100), DQS PI = 52
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 180%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 30
+[0] MIN Duty = 4856%(X100), DQS PI = 0
+[0] AVG Duty = 4946%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 28
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4964%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 180%
+CH1 DQ 1 Duty spec in!! Max-Min= 144%
+[3200][CH0][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 360
+[3200][CH0][RK1][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA0, Window Sum 361
+[3200][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 27 at DQ4, Window Sum 450
+[3200][CH0][RK0][RX] Best Vref B0 = 20, Window Min 33 at DQ6, Window Sum 299
+[3200][CH0][RK0][RX] Best Vref B1 = 20, Window Min 34 at DQ10, Window Sum 295
+[3200][CH0][RK1][TX] Best Vref 28 VrefRange 0, Window Min 26 at DQ4, Window Sum 434
+[3200][CH1][RK0][CBT] Best Vref 24 VrefRange 0, Window Min 59 at CA1, Window Sum 360
+[3200][CH1][RK1][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA1, Window Sum 363
+[3200][CH1][RK0][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ9, Window Sum 446
+[3200][CH1][RK0][RX] Best Vref B0 = 20, Window Min 31 at DQ2, Window Sum 291
+[3200][CH1][RK0][RX] Best Vref B1 = 22, Window Min 32 at DQ11, Window Sum 289
+[3200][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ1, Window Sum 438
+sync_frequency_calibration_params sync calibration params of frequency 1600 to shu:7
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1600
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 1
+[1] MAX Duty = 5072%(X100), DQS PI = 0
+[1] MIN Duty = 5072%(X100), DQS PI = 0
+[1] AVG Duty = 5072%(X100)
+CH0 CLK Duty spec in!! Max-Min= 0%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 30
+[0] MIN Duty = 4892%(X100), DQS PI = 0
+[0] AVG Duty = 4982%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 48
+[0] MIN Duty = 4892%(X100), DQS PI = 36
+[0] AVG Duty = 4982%(X100)
+CH0 DQS 0 Duty spec in!! Max-Min= 180%
+CH0 DQS 1 Duty spec in!! Max-Min= 180%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5036%(X100), DQS PI = 10
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5000%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 22
+[0] MIN Duty = 4964%(X100), DQS PI = 56
+[0] AVG Duty = 5054%(X100)
+CH0 DQM 0 Duty spec in!! Max-Min= 72%
+CH0 DQM 1 Duty spec in!! Max-Min= 181%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5108%(X100), DQS PI = 12
+[-1] MIN Duty = 4964%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 48
+[0] MIN Duty = 4928%(X100), DQS PI = 58
+[0] AVG Duty = 5036%(X100)
+CH0 DQ 0 Duty spec in!! Max-Min= 144%
+CH0 DQ 1 Duty spec in!! Max-Min= 217%
+[DutyScan_Calibration_Flow] k_type=0
+==^[[1;32mCLK^[[m ==
+Final CLK duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 24
+[0] MIN Duty = 4746%(X100), DQS PI = 58
+[0] AVG Duty = 4909%(X100)
+CH1 CLK Duty spec in!! Max-Min= 326%
+[DutyScan_Calibration_Flow] k_type=1
+==^[[1;32mDQS 0^[[m ==
+Final DQS duty delay cell = -1
+[-1] MAX Duty = 5072%(X100), DQS PI = 24
+[-1] MIN Duty = 4856%(X100), DQS PI = 0
+[-1] AVG Duty = 4964%(X100)
+==^[[1;32mDQS 1^[[m ==
+Final DQS duty delay cell = 0
+[0] MAX Duty = 5145%(X100), DQS PI = 30
+[0] MIN Duty = 4964%(X100), DQS PI = 0
+[0] AVG Duty = 5054%(X100)
+CH1 DQS 0 Duty spec in!! Max-Min= 216%
+CH1 DQS 1 Duty spec in!! Max-Min= 181%
+[DutyScan_Calibration_Flow] k_type=3
+==^[[1;32mDQM 0^[[m ==
+Final DQM duty delay cell = 0
+[0] MAX Duty = 5108%(X100), DQS PI = 30
+[0] MIN Duty = 4855%(X100), DQS PI = 0
+[0] AVG Duty = 4981%(X100)
+==^[[1;32mDQM 1^[[m ==
+Final DQM duty delay cell = 1
+[1] MAX Duty = 5000%(X100), DQS PI = 30
+[1] MIN Duty = 4892%(X100), DQS PI = 8
+[1] AVG Duty = 4946%(X100)
+CH1 DQM 0 Duty spec in!! Max-Min= 253%
+CH1 DQM 1 Duty spec in!! Max-Min= 108%
+[DutyScan_Calibration_Flow] k_type=2
+==^[[1;32mDQ 0^[[m ==
+Final DQ duty delay cell = 0
+[0] MAX Duty = 5072%(X100), DQS PI = 32
+[0] MIN Duty = 4819%(X100), DQS PI = 0
+[0] AVG Duty = 4945%(X100)
+==^[[1;32mDQ 1^[[m ==
+Final DQ duty delay cell = -1
+[-1] MAX Duty = 5144%(X100), DQS PI = 30
+[-1] MIN Duty = 4928%(X100), DQS PI = 0
+[-1] AVG Duty = 5036%(X100)
+CH1 DQ 0 Duty spec in!! Max-Min= 253%
+CH1 DQ 1 Duty spec in!! Max-Min= 216%
+[3732][CH0][RK0][CBT] Best Vref 26 VrefRange 0, Window Min 58 at CA1, Window Sum 360
+[3732][CH0][RK1][CBT] Best Vref 26 VrefRange 0, Window Min 59 at CA0, Window Sum 362
+[3732][CH0][RK0][TX] Best Vref 28 VrefRange 0, Window Min 26 at DQ1, Window Sum 437
+[3732][CH0][RK1][TX] Best Vref 26 VrefRange 0, Window Min 26 at DQ0, Window Sum 429
+[3732][CH0][RK0][RX] Best Vref B0 = 19, Window Min 30 at DQ3, Window Sum 254
+[3732][CH0][RK0][RX] Best Vref B1 = 19, Window Min 30 at DQ8, Window Sum 248
+[3732][CH0][RK1][RX] Best Vref B0 = 19, Window Min 29 at DQ3, Window Sum 240
+[3732][CH0][RK1][RX] Best Vref B1 = 19, Window Min 29 at DQ8, Window Sum 238
+[3732][CH1][RK0][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA1, Window Sum 359
+[3732][CH1][RK1][CBT] Best Vref 22 VrefRange 0, Window Min 60 at CA5, Window Sum 360
+[3732][CH1][RK0][TX] Best Vref 28 VrefRange 0, Window Min 26 at DQ1, Window Sum 443
+[3732][CH1][RK1][TX] Best Vref 26 VrefRange 0, Window Min 27 at DQ5, Window Sum 446
+[3732][CH1][RK0][RX] Best Vref B0 = 21, Window Min 29 at DQ2, Window Sum 249
+[3732][CH1][RK0][RX] Best Vref B1 = 21, Window Min 29 at DQ10, Window Sum 243
+[3732][CH1][RK1][RX] Best Vref B0 = 21, Window Min 30 at DQ2, Window Sum 248
+[3732][CH1][RK1][RX] Best Vref B1 = 21, Window Min 30 at DQ8, Window Sum 245
+sync_frequency_calibration_params sync calibration params of frequency 1866 to shu:0
+calibartion params size is 380, SAVE_TIME_FOR_CALIBRATION_T:380, sdram_params:384
+[Calibration Summary] Freqency 1866
+CH 0, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : PASS
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 0, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 0
+SW Impedance     : PASS
+DUTY Scan        : PASS
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+CH 1, Rank 1
+SW Impedance     : PASS
+DUTY Scan        : NO K
+ZQ Calibration   : PASS
+Jitter Meter     : NO K
+CBT Training     : PASS
+Write leveling   : PASS
+RX DQS gating    : PASS
+RX DQ/DQS(RDDQC) : PASS
+TX DQ/DQS        : PASS
+RX DATLAT        : PASS
+RX DQ/DQS(Engine): PASS
+TX OE            : PASS
+All Pass.
+[FAST_K] Save calibration result to emmc
+sync common calibartion params.
+sync cbt_mode0:0, 1:0
+[DRAMC] rank_nr = 2
+0:dram_rank_size:100000000
+0:dram_rank_size:100000000
+1:dram_rank_size:100000000
+1:dram_rank_size:100000000
+sync rank num:2, rank0_size:0x100000000, rank1_size:0x100000000
+[freqGroup] freqGroup: 1866, Freq= 1792
+dram_init: dram init end (result: 0)
+^[[0m[INFO ]  DRAM-K: Full calibration passed in 2396 msecs^[[0m
+^[[7m[ERROR]  MRC: failed to locate region type 0.^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x240000000) as     cacheable | read-write | non-secure | normal^[[0m
+^[[0m[INFO ]  Mapping address range [0x40000000:0x40100000) as non-cacheable | read-write | non-secure | normal^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x80000000) with new page table @0x00105000^[[0m
+^[[0m[DEBUG]  Backing address range [0x40000000:0x40200000) with new page table @0x00106000^[[0m
+^[[0m[INFO ]  dram size (romstage): 0x200000000^[[0m
+^[[0m[DEBUG]  CBMEM:^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xfffff000 254 entries.^[[0m
+^[[0m[DEBUG]  IMD: root @ 0xffffec00 62 entries.^[[0m
+^[[0m[DEBUG]  FMAP: area RO_VPD found @ 3f8000 (32768 bytes)^[[0m
+^[[1;4m[WARN ]  RO_VPD is uninitialized or empty.^[[0m
+^[[0m[DEBUG]  FMAP: area RW_VPD found @ 577000 (16384 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/ramstage' @0xea80 size 0x105d7 in mcache @0x0010c0ac^[[0m
+^[[0m[DEBUG]  read SPI 0x2fb00 0x105d7: 5375 us, 12470 KB/s, 99.760 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 67031 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  BS: romstage times (exec / console): total (unknown) / 1644 ms^[[0m
+^[[0m
+^[[0m
+^[[1m[NOTE ]  coreboot-v1.9308_26_0.0.22-29290-gbc6a2a1197a Tue May 14 10:29:19 UTC 2024 ramstage starting (log level: 8)...^[[0m
+^[[0m[DEBUG]  ARM64: Exception handlers installed.^[[0m
+^[[0m[DEBUG]  ARM64: Testing exception^[[0m
+^[[0m[DEBUG]  ARM64: Done test exception^[[0m
+^[[0m[INFO ]  Enumerating buses...^[[0m
+^[[0m[SPEW ]  Show all devs... Before device enumeration.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[SPEW ]  Compare with tree...^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]   CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  Root Device scanning...^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 enabled^[[0m
+^[[0m[SPEW ]  scan_static_bus for Root Device done^[[0m
+^[[0m[DEBUG]  scan_bus: bus Root Device finished in 12 msecs^[[0m
+^[[0m[INFO ]  done^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE run times (exec / console): 0 / 51 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_MRC_CACHE found @ 57d000 (8192 bytes)^[[0m
+^[[0m[INFO ]  SF: Detected 00 0000 with sector size 0x1000, total 0x800000^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENUMERATE exit times (exec / console): 0 / 13 ms^[[0m
+^[[0m[INFO ]  Allocating resources...^[[0m
+^[[0m[INFO ]  Reading resources...^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0^[[0m
+^[[0m[INFO ]  dram size: 0x200000000^[[0m
+^[[0m[SPEW ]  dev: CPU_CLUSTER: 0, index: 0x0, base: 0x40000000, size: 0x200000000^[[0m
+^[[0m[SPEW ]  Root Device read_resources bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done reading resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After reading.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0^[[0m
+^[[0m[SPEW ]  Root Device assign_resources, bus 0 link: 0 done^[[0m
+^[[0m[INFO ]  Done setting resources.^[[0m
+^[[0m[SPEW ]  Show resources in subtree (Root Device)...After assigning values.^[[0m
+^[[0m[DEBUG]   Root Device child on link 0 CPU_CLUSTER: 0^[[0m
+^[[0m[DEBUG]    CPU_CLUSTER: 0^[[0m
+^[[0m[SPEW ]    CPU_CLUSTER: 0 resource base 40000000 size 200000000 align 0 gran 0 limit 0 flags e0004200 index 0^[[0m
+^[[0m[INFO ]  Done allocating resources.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_RESOURCES run times (exec / console): 0 / 102 ms^[[0m
+^[[0m[INFO ]  Enabling resources...^[[0m
+^[[0m[INFO ]  done.^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_ENABLE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[INFO ]  Initializing devices...^[[0m
+^[[0m[DEBUG]  Root Device init^[[0m
+^[[0m[DEBUG]  init hardware done!^[[0m
+^[[0m[DEBUG]  0x00000018: ctrlr->caps^[[0m
+^[[0m[DEBUG]  52.000 MHz: ctrlr->f_max^[[0m
+^[[0m[DEBUG]  0.400 MHz: ctrlr->f_min^[[0m
+^[[0m[DEBUG]  0x40ff8080: ctrlr->voltages^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  sclk: 390625^[[0m
+^[[0m[DEBUG]  Bus Width = 1^[[0m
+^[[0m[DEBUG]  Early init status = 3^[[0m
+^[[0m[INFO ]  SD card init^[[0m
+^[[0m[INFO ]  [SSUSB] Setting up USB HOST controller...^[[0m
+^[[0m[INFO ]  [SSUSB] u3phy_ports_enable u2p:1, u3p:1^[[0m
+^[[0m[INFO ]  [SSUSB] phy power-on done.^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 cf 1f 01 00 00 08 00 06 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 7f 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 51 2b ^[[0m
+^[[0m[INFO ]  FW_CONFIG value from CBI is 0x2b51^[[0m
+^[[0m[INFO ]  fw_config match found: AUDIO_AMP=AMP_ALC1019^[[0m
+^[[0m[DEBUG]  FMAP: area COREBOOT found @ 21000 (4005888 bytes)^[[0m
+^[[0m[INFO ]  CBFS: Found 'spm_firmware.bin' @0x2b440 size 0x249c in mcache @0xfffdc278^[[0m
+^[[0m[DEBUG]  read SPI 0x4c4a8 0x249c: 764 us, 12267 KB/s, 98.136 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 9372 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  SPM: binary array size = 0xbb8^[[0m
+^[[0m[INFO ]  SPM: spmfw (version pcm_suspend_mp_v1109            )^[[0m
+^[[0m[DEBUG]  spm_kick_im_to_fetch: ptr = 0x80000010, pmem/dmem words = 0xbb7/0x1^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) spm_firmware.bin in 47 msecs (12064 bytes)^[[0m
+^[[0m[INFO ]  SPM: spm_init done in 55 msecs, spm pc = 0x250^[[0m
+^[[0m[DEBUG]  out: cmd=0x6: 03 f7 06 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f9 00 00 02 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 02 00 ^[[0m
+^[[0m[INFO ]  mtk_display_init: Starting display initialization^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Init interface.^[[0m
+^[[0m[INFO ]  anx7625_disable_pd_protocol: Disabled PD feature.^[[0m
+^[[0m[INFO ]  anx7625_power_on_init: Firmware: ver 0x13, rev 0x0.^[[0m
+^[[0m[INFO ]  anx7625_start_dp_work: Secure OCM version=00^[[0m
+^[[0m[INFO ]  anx7625_hpd_change_detect: HPD received 0x7e:0x45=0x91^[[0m
+^[[0m[INFO ]  sp_tx_get_edid_block: EDID Block = 1^[[0m
+^[[0m[SPEW ]  Extracted contents:^[[0m
+^[[0m[SPEW ]  header:          00 ff ff ff ff ff ff 00^[[0m
+^[[0m[SPEW ]  serial number:   06 af 5c 63 00 00 00 00 00 1b^[[0m
+^[[0m[SPEW ]  version:         01 04^[[0m
+^[[0m[SPEW ]  basic params:    95 1a 0e 78 02^[[0m
+^[[0m[SPEW ]  chroma info:     99 85 95 55 56 92 28 22 50 54^[[0m
+^[[0m[SPEW ]  established:     00 00 00^[[0m
+^[[0m[SPEW ]  standard:        01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01^[[0m
+^[[0m[SPEW ]  descriptor 1:    66 1c 56 a0 50 00 19 30 30 20 46 00 00 90 10 00 00 18^[[0m
+^[[0m[SPEW ]  descriptor 2:    00 00 00 0f 00 00 00 00 00 00 00 00 00 00 00 00 00 20^[[0m
+^[[0m[SPEW ]  descriptor 3:    00 00 00 fe 00 41 55 4f 0a 20 20 20 20 20 20 20 20 20^[[0m
+^[[0m[SPEW ]  descriptor 4:    00 00 00 fe 00 42 31 31 36 58 41 4e 30 36 2e 33 20 0a^[[0m
+^[[0m[SPEW ]  extensions:      00^[[0m
+^[[0m[SPEW ]  checksum:        02^[[0m
+^[[0m
+^[[0m[SPEW ]  Manufacturer: AUO Model 635c Serial Number 0^[[0m
+^[[0m[SPEW ]  Made week 0 of 2017^[[0m
+^[[0m[SPEW ]  EDID version: 1.4^[[0m
+^[[0m[SPEW ]  Digital display^[[0m
+^[[0m[SPEW ]  6 bits per primary color channel^[[0m
+^[[0m[SPEW ]  DisplayPort interface^[[0m
+^[[0m[SPEW ]  Maximum image size: 26 cm x 14 cm^[[0m
+^[[0m[SPEW ]  Gamma: 220%^[[0m
+^[[0m[SPEW ]  Check DPMS levels^[[0m
+^[[0m[SPEW ]  Supported color formats: RGB 4:4:4^[[0m
+^[[0m[SPEW ]  First detailed timing is preferred timing^[[0m
+^[[0m[SPEW ]  Established timings supported:^[[0m
+^[[0m[SPEW ]  Standard timings supported:^[[0m
+^[[0m[SPEW ]  Detailed timings^[[0m
+^[[0m[SPEW ]  Hex of detail: 661c56a05000193030204600009010000018^[[0m
+^[[0m[SPEW ]  Detailed mode (IN HEX): Clock 72700 KHz, 100 mm x 90 mm^[[0m
+^[[0m[SPEW ]                 0556 0586 05a6 05f6 hborder 0^[[0m
+^[[0m[SPEW ]                 0300 0304 030a 0319 vborder 0^[[0m
+^[[0m[SPEW ]                 -hsync -vsync^[[0m
+^[[0m[SPEW ]  Did detailed timing^[[0m
+^[[0m[SPEW ]  Hex of detail: 0000000f0000000000000000000000000020^[[0m
+^[[0m[SPEW ]  Manufacturer-specified data, tag 15^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe0041554f0a202020202020202020^[[0m
+^[[0m[SPEW ]  ASCII string: AUO^[[0m
+^[[0m[SPEW ]  Hex of detail: 000000fe004231313658414e30362e33200a^[[0m
+^[[0m[SPEW ]  ASCII string: B116XAN06.3 ^[[0m
+^[[0m[SPEW ]  Checksum^[[0m
+^[[0m[SPEW ]  Checksum: 0x2 (valid)^[[0m
+^[[0m[INFO ]  DSI data_rate: 436200000 bps^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: set default k value to 0x3d for panel^[[0m
+^[[0m[INFO ]  anx7625_parse_edid: pixelclock(72700).^[[0m
+^[[0m[INFO ]   hactive(1366), hsync(32), hfp(48), hbp(80)^[[0m
+^[[0m[INFO ]   vactive(768), vsync(6), vfp(4), vbp(15)^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: config dsi.^[[0m
+^[[0m[INFO ]  anx7625_dsi_video_config: compute M(11911168), N(552960), divider(8).^[[0m
+^[[0m[INFO ]  anx7625_dsi_config: success to config DSI^[[0m
+^[[0m[INFO ]  anx7625_dp_start: MIPI phy setup OK.^[[0m
+^[[0m[INFO ]  mtk_display_init: 'AUO B116XAN06.3 ' 1366x768@0Hz^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: display resolution: 1366x768@0 bpp 4^[[0m
+^[[0m[INFO ]  mtk_ddp_mode_set: invalid vrefresh; setting to 60^[[0m
+^[[0m[INFO ]  framebuffer_info: bytes_per_line: 5464, bits_per_pixel: 32^[[0m
+^[[0m[INFO ]                     x_res x y_res: 1366 x 768, size: 4196352 at 0x0^[[0m
+^[[0m[DEBUG]  Root Device init finished in 725 msecs^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init^[[0m
+^[[0m[INFO ]  Mapping address range [0x00200000:0x00280000) as     cacheable | read-write |     secure | device^[[0m
+^[[0m[INFO ]  CBFS: Found 'sspm.bin' @0x1f7c0 size 0xbc20 in mcache @0xfffdc218^[[0m
+^[[0m[DEBUG]  read SPI 0x40820 0xbc20: 3878 us, 12418 KB/s, 99.344 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 48160 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  mtk_init_mcu: Loaded (and reset) sspm.bin in 30 msecs (134356 bytes)^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_0: 0x50100200^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_1: 0x43000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_2: 0x50000000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_3: 0x240000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_5: 0xc008f0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_0: 0xf3ffc3c3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_1: 0xffcc0fef^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_2: 0xff22ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_3: 0xffffffce^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_4: 0x2fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_7: 0xffc3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_8: 0x8ffff3ff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D1_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_0: 0xfcffcfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_1: 0xffffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_4: 0xfcc3fcc3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_5: 0xc300000f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D2_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_0: 0xfffff333^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_3: 0xffffffcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D3_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_5: 0xfcfffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_6: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D4_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_0: 0xf0fffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_1: 0xfcffffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_3: 0xfffcffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_4: 0xf0003fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_5: 0xf0fff3f3^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_6: 0xffcfffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_8: 0x3fffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D5_APC_9: 0x3fff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_0: 0xf0fffffc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D6_APC_9: 0xfff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_0: 0xfcfff3fc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_5: 0xfffffff0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_7: 0xfff3ffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_8: 0xffffff3f^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO_SYS0)D7_APC_9: 0x3cff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (INFRA_AO)MAS_SEC_0: 0x200000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D0_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_6: 0x3fffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_7: 0x3fc00000^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_20: 0xffc3ffcf^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D1_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_2: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_3: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_4: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_5: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_6: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_7: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_8: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_9: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_10: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_11: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_12: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_13: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_14: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_15: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_16: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_17: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_18: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_19: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_20: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_21: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D2_APC_22: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_2: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_3: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_4: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_5: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_6: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_7: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_8: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_9: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_10: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_11: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_12: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_13: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_14: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_15: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_16: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_17: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_18: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_19: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_20: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_21: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO_SYS0)D3_APC_22: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (MM_AO)MAS_SEC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D0_APC_2: 0x44^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D1_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D2_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D3_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D4_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D5_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_0: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_1: 0x0^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D6_APC_2: 0xcc^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D7_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D8_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D9_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D10_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D11_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D12_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D13_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D14_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_0: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_1: 0xffffffff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO_SYS0)D15_APC_2: 0xff^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)MAS_0: 0x6^[[0m
+^[[0m[DEBUG]  [DEVAPC] (AUD_AO)SEC_0: 0x0^[[0m
+^[[0m[INFO ]  dfd_init: enable DFD (Design For Debug)^[[0m
+^[[0m[DEBUG]  CPU_CLUSTER: 0 init finished in 1194 msecs^[[0m
+^[[0m[INFO ]  Devices initialized^[[0m
+^[[0m[SPEW ]  Show all devs... After init.^[[0m
+^[[0m[SPEW ]  Root Device: enabled 1^[[0m
+^[[0m[SPEW ]  CPU_CLUSTER: 0: enabled 1^[[0m
+^[[0m[DEBUG]  BS: BS_DEV_INIT run times (exec / console): 278 / 1676 ms^[[0m
+^[[0m[DEBUG]  FMAP: area RW_ELOG found @ 57f000 (4096 bytes)^[[0m
+^[[0m[INFO ]  ELOG: NV offset 0x57f000 size 0x1000^[[0m
+^[[0m[DEBUG]  read SPI 0x57f000 0x1000: 363 us, 11283 KB/s, 90.264 Mbps^[[0m
+^[[0m[INFO ]  ELOG: area is 4096 bytes, full threshold 3842, shrink size 1024^[[0m
+^[[0m[INFO ]  ELOG: Event(17) added with size 13 at 2025-01-29 01:39:01 UTC^[[0m
+^[[0m[DEBUG]  out: cmd=0x121: 03 db 21 01 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f6 00 00 2c 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 6a cd 08 00 01 00 00 00 02 04 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 08 00 00 00 b6 c0 07 00 ^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() boot_mode=`Broken screen`^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() recovery_reason: 0x54 / 0x4^[[0m
+^[[0m[INFO ]  VB2:vb2api_get_fw_boot_info() fw_tried=`A` fw_try_count=0 fw_prev_tried=`A` fw_prev_result=`Unknown`.^[[0m
+^[[0m[INFO ]  ELOG: Event(B7) added with size 13 at 2025-01-29 01:39:01 UTC^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE entry times (exec / console): 2 / 84 ms^[[0m
+^[[0m[INFO ]  Finalize devices...^[[0m
+^[[0m[INFO ]  Devices finalized^[[0m
+^[[0m[DEBUG]  BS: BS_POST_DEVICE run times (exec / console): 0 / 6 ms^[[0m
+^[[0m[DEBUG]  Writing coreboot table at 0xffec4000^[[0m
+^[[0m[DEBUG]   0. 0000000000100000-0000000000106fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   1. 0000000000108000-000000000010afff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   2. 0000000040000000-00000000400fffff: RAM^[[0m
+^[[0m[DEBUG]   3. 0000000040100000-0000000040330fff: RAMSTAGE^[[0m
+^[[0m[DEBUG]   4. 0000000040331000-00000000545fffff: RAM^[[0m
+^[[0m[DEBUG]   5. 0000000054600000-000000005465ffff: BL31^[[0m
+^[[0m[DEBUG]   6. 0000000054660000-0000000069ffffff: RAM^[[0m
+^[[0m[DEBUG]   7. 000000006a000000-000000006a0fffff: RESERVED^[[0m
+^[[0m[DEBUG]   8. 000000006a100000-00000000ffec3fff: RAM^[[0m
+^[[0m[DEBUG]   9. 00000000ffec4000-00000000ffffffff: CONFIGURATION TABLES^[[0m
+^[[0m[DEBUG]  10. 0000000100000000-000000023fffffff: RAM^[[0m
+^[[0m[INFO ]  Passing 4 GPIOs to payload:^[[0m
+^[[0m[INFO ]              NAME |       PORT | POLARITY |     VALUE^[[0m
+^[[0m[INFO ]      EC interrupt | 0x0000000d |      low | undefined^[[0m
+^[[0m[INFO ]          EC in RW | 0x0000000e |      low | undefined^[[0m
+^[[0m[INFO ]     TPM interrupt | 0x0000000f |     high | undefined^[[0m
+^[[0m[INFO ]    speaker enable | 0x00000096 |     high | undefined^[[0m
+^[[0m[DEBUG]  ADC[3]: Raw value=317871 ID=2^[[0m
+^[[0m[DEBUG]  ADC[2]: Raw value=67749 ID=0^[[0m
+^[[0m[DEBUG]  RAM Code: 0x20^[[0m
+^[[0m[DEBUG]  out: cmd=0x11f: 03 d3 1f 01 00 00 08 00 02 00 00 00 00 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-header: 03 f7 00 00 04 00 00 00 ^[[0m
+^[[0m[DEBUG]  in-data: 00 00 02 00 ^[[0m
+^[[0m[DEBUG]  SKU Code: 0x20000^[[0m
+^[[0m[INFO ]  Board ID: 2^[[0m
+^[[0m[INFO ]  RAM code: 32^[[0m
+^[[0m[INFO ]  SKU ID: 131072^[[0m
+^[[0m[INFO ]  FW config: 0x2b51^[[0m
+^[[0m[DEBUG]  Wrote coreboot table at: 0xffec4000, 0x3cc bytes, checksum a5f9^[[0m
+^[[0m[DEBUG]  coreboot table: 996 bytes.^[[0m
+^[[0m[DEBUG]  IMD ROOT    0. 0xfffff000 0x00001000^[[0m
+^[[0m[DEBUG]  IMD SMALL   1. 0xffffe000 0x00001000^[[0m
+^[[0m[DEBUG]  CONSOLE     2. 0xfffde000 0x00020000^[[0m
+^[[0m[DEBUG]  RO MCACHE   3. 0xfffdc000 0x00001a3c^[[0m
+^[[0m[DEBUG]  FMAP        4. 0xfffdb000 0x0000047c^[[0m
+^[[0m[DEBUG]  TIME STAMP  5. 0xfffda000 0x00000910^[[0m
+^[[0m[DEBUG]  VBOOT WORK  6. 0xfffc6000 0x00014000^[[0m
+^[[0m[DEBUG]  RAMOOPS     7. 0xffec6000 0x00100000^[[0m
+^[[0m[DEBUG]  COREBOOT    8. 0xffec4000 0x00002000^[[0m
+^[[0m[DEBUG]  IMD small region:^[[0m
+^[[0m[DEBUG]    IMD ROOT    0. 0xffffec00 0x00000400^[[0m
+^[[0m[DEBUG]    VPD         1. 0xffffeba0 0x0000004c^[[0m
+^[[0m[DEBUG]    MEM CHIP INFO 2. 0xffffeb40 0x00000054^[[0m
+^[[0m[DEBUG]    MMC STATUS  3. 0xffffeb20 0x00000004^[[0m
+^[[0m[DEBUG]  BS: BS_WRITE_TABLES run times (exec / console): 2 / 217 ms^[[0m
+^[[0m[INFO ]  Probing TPM:  done!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Connected to device vid:did:rid of 6666:504a:53^[[0m
+^[[0m[INFO ]  Initialized TPM device TI50 revision 83^[[0m
+^[[0m[INFO ]  Checking cr50 for pending updates^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[INFO ]  Reading cr50 TPM mode^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[7m[ERROR]  Cr50 TPM IRQ timeout!^[[0m
+^[[7m[ERROR]  Timeout waiting for TPM IRQ!^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD entry times (exec / console): 19505 / 212 ms^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/payload' @0x2dacc0 size 0x252ee in mcache @0xfffdd9a4^[[0m
+^[[0m[DEBUG]  read SPI 0x2fbd18 0x252ee: 12186 us, 12498 KB/s, 99.984 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 152302 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0xf1000000 memsize 0x21b26a0 srcaddr 0x40100038 filesize 0x252b6^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0xf1000000 memsz: 0x00000000021b26a0 filesz: 0x00000000000252b6^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0xf1000000, f1058238, 0xf31b26a0) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x00000000f1058238 memsz: 0x000000000215a468^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0xf1000000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+^[[0m[DEBUG]  BS: BS_PAYLOAD_LOAD run times (exec / console): 36 / 88 ms^[[0m
+^[[0m[DEBUG]  Jumping to boot code at 0xf1000000(0xffec4000)^[[0m
+^[[0m[SPEW ]  CPU0: stack: 0x00108000 - 0x0010a800, lowest used address 0x00109d60, stack used: 2720 bytes^[[0m
+^[[0m[INFO ]  CBFS: Found 'fallback/bl31' @0x424c0 size 0x72db in mcache @0xfffdc35c^[[0m
+^[[0m[DEBUG]  read SPI 0x63514 0x72db: 2372 us, 12395 KB/s, 99.160 Mbps^[[0m
+^[[0m[INFO ]  VB2:vb2_digest_init() 29403 bytes, hash algo 2, HW acceleration forbidden^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]  Checking segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x40100000^[[0m
+^[[0m[DEBUG]    code (compression=1)^[[0m
+^[[0m[DEBUG]    New segment dstaddr 0x54600000 memsize 0x2c000 srcaddr 0x40100038 filesize 0x72a3^[[0m
+^[[0m[DEBUG]  Loading Segment: addr: 0x54600000 memsz: 0x000000000002c000 filesz: 0x00000000000072a3^[[0m
+^[[0m[DEBUG]  using LZMA^[[0m
+^[[0m[SPEW ]  [ 0x54600000, 54612aa8, 0x5462c000) <- 40100038^[[0m
+^[[0m[DEBUG]  Clearing Segment: addr: 0x0000000054612aa8 memsz: 0x0000000000019558^[[0m
+^[[0m[DEBUG]  Loading segment from ROM address 0x4010001c^[[0m
+^[[0m[DEBUG]    Entry Point 0x54601000^[[0m
+^[[0m[SPEW ]  Loaded segments^[[0m
+INFO:    MT8186 bl31_setup
+NOTICE:  BL31: v2.7(debug):v2.7.0-625-g5c5ee8798
+NOTICE:  BL31: Built : Tue May 14 10:29:19 UTC 2024
+INFO:    dcm_set_default: 1INFO:    GICv3 without legacy support detected.
+INFO:    ARM GICv3 driver initialized in EL3
+INFO:    Maximum SPI INTID supported: 511
+INFO:    [mt_systimer_init] systimer initialization
+NOTICE:  MT8186 spm_boot_init
+INFO:    BL31: Initializing runtime services
+INFO:    BL31: cortex_a55: CPU workaround for 1221012 was applied
+INFO:    BL31: cortex_a55: CPU workaround for 1530923 was applied
+INFO:    SPM: enable CPC mode
+INFO:    mcdi ready for mcusys-off-idle and system suspend
+INFO:    BL31: Preparing for EL3 exit to normal world
+INFO:    Entry point address = 0xf1000000
+INFO:    SPSR = 0x8
+Starting depthcharge on Steelix...
+fw_config match found: AUDIO_AMP=AMP_ALC1019
+[board_setup] Setup ALC1019
+Wipe memory regions:
+[0x00000040000000, 0x00000054600000)
+[0x00000054660000, 0x0000006a000000)
+[0x0000006a100000, 0x000000f1000000)
+[0x000000f31b26a0, 0x000000ffec4000)
+[0x00000100000000, 0x00000240000000)

--- a/tests/test_linux_boot.py
+++ b/tests/test_linux_boot.py
@@ -212,6 +212,12 @@ LOG_DIR = 'tests/logs/linux_boot'
                 ]
             },
             {
+                "call_trace": [],
+                "error_summary": "Fatal exception",
+                "error_type": "linux.kernel.panic",
+                "hardware": None
+            },
+            {
                 "call_trace": [
                     "? __warn+0x98/0xda",
                     "? apply_returns+0xc0/0x241",
@@ -280,6 +286,12 @@ LOG_DIR = 'tests/logs/linux_boot'
                     "industrialio",
                     "snd_timer"
                 ]
+            },
+            {
+                "call_trace": [],
+                "error_summary": "Fatal exception",
+                "error_type": "linux.kernel.panic",
+                "hardware": None
             },
             {
                 "call_trace": [
@@ -599,6 +611,175 @@ LOG_DIR = 'tests/logs/linux_boot'
                  "error_summary": "workqueue lockup",
                  "error_type": "linux.kernel.bug",
                  "hardware": None
+             }
+         ],
+         "linux.boot.kernel_started": True,
+         "linux.boot.prompt": False
+     }),
+
+    # Kernel panic incomplete due reboot
+    ('linux_boot_008.log',
+     'generic_linux_boot',
+     {
+         "bootloader.done": True,
+         "errors": [
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-img failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-img failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-imp_iic_wrap failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-ipe failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-mdp failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-mfg failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-vdec failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-venc failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-wpe failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver coreboot_table failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "Direct firmware load for regulatory.db failed with error -2",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "Direct firmware load for mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin failed with error -2",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "call_trace": [
+                     "show_stack+0x20/0x38 (C)",
+                     "dump_stack_lvl+0xc8/0xf8",
+                     "dump_stack+0x18/0x28",
+                     "panic+0x3d0/0x438",
+                     "do_exit+0x84c/0xa28",
+                     "__arm64_sys_exit+0x20/0x28",
+                     "invoke_syscall+0x70/0x100",
+                     "el0_svc_common.constprop.0+0x48/0xf0",
+                     "do_el0_svc+0x24/0x38",
+                     "el0_svc+0x34/0xf0",
+                     "el0t_64_sync_handler+0x10c/0x138",
+                     "el0t_64_sync+0x1b0/0x1b8"
+                 ],
+                 "error_summary": "Attempted to kill init! exitcode=0x00000200",
+                 "error_type": "linux.kernel.panic",
+                 "hardware": "Google Steelix board (DT)"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-cam failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-img failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-img failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-imp_iic_wrap failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-ipe failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-mdp failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-mfg failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-vdec failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-venc failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver clk-mt8186-wpe failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "probe with driver coreboot_table failed with error -22",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "Direct firmware load for regulatory.db failed with error -2",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "error_summary": "Direct firmware load for mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin failed with error -2",
+                 "error_type": "linux.kernel.error_return_code"
+             },
+             {
+                 "call_trace": [
+                     "show_stack+0x20/0x38 (C)",
+                     "dump_stack_lvl+0xc8/0xf8",
+                     "dump_stack+0x18/0x28",
+                     "panic+0x3d0/0x438",
+                     "do_exit+0x84c/0xa28",
+                     "__arm64_sys_exit+0x20/0x28",
+                     "invoke_syscall+0x70/0x100",
+                     "el0_svc_common.constprop.0+0x48/0xf0",
+                     "do_el0_svc+0x24/0x38",
+                     "el0_svc+0x34/0xf0",
+                     "el0t_64_sync_handler+0x10c/0x138",
+                     "el0t_64_sync+0x1b0/0x1b8"
+                 ],
+                 "error_summary": "Attempted to kill init! exitcode=0x00000200",
+                 "error_type": "linux.kernel.panic",
+                 "hardware": "Google Steelix board (DT)"
              }
          ],
          "linux.boot.kernel_started": True,


### PR DESCRIPTION
errors/linux_kernel: handle incomplete kernel panics
    
A kernel panic can be incomplete if there is a reboot in the middle of
it. Handle this case by getting the next block or lines starting with
LINUX_TIMESTAMP that represents those are kernel messages.

Depends on https://github.com/kernelci/logspec/pull/7 to avoid conflicts on the tests definitions