### PR TITLE
Fix crash in _detect_kernel_start()

### DIFF
--- a/logspec/states/linux_kernel.py
+++ b/logspec/states/linux_kernel.py
@@ -18,6 +18,10 @@ def _detect_kernel_start(text):
     kernel starting. Returns a Match object if it does, None if it
     doesn't.
     """
+    # Avoid crash if 'text' is not well formed
+    if '\n' not in text:
+        return None
+
     first_line_end = text.index('\n')
     return re.match(fr'{LINUX_TIMESTAMP} .*',
                     text[:first_line_end]) or re.search(fr'{LINUX_TIMESTAMP} Linux version .*', text)


### PR DESCRIPTION
  File "/home/kernelci/.local/lib/python3.11/site-packages/logspec/states/linux_kernel.py", line 64, in detect_linux_prompt
    if _detect_kernel_start(text[kernel_first_line_start:]):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/.local/lib/python3.11/site-packages/logspec/states/linux_kernel.py", line 21, in _detect_kernel_start
    first_line_end = text.index('\n')
                     ^^^^^^^^^^^^^^^^
ValueError: substring not found