### PR TITLE
kbuild: ignore timestamp prefix in error summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install .
+
+      - name: Run tests
+        run: ./run_tests.sh

--- a/tests/logs/kbuild/kbuild_018.log
+++ b/tests/logs/kbuild/kbuild_018.log
@@ -1,0 +1,14992 @@
+  HOSTCC  scripts/basic/fixdep
+  HOSTCC  scripts/kconfig/conf.o
+  HOSTCC  scripts/kconfig/confdata.o
+  HOSTCC  scripts/kconfig/expr.o
+  LEX     scripts/kconfig/lexer.lex.c
+  YACC    scripts/kconfig/parser.tab.[ch]
+  HOSTCC  scripts/kconfig/lexer.lex.o
+  HOSTCC  scripts/kconfig/menu.o
+  HOSTCC  scripts/kconfig/parser.tab.o
+  HOSTCC  scripts/kconfig/preprocess.o
+  HOSTCC  scripts/kconfig/symbol.o
+  HOSTCC  scripts/kconfig/util.o
+  HOSTLD  scripts/kconfig/conf
+.config:2407:warning: symbol value 'm' invalid for DRIVER_PE_KUNIT_TEST
+.config:4539:warning: symbol value 'm' invalid for SERIAL_SC16IS7XX_I2C
+.config:4540:warning: symbol value 'm' invalid for SERIAL_SC16IS7XX_SPI
+.config:4932:warning: symbol value 'm' invalid for GPIO_TPS68470
+.config:6040:warning: symbol value 'm' invalid for RADIO_ADAPTERS
+.config:7449:warning: symbol value 'm' invalid for SND_SOC_SOF_DEBUG_PROBES
+.config:7503:warning: symbol value 'm' invalid for SND_SOC_SOF_HDA_PROBES
+.config:11590:warning: symbol value 'm' invalid for KPROBES_SANITY_TEST
+#
+# configuration written to .config
+#
+00:00:01   SYNC    include/config/auto.conf
+00:00:03 *
+00:00:03 * Restart config...
+00:00:03 *
+00:00:03 *
+00:00:03 * Certificates for signature checking
+00:00:03 *
+00:00:03 File name or PKCS#11 URI of module signing key (MODULE_SIG_KEY) [certs/signing_key.pem] certs/signing_key.pem
+00:00:03 Type of module signing key to be generated
+00:00:03 > 1. RSA (MODULE_SIG_KEY_TYPE_RSA)
+00:00:03   2. ECDSA (MODULE_SIG_KEY_TYPE_ECDSA)
+00:00:03 choice[1-2?]: 1
+00:00:03 Provide system-wide ring of trusted keys (SYSTEM_TRUSTED_KEYRING) [Y/?] y
+00:00:03   Additional X.509 keys for default system keyring (SYSTEM_TRUSTED_KEYS) [] (NEW) 
+00:00:03 Error in reading or end of file.
+00:00:03 
+00:00:03   Reserve area for inserting a certificate without recompiling (SYSTEM_EXTRA_CERTIFICATE) [Y/n/?] y
+00:00:03     Number of bytes to reserve for the extra certificate (SYSTEM_EXTRA_CERTIFICATE_SIZE) [4096] 4096
+00:00:03   Provide a keyring to which extra trustable keys may be added (SECONDARY_TRUSTED_KEYRING) [Y/n/?] y
+00:00:03 Provide system-wide ring of blacklisted keys (SYSTEM_BLACKLIST_KEYRING) [Y/n/?] y
+00:00:03   Hashes to be preloaded into the system blacklist keyring (SYSTEM_BLACKLIST_HASH_LIST) [] 
+00:00:03   Provide system-wide ring of revocation certificates (SYSTEM_REVOCATION_LIST) [N/y/?] n
+00:00:04   UPD     include/config/kernel.release
+00:00:04 make -f ./Makefile
+00:00:06   SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
+00:00:06   SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
+00:00:06   SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
+00:00:06   SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
+00:00:06   SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
+00:00:06   SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
+00:00:06   SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
+00:00:06   HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/errno.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/poll.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/param.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/resource.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/socket.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/sockios.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/termbits.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/termios.h
+00:00:06   WRAP    arch/x86/include/generated/uapi/asm/types.h
+00:00:06   HOSTCC  arch/x86/tools/relocs_32.o
+00:00:06   HOSTCC  arch/x86/tools/relocs_64.o
+00:00:06   HOSTCC  arch/x86/tools/relocs_common.o
+00:00:06   WRAP    arch/x86/include/generated/asm/early_ioremap.h
+00:00:06   WRAP    arch/x86/include/generated/asm/export.h
+00:00:06   WRAP    arch/x86/include/generated/asm/mcs_spinlock.h
+00:00:06   WRAP    arch/x86/include/generated/asm/irq_regs.h
+00:00:06   WRAP    arch/x86/include/generated/asm/kmap_size.h
+00:00:06   WRAP    arch/x86/include/generated/asm/mmiowb.h
+00:00:06   WRAP    arch/x86/include/generated/asm/local64.h
+00:00:06   WRAP    arch/x86/include/generated/asm/module.lds.h
+00:00:06   WRAP    arch/x86/include/generated/asm/rwonce.h
+00:00:06   WRAP    arch/x86/include/generated/asm/unaligned.h
+00:00:06   HOSTLD  arch/x86/tools/relocs
+00:00:07   UPD     include/generated/uapi/linux/version.h
+00:00:07   UPD     include/generated/utsrelease.h
+00:00:07   HOSTCC  scripts/bin2c
+00:00:07   HOSTCC  scripts/kallsyms
+00:00:07   HOSTCC  scripts/sorttable
+00:00:07   HOSTCC  scripts/asn1_compiler
+00:00:07   HOSTCC  scripts/selinux/genheaders/genheaders
+00:00:07   HOSTCC  scripts/selinux/mdp/mdp
+00:00:07   HOSTCC  scripts/unifdef
+00:00:07   HOSTCC  scripts/sign-file
+00:00:07   DESCEND objtool
+00:00:07   HOSTCC  scripts/extract-cert
+00:00:07   HOSTCC  scripts/insert-sys-cert
+00:00:07 gcc   -o /builds/9400817560/workdir/tools/objtool/fixdep /builds/9400817560/workdir/tools/objtool/fixdep-in.o
+00:00:07   CC      scripts/mod/empty.o
+00:00:07   HOSTCC  scripts/mod/mk_elfconfig
+00:00:07   CC      scripts/mod/devicetable-offsets.s
+00:00:07   UPD     scripts/mod/devicetable-offsets.h
+00:00:07   HDRINST usr/include/asm-generic/auxvec.h
+00:00:07   HDRINST usr/include/asm-generic/bitsperlong.h
+00:00:07   HDRINST usr/include/asm-generic/bpf_perf_event.h
+00:00:07   HDRINST usr/include/asm-generic/errno-base.h
+00:00:07   HDRINST usr/include/asm-generic/errno.h
+00:00:07   HDRINST usr/include/asm-generic/fcntl.h
+00:00:07   MKELF   scripts/mod/elfconfig.h
+00:00:07   HDRINST usr/include/asm-generic/hugetlb_encode.h
+00:00:07   HDRINST usr/include/asm-generic/int-l64.h
+00:00:07   HDRINST usr/include/asm-generic/int-ll64.h
+00:00:07   HOSTCC  scripts/mod/modpost.o
+00:00:07   HDRINST usr/include/asm-generic/ioctl.h
+00:00:07   HOSTCC  scripts/mod/file2alias.o
+00:00:07   HDRINST usr/include/asm-generic/ipcbuf.h
+00:00:07   HDRINST usr/include/asm-generic/ioctls.h
+00:00:07   HDRINST usr/include/asm-generic/kvm_para.h
+00:00:07   HOSTCC  scripts/mod/sumversion.o
+00:00:07   HDRINST usr/include/asm-generic/mman-common.h
+00:00:07   HDRINST usr/include/asm-generic/mman.h
+00:00:07   HDRINST usr/include/asm-generic/msgbuf.h
+00:00:07   HDRINST usr/include/asm-generic/param.h
+00:00:07   HDRINST usr/include/asm-generic/poll.h
+00:00:07   HDRINST usr/include/asm-generic/posix_types.h
+00:00:07   HDRINST usr/include/asm-generic/resource.h
+00:00:07   HDRINST usr/include/asm-generic/sembuf.h
+00:00:07   HDRINST usr/include/asm-generic/setup.h
+00:00:07   HDRINST usr/include/asm-generic/shmbuf.h
+00:00:07   HDRINST usr/include/asm-generic/siginfo.h
+00:00:07   HDRINST usr/include/asm-generic/signal-defs.h
+00:00:07   HDRINST usr/include/asm-generic/signal.h
+00:00:07   HDRINST usr/include/asm-generic/socket.h
+00:00:07   HDRINST usr/include/asm-generic/sockios.h
+00:00:07   HDRINST usr/include/asm-generic/stat.h
+00:00:07   HDRINST usr/include/asm-generic/statfs.h
+00:00:07   HDRINST usr/include/asm-generic/swab.h
+00:00:07   HDRINST usr/include/asm-generic/termbits.h
+00:00:07   HDRINST usr/include/asm-generic/termios.h
+00:00:07   HDRINST usr/include/asm-generic/types.h
+00:00:07   HDRINST usr/include/asm-generic/ucontext.h
+00:00:07   HDRINST usr/include/asm-generic/unistd.h
+00:00:07   HDRINST usr/include/drm/amdgpu_drm.h
+00:00:07   HDRINST usr/include/drm/armada_drm.h
+00:00:07   HDRINST usr/include/drm/drm.h
+00:00:07   HDRINST usr/include/drm/drm_fourcc.h
+00:00:07   HDRINST usr/include/drm/drm_mode.h
+00:00:07   HDRINST usr/include/drm/drm_sarea.h
+00:00:07   HDRINST usr/include/drm/etnaviv_drm.h
+00:00:07   HDRINST usr/include/drm/exynos_drm.h
+00:00:07   HDRINST usr/include/drm/i810_drm.h
+00:00:07   HDRINST usr/include/drm/i915_drm.h
+00:00:07   HDRINST usr/include/drm/lima_drm.h
+00:00:07   HDRINST usr/include/drm/mga_drm.h
+00:00:07   HDRINST usr/include/drm/msm_drm.h
+00:00:07   HDRINST usr/include/drm/nouveau_drm.h
+00:00:07   HDRINST usr/include/drm/omap_drm.h
+00:00:07   HDRINST usr/include/drm/panfrost_drm.h
+00:00:07   HDRINST usr/include/drm/qxl_drm.h
+00:00:07   HDRINST usr/include/drm/r128_drm.h
+00:00:07   HDRINST usr/include/drm/radeon_drm.h
+00:00:07   HDRINST usr/include/drm/savage_drm.h
+00:00:07   HDRINST usr/include/drm/sis_drm.h
+00:00:07   HDRINST usr/include/drm/tegra_drm.h
+00:00:07   HDRINST usr/include/drm/v3d_drm.h
+00:00:07   HDRINST usr/include/drm/vc4_drm.h
+00:00:07   HDRINST usr/include/drm/vgem_drm.h
+00:00:07   HDRINST usr/include/drm/via_drm.h
+00:00:07   HDRINST usr/include/drm/virtgpu_drm.h
+00:00:07   HDRINST usr/include/drm/vmwgfx_drm.h
+00:00:07   HDRINST usr/include/linux/a.out.h
+00:00:07   HDRINST usr/include/linux/acct.h
+00:00:07   HDRINST usr/include/linux/adb.h
+00:00:07   HDRINST usr/include/linux/acrn.h
+00:00:07   HDRINST usr/include/linux/adfs_fs.h
+00:00:07   HDRINST usr/include/linux/affs_hardblocks.h
+00:00:07   HDRINST usr/include/linux/agpgart.h
+00:00:07   HDRINST usr/include/linux/aio_abi.h
+00:00:07   HDRINST usr/include/linux/am437x-vpfe.h
+00:00:07   HDRINST usr/include/linux/android/binder.h
+00:00:07   HDRINST usr/include/linux/android/binderfs.h
+00:00:07   HDRINST usr/include/linux/apm_bios.h
+00:00:07   HDRINST usr/include/linux/arcfb.h
+00:00:07   HDRINST usr/include/linux/arm_sdei.h
+00:00:07   HDRINST usr/include/linux/aspeed-lpc-ctrl.h
+00:00:07   HDRINST usr/include/linux/aspeed-p2a-ctrl.h
+00:00:07   HDRINST usr/include/linux/atalk.h
+00:00:07   HDRINST usr/include/linux/atm.h
+00:00:07   HDRINST usr/include/linux/atm_eni.h
+00:00:07   HDRINST usr/include/linux/atm_he.h
+00:00:07   HDRINST usr/include/linux/atm_idt77105.h
+00:00:07   HDRINST usr/include/linux/atm_nicstar.h
+00:00:07   HDRINST usr/include/linux/atm_tcp.h
+00:00:07   HDRINST usr/include/linux/atm_zatm.h
+00:00:07   HDRINST usr/include/linux/atmapi.h
+00:00:07   HDRINST usr/include/linux/atmarp.h
+00:00:07   HDRINST usr/include/linux/atmbr2684.h
+00:00:07   HDRINST usr/include/linux/atmclip.h
+00:00:07   HDRINST usr/include/linux/atmdev.h
+00:00:07   HDRINST usr/include/linux/atmioc.h
+00:00:07   HDRINST usr/include/linux/atmlec.h
+00:00:07   HDRINST usr/include/linux/atmmpc.h
+00:00:07   HDRINST usr/include/linux/atmppp.h
+00:00:07   HDRINST usr/include/linux/atmsap.h
+00:00:08   HDRINST usr/include/linux/atmsvc.h
+00:00:08   HDRINST usr/include/linux/audit.h
+00:00:08   HDRINST usr/include/linux/auto_dev-ioctl.h
+00:00:08   HDRINST usr/include/linux/auto_fs.h
+00:00:08   HDRINST usr/include/linux/auxvec.h
+00:00:08   HDRINST usr/include/linux/auto_fs4.h
+00:00:08   HDRINST usr/include/linux/ax25.h
+00:00:08   HDRINST usr/include/linux/batadv_packet.h
+00:00:08   HDRINST usr/include/linux/batman_adv.h
+00:00:08   HDRINST usr/include/linux/baycom.h
+00:00:08   HDRINST usr/include/linux/bcache.h
+00:00:08   HDRINST usr/include/linux/bcm933xx_hcs.h
+00:00:08   HDRINST usr/include/linux/bfs_fs.h
+00:00:08   HDRINST usr/include/linux/binfmts.h
+00:00:08   HDRINST usr/include/linux/blkpg.h
+00:00:08   HDRINST usr/include/linux/blktrace_api.h
+00:00:08   HDRINST usr/include/linux/blkzoned.h
+00:00:08   HDRINST usr/include/linux/bpf.h
+00:00:08   HDRINST usr/include/linux/bpf_common.h
+00:00:08   HDRINST usr/include/linux/bpf_perf_event.h
+00:00:08   HDRINST usr/include/linux/bpfilter.h
+00:00:08   HDRINST usr/include/linux/bpqether.h
+00:00:08   HDRINST usr/include/linux/bt-bmc.h
+00:00:08   HDRINST usr/include/linux/bsg.h
+00:00:08   HDRINST usr/include/linux/btf.h
+00:00:08   HDRINST usr/include/linux/btrfs.h
+00:00:08   HDRINST usr/include/linux/btrfs_tree.h
+00:00:08   HDRINST usr/include/linux/byteorder/big_endian.h
+00:00:08   HDRINST usr/include/linux/byteorder/little_endian.h
+00:00:08   HDRINST usr/include/linux/caif/caif_socket.h
+00:00:08   HDRINST usr/include/linux/caif/if_caif.h
+00:00:08   HDRINST usr/include/linux/can.h
+00:00:08   HDRINST usr/include/linux/can/bcm.h
+00:00:08   HDRINST usr/include/linux/can/error.h
+00:00:08   HDRINST usr/include/linux/can/gw.h
+00:00:08   HDRINST usr/include/linux/can/isotp.h
+00:00:08   HDRINST usr/include/linux/can/j1939.h
+00:00:08   HDRINST usr/include/linux/can/netlink.h
+00:00:08   HDRINST usr/include/linux/can/raw.h
+00:00:08   HDRINST usr/include/linux/can/vxcan.h
+00:00:08   HDRINST usr/include/linux/capability.h
+00:00:08   HDRINST usr/include/linux/capi.h
+00:00:08   HDRINST usr/include/linux/cciss_defs.h
+00:00:08   HDRINST usr/include/linux/cciss_ioctl.h
+00:00:08   HDRINST usr/include/linux/ccs.h
+00:00:08   HDRINST usr/include/linux/cdrom.h
+00:00:08   HDRINST usr/include/linux/cec-funcs.h
+00:00:08   HDRINST usr/include/linux/cfm_bridge.h
+00:00:08   HDRINST usr/include/linux/cec.h
+00:00:08   HDRINST usr/include/linux/cgroupstats.h
+00:00:08   HDRINST usr/include/linux/chio.h
+00:00:08   HDRINST usr/include/linux/cifs/cifs_mount.h
+00:00:08   HDRINST usr/include/linux/cifs/cifs_netlink.h
+00:00:08   HDRINST usr/include/linux/close_range.h
+00:00:08   HDRINST usr/include/linux/cm4000_cs.h
+00:00:08   HDRINST usr/include/linux/cn_proc.h
+00:00:08   HDRINST usr/include/linux/coda.h
+00:00:08   HDRINST usr/include/linux/coff.h
+00:00:08   HDRINST usr/include/linux/connector.h
+00:00:08   HDRINST usr/include/linux/const.h
+00:00:08   HDRINST usr/include/linux/coresight-stm.h
+00:00:08   HDRINST usr/include/linux/cramfs_fs.h
+00:00:08   HDRINST usr/include/linux/cryptouser.h
+00:00:08   HDRINST usr/include/linux/cuda.h
+00:00:08   HDRINST usr/include/linux/cxl_mem.h
+00:00:08   HDRINST usr/include/linux/cyclades.h
+00:00:08   HDRINST usr/include/linux/cycx_cfm.h
+00:00:08   HDRINST usr/include/linux/dcbnl.h
+00:00:08   HDRINST usr/include/linux/dccp.h
+00:00:08   HDRINST usr/include/linux/devlink.h
+00:00:08   HDRINST usr/include/linux/dlm.h
+00:00:08   HDRINST usr/include/linux/dlm_device.h
+00:00:08   HDRINST usr/include/linux/dlm_netlink.h
+00:00:08   HDRINST usr/include/linux/dlm_plock.h
+00:00:08   HDRINST usr/include/linux/dlmconstants.h
+00:00:08   HDRINST usr/include/linux/dm-ioctl.h
+00:00:08   HDRINST usr/include/linux/dm-log-userspace.h
+00:00:08   HDRINST usr/include/linux/dma-buf.h
+00:00:08   HDRINST usr/include/linux/dma-heap.h
+00:00:08   HDRINST usr/include/linux/dns_resolver.h
+00:00:08   HDRINST usr/include/linux/dvb/audio.h
+00:00:08   HDRINST usr/include/linux/dvb/ca.h
+00:00:08   HDRINST usr/include/linux/dvb/dmx.h
+00:00:08   HDRINST usr/include/linux/dvb/frontend.h
+00:00:08   HDRINST usr/include/linux/dqblk_xfs.h
+00:00:08   HDRINST usr/include/linux/dvb/net.h
+00:00:08   HDRINST usr/include/linux/dvb/osd.h
+00:00:08   HDRINST usr/include/linux/dvb/version.h
+00:00:08   HDRINST usr/include/linux/edd.h
+00:00:08   HDRINST usr/include/linux/dvb/video.h
+00:00:08   HDRINST usr/include/linux/efs_fs_sb.h
+00:00:08   HDRINST usr/include/linux/elf-em.h
+00:00:08   HDRINST usr/include/linux/elf-fdpic.h
+00:00:08   HDRINST usr/include/linux/elf.h
+00:00:08   HDRINST usr/include/linux/errno.h
+00:00:08   HDRINST usr/include/linux/errqueue.h
+00:00:08 rm -f /builds/9400817560/workdir/tools/objtool/libsubcmd.a && ar rcs /builds/9400817560/workdir/tools/objtool/libsubcmd.a /builds/9400817560/workdir/tools/objtool/libsubcmd-in.o
+00:00:08   HDRINST usr/include/linux/erspan.h
+00:00:08   HDRINST usr/include/linux/ethtool.h
+00:00:08   HDRINST usr/include/linux/ethtool_netlink.h
+00:00:08   HDRINST usr/include/linux/eventpoll.h
+00:00:08   HDRINST usr/include/linux/f2fs.h
+00:00:08   HDRINST usr/include/linux/fadvise.h
+00:00:08   HDRINST usr/include/linux/falloc.h
+00:00:08   HDRINST usr/include/linux/fanotify.h
+00:00:08   HDRINST usr/include/linux/fb.h
+00:00:08   HDRINST usr/include/linux/fcntl.h
+00:00:08   HDRINST usr/include/linux/fd.h
+00:00:08   HDRINST usr/include/linux/fdreg.h
+00:00:08   HDRINST usr/include/linux/fib_rules.h
+00:00:08   HDRINST usr/include/linux/fiemap.h
+00:00:08   HDRINST usr/include/linux/filter.h
+00:00:08   HDRINST usr/include/linux/firewire-cdev.h
+00:00:08   HDRINST usr/include/linux/firewire-constants.h
+00:00:08   HDRINST usr/include/linux/fou.h
+00:00:08   HDRINST usr/include/linux/fpga-dfl.h
+00:00:08   HDRINST usr/include/linux/fs.h
+00:00:08   HDRINST usr/include/linux/fscrypt.h
+00:00:08   HDRINST usr/include/linux/fsi.h
+00:00:08   HDRINST usr/include/linux/fsl_hypervisor.h
+00:00:08   HDRINST usr/include/linux/fsl_mc.h
+00:00:08   HDRINST usr/include/linux/fsmap.h
+00:00:08   HDRINST usr/include/linux/fsverity.h
+00:00:08   HDRINST usr/include/linux/fuse.h
+00:00:08   HDRINST usr/include/linux/futex.h
+00:00:08   HDRINST usr/include/linux/gameport.h
+00:00:08   HDRINST usr/include/linux/gen_stats.h
+00:00:08   HDRINST usr/include/linux/genetlink.h
+00:00:08   HDRINST usr/include/linux/genwqe/genwqe_card.h
+00:00:08   HDRINST usr/include/linux/gfs2_ondisk.h
+00:00:08   HDRINST usr/include/linux/gpio.h
+00:00:08   HDRINST usr/include/linux/gsmmux.h
+00:00:08   HDRINST usr/include/linux/gtp.h
+00:00:08   HDRINST usr/include/linux/hash_info.h
+00:00:08   HDRINST usr/include/linux/hdlc.h
+00:00:08   HDRINST usr/include/linux/hdlc/ioctl.h
+00:00:08   HDRINST usr/include/linux/hdlcdrv.h
+00:00:08   HDRINST usr/include/linux/hdreg.h
+00:00:08   HDRINST usr/include/linux/hid.h
+00:00:08   HDRINST usr/include/linux/hiddev.h
+00:00:08   HDRINST usr/include/linux/hidraw.h
+00:00:08   HDRINST usr/include/linux/hpet.h
+00:00:08   HDRINST usr/include/linux/hsi/cs-protocol.h
+00:00:08   HDRINST usr/include/linux/hsi/hsi_char.h
+00:00:08   HDRINST usr/include/linux/hsr_netlink.h
+00:00:08   HDRINST usr/include/linux/hw_breakpoint.h
+00:00:08   HDRINST usr/include/linux/hyperv.h
+00:00:08   HDRINST usr/include/linux/i2c-dev.h
+00:00:08   HDRINST usr/include/linux/i2c.h
+00:00:08   HDRINST usr/include/linux/i2o-dev.h
+00:00:08   HDRINST usr/include/linux/i8k.h
+00:00:08   HDRINST usr/include/linux/icmp.h
+00:00:08   HDRINST usr/include/linux/icmpv6.h
+00:00:08   HDRINST usr/include/linux/idxd.h
+00:00:08   HDRINST usr/include/linux/if.h
+00:00:08   HDRINST usr/include/linux/if_addr.h
+00:00:08   HDRINST usr/include/linux/if_addrlabel.h
+00:00:08   HDRINST usr/include/linux/if_alg.h
+00:00:08   HDRINST usr/include/linux/if_arcnet.h
+00:00:08   HDRINST usr/include/linux/if_arp.h
+00:00:08   HDRINST usr/include/linux/if_bonding.h
+00:00:08   HDRINST usr/include/linux/if_bridge.h
+00:00:08   HDRINST usr/include/linux/if_cablemodem.h
+00:00:08   HDRINST usr/include/linux/if_eql.h
+00:00:08   HDRINST usr/include/linux/if_fc.h
+00:00:08   HDRINST usr/include/linux/if_ether.h
+00:00:08   HDRINST usr/include/linux/if_fddi.h
+00:00:08   HDRINST usr/include/linux/if_hippi.h
+00:00:08   HDRINST usr/include/linux/if_infiniband.h
+00:00:08   HDRINST usr/include/linux/if_link.h
+00:00:08   HDRINST usr/include/linux/if_ltalk.h
+00:00:08   HDRINST usr/include/linux/if_macsec.h
+00:00:08   HDRINST usr/include/linux/if_packet.h
+00:00:08   HDRINST usr/include/linux/if_phonet.h
+00:00:08   HDRINST usr/include/linux/if_plip.h
+00:00:08   HDRINST usr/include/linux/if_ppp.h
+00:00:08   HDRINST usr/include/linux/if_pppol2tp.h
+00:00:08   HDRINST usr/include/linux/if_pppox.h
+00:00:08   HDRINST usr/include/linux/if_slip.h
+00:00:08   HDRINST usr/include/linux/if_team.h
+00:00:08   HDRINST usr/include/linux/if_tun.h
+00:00:08   HDRINST usr/include/linux/if_tunnel.h
+00:00:08   HDRINST usr/include/linux/if_vlan.h
+00:00:08   HDRINST usr/include/linux/if_x25.h
+00:00:08   HDRINST usr/include/linux/ife.h
+00:00:08   HDRINST usr/include/linux/if_xdp.h
+00:00:08   HDRINST usr/include/linux/igmp.h
+00:00:08   HDRINST usr/include/linux/iio/buffer.h
+00:00:08   HDRINST usr/include/linux/iio/events.h
+00:00:08   HDRINST usr/include/linux/iio/types.h
+00:00:08   HDRINST usr/include/linux/ila.h
+00:00:08   HDRINST usr/include/linux/in.h
+00:00:08   HDRINST usr/include/linux/in6.h
+00:00:08   HDRINST usr/include/linux/in_route.h
+00:00:08   HDRINST usr/include/linux/inet_diag.h
+00:00:08   HDRINST usr/include/linux/inotify.h
+00:00:08   HDRINST usr/include/linux/input-event-codes.h
+00:00:08   HDRINST usr/include/linux/input.h
+00:00:08   HDRINST usr/include/linux/io_uring.h
+00:00:08   HDRINST usr/include/linux/ioam6.h
+00:00:08   HDRINST usr/include/linux/ioam6_genl.h
+00:00:08   HDRINST usr/include/linux/ioam6_iptunnel.h
+00:00:08   HDRINST usr/include/linux/ioctl.h
+00:00:08   HDRINST usr/include/linux/iommu.h
+00:00:08   HDRINST usr/include/linux/ioprio.h
+00:00:08   HDRINST usr/include/linux/ip.h
+00:00:08   HDRINST usr/include/linux/ip6_tunnel.h
+00:00:08   HDRINST usr/include/linux/ip_vs.h
+00:00:08   HDRINST usr/include/linux/ipc.h
+00:00:08   HDRINST usr/include/linux/ipmi.h
+00:00:08   HDRINST usr/include/linux/ipmi_bmc.h
+00:00:08   HDRINST usr/include/linux/ipmi_msgdefs.h
+00:00:08   HDRINST usr/include/linux/ipsec.h
+00:00:08   HDRINST usr/include/linux/ipv6.h
+00:00:08   HDRINST usr/include/linux/ipv6_route.h
+00:00:08   HDRINST usr/include/linux/irqnr.h
+00:00:08   HDRINST usr/include/linux/isdn/capicmd.h
+00:00:08   HDRINST usr/include/linux/iso_fs.h
+00:00:08   HDRINST usr/include/linux/isst_if.h
+00:00:08   HDRINST usr/include/linux/ivtv.h
+00:00:08   HDRINST usr/include/linux/ivtvfb.h
+00:00:08   HDRINST usr/include/linux/jffs2.h
+00:00:08   HDRINST usr/include/linux/joystick.h
+00:00:08   HDRINST usr/include/linux/kcmp.h
+00:00:08   HDRINST usr/include/linux/kcm.h
+00:00:08   HDRINST usr/include/linux/kcov.h
+00:00:08   HDRINST usr/include/linux/kd.h
+00:00:08   HDRINST usr/include/linux/kdev_t.h
+00:00:08   HDRINST usr/include/linux/kernel-page-flags.h
+00:00:08   HDRINST usr/include/linux/kernel.h
+00:00:08   HDRINST usr/include/linux/kernelcapi.h
+00:00:08   HDRINST usr/include/linux/kexec.h
+00:00:08   HDRINST usr/include/linux/keyboard.h
+00:00:08   HDRINST usr/include/linux/keyctl.h
+00:00:08   HDRINST usr/include/linux/kfd_ioctl.h
+00:00:08   HDRINST usr/include/linux/kvm.h
+00:00:08   HDRINST usr/include/linux/kvm_para.h
+00:00:08   HDRINST usr/include/linux/l2tp.h
+00:00:08   HDRINST usr/include/linux/landlock.h
+00:00:08   HDRINST usr/include/linux/libc-compat.h
+00:00:08   HDRINST usr/include/linux/limits.h
+00:00:08   HDRINST usr/include/linux/lirc.h
+00:00:08   HDRINST usr/include/linux/llc.h
+00:00:08   HDRINST usr/include/linux/loop.h
+00:00:08   HDRINST usr/include/linux/lp.h
+00:00:08   HDRINST usr/include/linux/lwtunnel.h
+00:00:08   HDRINST usr/include/linux/magic.h
+00:00:08   HDRINST usr/include/linux/major.h
+00:00:08   HDRINST usr/include/linux/map_to_7segment.h
+00:00:08   HDRINST usr/include/linux/matroxfb.h
+00:00:08   HDRINST usr/include/linux/max2175.h
+00:00:08   HDRINST usr/include/linux/mctp.h
+00:00:08   HDRINST usr/include/linux/mdio.h
+00:00:08   HDRINST usr/include/linux/media-bus-format.h
+00:00:08   HDRINST usr/include/linux/media.h
+00:00:08   HDRINST usr/include/linux/mei.h
+00:00:08   HDRINST usr/include/linux/membarrier.h
+00:00:08   HDRINST usr/include/linux/memfd.h
+00:00:08   HDRINST usr/include/linux/mempolicy.h
+00:00:08   HDRINST usr/include/linux/meye.h
+00:00:08   HDRINST usr/include/linux/mii.h
+00:00:08   HDRINST usr/include/linux/minix_fs.h
+00:00:08   HDRINST usr/include/linux/misc/bcm_vk.h
+00:00:08   HDRINST usr/include/linux/mman.h
+00:00:08   HDRINST usr/include/linux/mmc/ioctl.h
+00:00:08   HDRINST usr/include/linux/mmtimer.h
+00:00:08   HDRINST usr/include/linux/module.h
+00:00:08   HDRINST usr/include/linux/mount.h
+00:00:08   HDRINST usr/include/linux/mpls.h
+00:00:08   HDRINST usr/include/linux/mpls_iptunnel.h
+00:00:08   HDRINST usr/include/linux/mptcp.h
+00:00:08   HDRINST usr/include/linux/mqueue.h
+00:00:08   HDRINST usr/include/linux/mroute.h
+00:00:08   HDRINST usr/include/linux/mroute6.h
+00:00:08   HDRINST usr/include/linux/mrp_bridge.h
+00:00:08   HDRINST usr/include/linux/msdos_fs.h
+00:00:08   HDRINST usr/include/linux/msg.h
+00:00:08   HDRINST usr/include/linux/mtio.h
+00:00:08   HDRINST usr/include/linux/nbd-netlink.h
+00:00:08   HDRINST usr/include/linux/nbd.h
+00:00:08   HDRINST usr/include/linux/ncsi.h
+00:00:08   HDRINST usr/include/linux/neighbour.h
+00:00:08   HDRINST usr/include/linux/ndctl.h
+00:00:08   HDRINST usr/include/linux/net.h
+00:00:08   HDRINST usr/include/linux/net_dropmon.h
+00:00:08   HDRINST usr/include/linux/net_namespace.h
+00:00:08   HDRINST usr/include/linux/net_tstamp.h
+00:00:08   HDRINST usr/include/linux/netconf.h
+00:00:08   HDRINST usr/include/linux/netdevice.h
+00:00:08   HDRINST usr/include/linux/netfilter.h
+00:00:08   HDRINST usr/include/linux/netfilter/ipset/ip_set.h
+00:00:08   HDRINST usr/include/linux/netfilter/ipset/ip_set_bitmap.h
+00:00:08   HDRINST usr/include/linux/netfilter/ipset/ip_set_hash.h
+00:00:08   HDRINST usr/include/linux/netfilter/ipset/ip_set_list.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_conntrack_common.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_conntrack_ftp.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_conntrack_sctp.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_conntrack_tcp.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_conntrack_tuple_common.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_log.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_nat.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_synproxy.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_tables.h
+00:00:08   HDRINST usr/include/linux/netfilter/nf_tables_compat.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_acct.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_compat.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_conntrack.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_cthelper.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_cttimeout.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_hook.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_log.h
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_osf.h
+00:00:08   HOSTLD  scripts/mod/modpost
+00:00:08   HDRINST usr/include/linux/netfilter/nfnetlink_queue.h
+00:00:08   HDRINST usr/include/linux/netfilter/x_tables.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_AUDIT.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_CHECKSUM.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_CLASSIFY.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_CONNMARK.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_CONNSECMARK.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_CT.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_DSCP.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_IDLETIMER.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_HMARK.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_LED.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_LOG.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_MARK.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_NFLOG.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_NFQUEUE.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_RATEEST.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_SECMARK.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_SYNPROXY.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_TCPMSS.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_TCPOPTSTRIP.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_TEE.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_TPROXY.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_addrtype.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_bpf.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_cgroup.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_cluster.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_comment.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_connbytes.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_connlabel.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_connlimit.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_connmark.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_conntrack.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_cpu.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_dccp.h
+00:00:08   CC      kernel/bounds.s
+00:00:08   HDRINST usr/include/linux/netfilter/xt_devgroup.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_dscp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_ecn.h
+00:00:08   CALL    scripts/atomic/check-atomics.sh
+00:00:08   UPD     include/generated/timeconst.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_esp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_hashlimit.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_helper.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_ipcomp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_iprange.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_ipvs.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_l2tp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_length.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_limit.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_mac.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_mark.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_multiport.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_nfacct.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_osf.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_owner.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_pkttype.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_physdev.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_policy.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_quota.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_rateest.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_realm.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_recent.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_rpfilter.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_sctp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_set.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_socket.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_state.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_statistic.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_string.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_tcpmss.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_tcpudp.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_time.h
+00:00:08   HDRINST usr/include/linux/netfilter/xt_u32.h
+00:00:08   HDRINST usr/include/linux/netfilter_arp.h
+00:00:08   HDRINST usr/include/linux/netfilter_arp/arp_tables.h
+00:00:08   HDRINST usr/include/linux/netfilter_arp/arpt_mangle.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_802_3.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_among.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_arp.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_arpreply.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_ip.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_ip6.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_limit.h
+00:00:08   UPD     include/generated/bounds.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_log.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_mark_m.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_mark_t.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_nat.h
+00:00:08   CC      arch/x86/kernel/asm-offsets.s
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_nflog.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_pkttype.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_redirect.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_stp.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebt_vlan.h
+00:00:08   HDRINST usr/include/linux/netfilter_bridge/ebtables.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ip_tables.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_CLUSTERIP.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_ECN.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_LOG.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_REJECT.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_TTL.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_ah.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_ecn.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv4/ipt_ttl.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6_tables.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_HL.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_LOG.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_NPT.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_REJECT.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_ah.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_frag.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_hl.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_ipv6header.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_mh.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_opts.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_rt.h
+00:00:08   HDRINST usr/include/linux/netfilter_ipv6/ip6t_srh.h
+00:00:08   HDRINST usr/include/linux/netlink.h
+00:00:08   HDRINST usr/include/linux/netlink_diag.h
+00:00:08   HDRINST usr/include/linux/netrom.h
+00:00:08   HDRINST usr/include/linux/nexthop.h
+00:00:08   HDRINST usr/include/linux/nfc.h
+00:00:08   HDRINST usr/include/linux/nfs.h
+00:00:08   HDRINST usr/include/linux/nfs2.h
+00:00:08   HDRINST usr/include/linux/nfs3.h
+00:00:08   HDRINST usr/include/linux/nfs4.h
+00:00:08   HDRINST usr/include/linux/nfs4_mount.h
+00:00:08   HDRINST usr/include/linux/nfs_fs.h
+00:00:08   HDRINST usr/include/linux/nfs_idmap.h
+00:00:08   HDRINST usr/include/linux/nfs_mount.h
+00:00:08   HDRINST usr/include/linux/nfsacl.h
+00:00:08   HDRINST usr/include/linux/nfsd/cld.h
+00:00:08   HDRINST usr/include/linux/nfsd/debug.h
+00:00:08   HDRINST usr/include/linux/nfsd/export.h
+00:00:08   HDRINST usr/include/linux/nfsd/stats.h
+00:00:08   HDRINST usr/include/linux/nilfs2_api.h
+00:00:08   HDRINST usr/include/linux/nilfs2_ondisk.h
+00:00:08   HDRINST usr/include/linux/nitro_enclaves.h
+00:00:08   HDRINST usr/include/linux/nl80211-vnd-intel.h
+00:00:08   HDRINST usr/include/linux/nl80211.h
+00:00:08   HDRINST usr/include/linux/nsfs.h
+00:00:08   HDRINST usr/include/linux/nubus.h
+00:00:08   HDRINST usr/include/linux/nvme_ioctl.h
+00:00:08   HDRINST usr/include/linux/nvram.h
+00:00:08   HDRINST usr/include/linux/omap3isp.h
+00:00:08   HDRINST usr/include/linux/omapfb.h
+00:00:08   HDRINST usr/include/linux/oom.h
+00:00:08   HDRINST usr/include/linux/openat2.h
+00:00:08   HDRINST usr/include/linux/openvswitch.h
+00:00:08   HDRINST usr/include/linux/packet_diag.h
+00:00:08   HDRINST usr/include/linux/param.h
+00:00:08   HDRINST usr/include/linux/parport.h
+00:00:08   HDRINST usr/include/linux/patchkey.h
+00:00:08   HDRINST usr/include/linux/pci.h
+00:00:08   HDRINST usr/include/linux/pci_regs.h
+00:00:08   HDRINST usr/include/linux/pcitest.h
+00:00:08   HDRINST usr/include/linux/perf_event.h
+00:00:08   HDRINST usr/include/linux/personality.h
+00:00:08   HDRINST usr/include/linux/pfkeyv2.h
+00:00:08   HDRINST usr/include/linux/pg.h
+00:00:08   HDRINST usr/include/linux/phantom.h
+00:00:08   HDRINST usr/include/linux/phonet.h
+00:00:08   HDRINST usr/include/linux/pidfd.h
+00:00:08   HDRINST usr/include/linux/pkt_cls.h
+00:00:08   HDRINST usr/include/linux/pkt_sched.h
+00:00:08   HDRINST usr/include/linux/pktcdvd.h
+00:00:08   HDRINST usr/include/linux/pmu.h
+00:00:08   HDRINST usr/include/linux/poll.h
+00:00:08   HDRINST usr/include/linux/posix_acl.h
+00:00:08   HDRINST usr/include/linux/posix_types.h
+00:00:08   HDRINST usr/include/linux/posix_acl_xattr.h
+00:00:08   HDRINST usr/include/linux/ppdev.h
+00:00:08   HDRINST usr/include/linux/ppp-comp.h
+00:00:08   HDRINST usr/include/linux/ppp-ioctl.h
+00:00:08   HDRINST usr/include/linux/ppp_defs.h
+00:00:08   HDRINST usr/include/linux/pps.h
+00:00:08   HDRINST usr/include/linux/pr.h
+00:00:08   HDRINST usr/include/linux/prctl.h
+00:00:08   HDRINST usr/include/linux/psample.h
+00:00:08   HDRINST usr/include/linux/psci.h
+00:00:08   HDRINST usr/include/linux/psp-sev.h
+00:00:08   HDRINST usr/include/linux/ptp_clock.h
+00:00:08   HDRINST usr/include/linux/ptrace.h
+00:00:08   HDRINST usr/include/linux/qemu_fw_cfg.h
+00:00:08   HDRINST usr/include/linux/qnx4_fs.h
+00:00:08   HDRINST usr/include/linux/qnxtypes.h
+00:00:08   HDRINST usr/include/linux/qrtr.h
+00:00:08   HDRINST usr/include/linux/quota.h
+00:00:08   HDRINST usr/include/linux/radeonfb.h
+00:00:08   HDRINST usr/include/linux/raid/md_p.h
+00:00:08   HDRINST usr/include/linux/random.h
+00:00:08   HDRINST usr/include/linux/raid/md_u.h
+00:00:08   HDRINST usr/include/linux/rds.h
+00:00:08   HDRINST usr/include/linux/reboot.h
+00:00:08   HDRINST usr/include/linux/reiserfs_fs.h
+00:00:08   HDRINST usr/include/linux/reiserfs_xattr.h
+00:00:08   HDRINST usr/include/linux/remoteproc_cdev.h
+00:00:08   HDRINST usr/include/linux/resource.h
+00:00:08   HDRINST usr/include/linux/rfkill.h
+00:00:08   HDRINST usr/include/linux/rio_cm_cdev.h
+00:00:08   HDRINST usr/include/linux/rkisp1-config.h
+00:00:08   HDRINST usr/include/linux/rio_mport_cdev.h
+00:00:08   HDRINST usr/include/linux/romfs_fs.h
+00:00:08   HDRINST usr/include/linux/rose.h
+00:00:08   HDRINST usr/include/linux/route.h
+00:00:08   HDRINST usr/include/linux/rpl.h
+00:00:08   HDRINST usr/include/linux/rpl_iptunnel.h
+00:00:08   HDRINST usr/include/linux/rpmsg.h
+00:00:08   HDRINST usr/include/linux/rpmsg_types.h
+00:00:08   HDRINST usr/include/linux/rseq.h
+00:00:08   HDRINST usr/include/linux/rtc.h
+00:00:08   HDRINST usr/include/linux/rtnetlink.h
+00:00:08   HDRINST usr/include/linux/rxrpc.h
+00:00:08   HDRINST usr/include/linux/scc.h
+00:00:08   HDRINST usr/include/linux/sched.h
+00:00:08   HDRINST usr/include/linux/sched/types.h
+00:00:08   HDRINST usr/include/linux/scif_ioctl.h
+00:00:08   HDRINST usr/include/linux/screen_info.h
+00:00:08   HDRINST usr/include/linux/sctp.h
+00:00:08   HDRINST usr/include/linux/seccomp.h
+00:00:08   HDRINST usr/include/linux/securebits.h
+00:00:08   HDRINST usr/include/linux/sed-opal.h
+00:00:08   HDRINST usr/include/linux/seg6.h
+00:00:08   HDRINST usr/include/linux/seg6_genl.h
+00:00:08   HDRINST usr/include/linux/seg6_hmac.h
+00:00:08   HDRINST usr/include/linux/seg6_iptunnel.h
+00:00:08   HDRINST usr/include/linux/seg6_local.h
+00:00:08   HDRINST usr/include/linux/selinux_netlink.h
+00:00:08   HDRINST usr/include/linux/sem.h
+00:00:08   HDRINST usr/include/linux/serial.h
+00:00:08   HDRINST usr/include/linux/serial_core.h
+00:00:08   HDRINST usr/include/linux/serial_reg.h
+00:00:08   HDRINST usr/include/linux/serio.h
+00:00:08   HDRINST usr/include/linux/signal.h
+00:00:08   HDRINST usr/include/linux/shm.h
+00:00:08   HDRINST usr/include/linux/signalfd.h
+00:00:08   HDRINST usr/include/linux/smc.h
+00:00:08   HDRINST usr/include/linux/smc_diag.h
+00:00:08   HDRINST usr/include/linux/smiapp.h
+00:00:08   HDRINST usr/include/linux/snmp.h
+00:00:08   HDRINST usr/include/linux/sock_diag.h
+00:00:08   HDRINST usr/include/linux/socket.h
+00:00:08   HDRINST usr/include/linux/sockios.h
+00:00:08   HDRINST usr/include/linux/sonet.h
+00:00:08   HDRINST usr/include/linux/sonypi.h
+00:00:08   HDRINST usr/include/linux/sound.h
+00:00:08   HDRINST usr/include/linux/soundcard.h
+00:00:08   HDRINST usr/include/linux/spi/spi.h
+00:00:08   HDRINST usr/include/linux/spi/spidev.h
+00:00:08   HDRINST usr/include/linux/stat.h
+00:00:08   HDRINST usr/include/linux/stddef.h
+00:00:08   HDRINST usr/include/linux/stm.h
+00:00:08   HDRINST usr/include/linux/string.h
+00:00:08   HDRINST usr/include/linux/sunrpc/debug.h
+00:00:08   HDRINST usr/include/linux/surface_aggregator/cdev.h
+00:00:08   HDRINST usr/include/linux/surface_aggregator/dtx.h
+00:00:08   HDRINST usr/include/linux/suspend_ioctls.h
+00:00:08   HDRINST usr/include/linux/swab.h
+00:00:08   HDRINST usr/include/linux/switchtec_ioctl.h
+00:00:08   HDRINST usr/include/linux/sync_file.h
+00:00:08   HDRINST usr/include/linux/synclink.h
+00:00:08   HDRINST usr/include/linux/sysctl.h
+00:00:08   HDRINST usr/include/linux/sysinfo.h
+00:00:08   HDRINST usr/include/linux/target_core_user.h
+00:00:08   HDRINST usr/include/linux/taskstats.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_bpf.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_connmark.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_csum.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_ct.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_ctinfo.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_defact.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_gact.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_gate.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_ife.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_ipt.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_mirred.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_mpls.h
+00:00:08   HDRINST usr/include/linux/tc_act/tc_nat.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_pedit.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_sample.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_skbedit.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_skbmod.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_tunnel_key.h
+00:00:09   HDRINST usr/include/linux/tc_act/tc_vlan.h
+00:00:09   HDRINST usr/include/linux/tc_ematch/tc_em_cmp.h
+00:00:09   HDRINST usr/include/linux/tc_ematch/tc_em_ipt.h
+00:00:09   HDRINST usr/include/linux/tc_ematch/tc_em_meta.h
+00:00:09   HDRINST usr/include/linux/tc_ematch/tc_em_nbyte.h
+00:00:09   HDRINST usr/include/linux/tc_ematch/tc_em_text.h
+00:00:09   HDRINST usr/include/linux/tcp.h
+00:00:09   HDRINST usr/include/linux/tcp_metrics.h
+00:00:09   HDRINST usr/include/linux/tee.h
+00:00:09   HDRINST usr/include/linux/termios.h
+00:00:09   HDRINST usr/include/linux/thermal.h
+00:00:09   HDRINST usr/include/linux/time.h
+00:00:09   HDRINST usr/include/linux/timerfd.h
+00:00:09   HDRINST usr/include/linux/time_types.h
+00:00:09   HDRINST usr/include/linux/times.h
+00:00:09   HDRINST usr/include/linux/timex.h
+00:00:09   HDRINST usr/include/linux/tiocl.h
+00:00:09   HDRINST usr/include/linux/tipc.h
+00:00:09   HDRINST usr/include/linux/tipc_config.h
+00:00:09   HDRINST usr/include/linux/tipc_netlink.h
+00:00:09   HDRINST usr/include/linux/tipc_sockets_diag.h
+00:00:09   HDRINST usr/include/linux/tls.h
+00:00:09   HDRINST usr/include/linux/toshiba.h
+00:00:09   HDRINST usr/include/linux/tty_flags.h
+00:00:09   HDRINST usr/include/linux/types.h
+00:00:09   HDRINST usr/include/linux/tty.h
+00:00:09   HDRINST usr/include/linux/udf_fs_i.h
+00:00:09   HDRINST usr/include/linux/udmabuf.h
+00:00:09   HDRINST usr/include/linux/udp.h
+00:00:09   HDRINST usr/include/linux/uhid.h
+00:00:09   HDRINST usr/include/linux/uinput.h
+00:00:09   HDRINST usr/include/linux/uio.h
+00:00:09   HDRINST usr/include/linux/uleds.h
+00:00:09   HDRINST usr/include/linux/ultrasound.h
+00:00:09   HDRINST usr/include/linux/um_timetravel.h
+00:00:09   HDRINST usr/include/linux/un.h
+00:00:09   HDRINST usr/include/linux/unistd.h
+00:00:09   HDRINST usr/include/linux/unix_diag.h
+00:00:09   HDRINST usr/include/linux/usb/audio.h
+00:00:09   HDRINST usr/include/linux/usb/cdc-wdm.h
+00:00:09   HDRINST usr/include/linux/usb/cdc.h
+00:00:09   HDRINST usr/include/linux/usb/ch11.h
+00:00:09   HDRINST usr/include/linux/usb/ch9.h
+00:00:09   HDRINST usr/include/linux/usb/charger.h
+00:00:09   HDRINST usr/include/linux/usb/functionfs.h
+00:00:09   HDRINST usr/include/linux/usb/g_printer.h
+00:00:09   HDRINST usr/include/linux/usb/g_uvc.h
+00:00:09   HDRINST usr/include/linux/usb/gadgetfs.h
+00:00:09   HDRINST usr/include/linux/usb/midi.h
+00:00:09   HDRINST usr/include/linux/usb/raw_gadget.h
+00:00:09   HDRINST usr/include/linux/usb/tmc.h
+00:00:09   HDRINST usr/include/linux/usb/video.h
+00:00:09   HDRINST usr/include/linux/usbdevice_fs.h
+00:00:09   HDRINST usr/include/linux/usbip.h
+00:00:09   HDRINST usr/include/linux/userfaultfd.h
+00:00:09   HDRINST usr/include/linux/userio.h
+00:00:09   HDRINST usr/include/linux/utime.h
+00:00:09   HDRINST usr/include/linux/utsname.h
+00:00:09   HDRINST usr/include/linux/uuid.h
+00:00:09   HDRINST usr/include/linux/uvcvideo.h
+00:00:09   HDRINST usr/include/linux/v4l2-common.h
+00:00:09   HDRINST usr/include/linux/v4l2-controls.h
+00:00:09   HDRINST usr/include/linux/v4l2-dv-timings.h
+00:00:09   HDRINST usr/include/linux/v4l2-mediabus.h
+00:00:09   HDRINST usr/include/linux/v4l2-subdev.h
+00:00:09   HDRINST usr/include/linux/vbox_err.h
+00:00:09   HDRINST usr/include/linux/vbox_vmmdev_types.h
+00:00:09   HDRINST usr/include/linux/vboxguest.h
+00:00:09   HDRINST usr/include/linux/vdpa.h
+00:00:09   HDRINST usr/include/linux/vduse.h
+00:00:09   HDRINST usr/include/linux/veth.h
+00:00:09   HDRINST usr/include/linux/vfio_ccw.h
+00:00:09   HDRINST usr/include/linux/vfio.h
+00:00:09   HDRINST usr/include/linux/vfio_zdev.h
+00:00:09   HDRINST usr/include/linux/vhost.h
+00:00:09   HDRINST usr/include/linux/vhost_types.h
+00:00:09   HDRINST usr/include/linux/virtio_9p.h
+00:00:09   HDRINST usr/include/linux/videodev2.h
+00:00:09   HDRINST usr/include/linux/virtio_balloon.h
+00:00:09   HDRINST usr/include/linux/virtio_blk.h
+00:00:09   HDRINST usr/include/linux/virtio_bt.h
+00:00:09   HDRINST usr/include/linux/virtio_config.h
+00:00:09   HDRINST usr/include/linux/virtio_console.h
+00:00:09   HDRINST usr/include/linux/virtio_crypto.h
+00:00:09   HDRINST usr/include/linux/virtio_fs.h
+00:00:09   HDRINST usr/include/linux/virtio_gpio.h
+00:00:09   HDRINST usr/include/linux/virtio_gpu.h
+00:00:09   HDRINST usr/include/linux/virtio_i2c.h
+00:00:09   HDRINST usr/include/linux/virtio_ids.h
+00:00:09   HDRINST usr/include/linux/virtio_input.h
+00:00:09   HDRINST usr/include/linux/virtio_iommu.h
+00:00:09   HDRINST usr/include/linux/virtio_mem.h
+00:00:09   HDRINST usr/include/linux/virtio_mmio.h
+00:00:09   HDRINST usr/include/linux/virtio_net.h
+00:00:09   HDRINST usr/include/linux/virtio_pci.h
+00:00:09   HDRINST usr/include/linux/virtio_pcidev.h
+00:00:09   HDRINST usr/include/linux/virtio_pmem.h
+00:00:09   HDRINST usr/include/linux/virtio_ring.h
+00:00:09   HDRINST usr/include/linux/virtio_rng.h
+00:00:09   HDRINST usr/include/linux/virtio_scmi.h
+00:00:09   HDRINST usr/include/linux/virtio_scsi.h
+00:00:09   HDRINST usr/include/linux/virtio_snd.h
+00:00:09   HDRINST usr/include/linux/virtio_types.h
+00:00:09   HDRINST usr/include/linux/virtio_vsock.h
+00:00:09   HDRINST usr/include/linux/vm_sockets.h
+00:00:09   HDRINST usr/include/linux/vm_sockets_diag.h
+00:00:09   HDRINST usr/include/linux/vmcore.h
+00:00:09   HDRINST usr/include/linux/vsockmon.h
+00:00:09   HDRINST usr/include/linux/vt.h
+00:00:09   HDRINST usr/include/linux/vtpm_proxy.h
+00:00:09   HDRINST usr/include/linux/wait.h
+00:00:09   HDRINST usr/include/linux/watch_queue.h
+00:00:09   HDRINST usr/include/linux/watchdog.h
+00:00:09   HDRINST usr/include/linux/wireguard.h
+00:00:09   HDRINST usr/include/linux/wireless.h
+00:00:09   HDRINST usr/include/linux/wmi.h
+00:00:09   HDRINST usr/include/linux/wwan.h
+00:00:09   HDRINST usr/include/linux/x25.h
+00:00:09   HDRINST usr/include/linux/xattr.h
+00:00:09   HDRINST usr/include/linux/xdp_diag.h
+00:00:09   HDRINST usr/include/linux/xfrm.h
+00:00:09   HDRINST usr/include/linux/xilinx-v4l2-controls.h
+00:00:09   HDRINST usr/include/linux/zorro.h
+00:00:09   HDRINST usr/include/linux/zorro_ids.h
+00:00:09   HDRINST usr/include/misc/cxl.h
+00:00:09   HDRINST usr/include/misc/fastrpc.h
+00:00:09   HDRINST usr/include/misc/habanalabs.h
+00:00:09   HDRINST usr/include/misc/ocxl.h
+00:00:09   HDRINST usr/include/misc/pvpanic.h
+00:00:09   HDRINST usr/include/misc/uacce/hisi_qm.h
+00:00:09   HDRINST usr/include/misc/uacce/uacce.h
+00:00:09   HDRINST usr/include/misc/xilinx_sdfec.h
+00:00:09   HDRINST usr/include/mtd/inftl-user.h
+00:00:09   HDRINST usr/include/mtd/mtd-abi.h
+00:00:09   HDRINST usr/include/mtd/mtd-user.h
+00:00:09   HDRINST usr/include/mtd/nftl-user.h
+00:00:09   HDRINST usr/include/mtd/ubi-user.h
+00:00:09   HDRINST usr/include/rdma/bnxt_re-abi.h
+00:00:09   HDRINST usr/include/rdma/cxgb4-abi.h
+00:00:09   HDRINST usr/include/rdma/efa-abi.h
+00:00:09   HDRINST usr/include/rdma/hfi/hfi1_ioctl.h
+00:00:09   HDRINST usr/include/rdma/hfi/hfi1_user.h
+00:00:09   HDRINST usr/include/rdma/hns-abi.h
+00:00:09   HDRINST usr/include/rdma/ib_user_ioctl_cmds.h
+00:00:09   HDRINST usr/include/rdma/ib_user_ioctl_verbs.h
+00:00:09   HDRINST usr/include/rdma/ib_user_mad.h
+00:00:09   HDRINST usr/include/rdma/ib_user_sa.h
+00:00:09   HDRINST usr/include/rdma/ib_user_verbs.h
+00:00:09   HDRINST usr/include/rdma/irdma-abi.h
+00:00:09   HDRINST usr/include/rdma/mlx4-abi.h
+00:00:09   HDRINST usr/include/rdma/mlx5-abi.h
+00:00:09   HDRINST usr/include/rdma/mlx5_user_ioctl_cmds.h
+00:00:09   HDRINST usr/include/rdma/mlx5_user_ioctl_verbs.h
+00:00:09   HDRINST usr/include/rdma/mthca-abi.h
+00:00:09   HDRINST usr/include/rdma/ocrdma-abi.h
+00:00:09   HDRINST usr/include/rdma/qedr-abi.h
+00:00:09   HDRINST usr/include/rdma/rdma_netlink.h
+00:00:09   HDRINST usr/include/rdma/rdma_user_cm.h
+00:00:09   HDRINST usr/include/rdma/rdma_user_ioctl.h
+00:00:09   HDRINST usr/include/rdma/rdma_user_ioctl_cmds.h
+00:00:09   HDRINST usr/include/rdma/rdma_user_rxe.h
+00:00:09   HDRINST usr/include/rdma/rvt-abi.h
+00:00:09   HDRINST usr/include/rdma/siw-abi.h
+00:00:09   HDRINST usr/include/rdma/vmw_pvrdma-abi.h
+00:00:09   HDRINST usr/include/scsi/cxlflash_ioctl.h
+00:00:09   HDRINST usr/include/scsi/fc/fc_els.h
+00:00:09   HDRINST usr/include/scsi/fc/fc_fs.h
+00:00:09   HDRINST usr/include/scsi/fc/fc_gs.h
+00:00:09   HDRINST usr/include/scsi/fc/fc_ns.h
+00:00:09   HDRINST usr/include/scsi/scsi_bsg_fc.h
+00:00:09   HDRINST usr/include/scsi/scsi_bsg_ufs.h
+00:00:09   HDRINST usr/include/scsi/scsi_netlink.h
+00:00:09   HDRINST usr/include/scsi/scsi_netlink_fc.h
+00:00:09   HDRINST usr/include/sound/asequencer.h
+00:00:09   HDRINST usr/include/sound/asoc.h
+00:00:09   HDRINST usr/include/sound/asound.h
+00:00:09   HDRINST usr/include/sound/asound_fm.h
+00:00:09   HDRINST usr/include/sound/compress_offload.h
+00:00:09   HDRINST usr/include/sound/compress_params.h
+00:00:09   HDRINST usr/include/sound/emu10k1.h
+00:00:09   HDRINST usr/include/sound/firewire.h
+00:00:09   HDRINST usr/include/sound/hdsp.h
+00:00:09   HDRINST usr/include/sound/hdspm.h
+00:00:09   HDRINST usr/include/sound/sb16_csp.h
+00:00:09   HDRINST usr/include/sound/sfnt_info.h
+00:00:09   HDRINST usr/include/sound/skl-tplg-interface.h
+00:00:09   HDRINST usr/include/sound/snd_sst_tokens.h
+00:00:09   HDRINST usr/include/sound/sof/abi.h
+00:00:09   HDRINST usr/include/sound/sof/fw.h
+00:00:09   HDRINST usr/include/sound/sof/header.h
+00:00:09   HDRINST usr/include/sound/sof/tokens.h
+00:00:09   HDRINST usr/include/sound/tlv.h
+00:00:09   HDRINST usr/include/sound/usb_stream.h
+00:00:09   HDRINST usr/include/video/edid.h
+00:00:09   HDRINST usr/include/video/sisfb.h
+00:00:09   HDRINST usr/include/video/uvesafb.h
+00:00:09   HDRINST usr/include/xen/evtchn.h
+00:00:09   HDRINST usr/include/xen/gntalloc.h
+00:00:09   HDRINST usr/include/xen/gntdev.h
+00:00:09   HDRINST usr/include/xen/privcmd.h
+00:00:09   HDRINST usr/include/linux/version.h
+00:00:09   HDRINST usr/include/asm/a.out.h
+00:00:09   HDRINST usr/include/asm/auxvec.h
+00:00:09   HDRINST usr/include/asm/bitsperlong.h
+00:00:09   HDRINST usr/include/asm/boot.h
+00:00:09   HDRINST usr/include/asm/bootparam.h
+00:00:09   HDRINST usr/include/asm/byteorder.h
+00:00:09   HDRINST usr/include/asm/debugreg.h
+00:00:09   HDRINST usr/include/asm/e820.h
+00:00:09   HDRINST usr/include/asm/hw_breakpoint.h
+00:00:09   HDRINST usr/include/asm/hwcap2.h
+00:00:09   HDRINST usr/include/asm/ist.h
+00:00:09   HDRINST usr/include/asm/kvm.h
+00:00:09   HDRINST usr/include/asm/kvm_para.h
+00:00:09   HDRINST usr/include/asm/kvm_perf.h
+00:00:09   UPD     include/generated/asm-offsets.h
+00:00:09   HDRINST usr/include/asm/ldt.h
+00:00:09   HDRINST usr/include/asm/mce.h
+00:00:09   HDRINST usr/include/asm/mman.h
+00:00:09   HDRINST usr/include/asm/msgbuf.h
+00:00:09   HDRINST usr/include/asm/msr.h
+00:00:09   CALL    scripts/checksyscalls.sh
+00:00:09   HDRINST usr/include/asm/mtrr.h
+00:00:09   HDRINST usr/include/asm/perf_regs.h
+00:00:09   HDRINST usr/include/asm/posix_types.h
+00:00:09   HDRINST usr/include/asm/posix_types_32.h
+00:00:09   HDRINST usr/include/asm/posix_types_64.h
+00:00:09   HDRINST usr/include/asm/posix_types_x32.h
+00:00:09   HDRINST usr/include/asm/prctl.h
+00:00:09   HDRINST usr/include/asm/processor-flags.h
+00:00:09   HDRINST usr/include/asm/ptrace-abi.h
+00:00:09   HDRINST usr/include/asm/ptrace.h
+00:00:09   HDRINST usr/include/asm/sembuf.h
+00:00:09   HDRINST usr/include/asm/setup.h
+00:00:09   HDRINST usr/include/asm/sgx.h
+00:00:09   HDRINST usr/include/asm/shmbuf.h
+00:00:09   HDRINST usr/include/asm/sigcontext.h
+00:00:09   HDRINST usr/include/asm/sigcontext32.h
+00:00:09   HDRINST usr/include/asm/siginfo.h
+00:00:09   HDRINST usr/include/asm/signal.h
+00:00:09   HDRINST usr/include/asm/stat.h
+00:00:09   HDRINST usr/include/asm/statfs.h
+00:00:09   HDRINST usr/include/asm/svm.h
+00:00:09   HDRINST usr/include/asm/swab.h
+00:00:09   HDRINST usr/include/asm/ucontext.h
+00:00:09   HDRINST usr/include/asm/unistd.h
+00:00:09   HDRINST usr/include/asm/vm86.h
+00:00:09   HDRINST usr/include/asm/vmx.h
+00:00:09   HDRINST usr/include/asm/vsyscall.h
+00:00:09   HDRINST usr/include/asm/unistd_64.h
+00:00:09   HDRINST usr/include/asm/unistd_32.h
+00:00:09   HDRINST usr/include/asm/unistd_x32.h
+00:00:09   HDRINST usr/include/asm/bpf_perf_event.h
+00:00:09   HDRINST usr/include/asm/errno.h
+00:00:09   HDRINST usr/include/asm/fcntl.h
+00:00:09   HDRINST usr/include/asm/ioctl.h
+00:00:09   HDRINST usr/include/asm/ioctls.h
+00:00:09   HDRINST usr/include/asm/ipcbuf.h
+00:00:09   HDRINST usr/include/asm/poll.h
+00:00:09   HDRINST usr/include/asm/param.h
+00:00:09   HDRINST usr/include/asm/resource.h
+00:00:09   HDRINST usr/include/asm/socket.h
+00:00:09   HDRINST usr/include/asm/sockios.h
+00:00:09   HDRINST usr/include/asm/termbits.h
+00:00:09   HDRINST usr/include/asm/termios.h
+00:00:09   HDRINST usr/include/asm/types.h
+00:00:09 gcc /builds/9400817560/workdir/tools/objtool/objtool-in.o -lelf /builds/9400817560/workdir/tools/objtool/libsubcmd.a   -o /builds/9400817560/workdir/tools/objtool/objtool
+00:00:09   CC      init/main.o
+00:00:09   CHK     include/generated/compile.h
+00:00:09   CC      init/do_mounts.o
+00:00:09   CC      init/do_mounts_initrd.o
+00:00:09   CC      init/initramfs.o
+00:00:09   CC      init/calibrate.o
+00:00:09   CC      init/init_task.o
+00:00:09   UPD     include/generated/compile.h
+00:00:09   CC      init/version.o
+00:00:09   HOSTCC  usr/gen_init_cpio
+00:00:09   HDRTEST usr/include/asm-generic/auxvec.h
+00:00:09   HDRTEST usr/include/asm-generic/bitsperlong.h
+00:00:09   HDRTEST usr/include/asm-generic/bpf_perf_event.h
+00:00:09   HDRTEST usr/include/asm-generic/errno-base.h
+00:00:09   HDRTEST usr/include/asm-generic/errno.h
+00:00:09   HDRTEST usr/include/asm-generic/hugetlb_encode.h
+00:00:09   HDRTEST usr/include/asm-generic/fcntl.h
+00:00:09   HDRTEST usr/include/asm-generic/int-l64.h
+00:00:09   HDRTEST usr/include/asm-generic/int-ll64.h
+00:00:09   HDRTEST usr/include/asm-generic/ioctl.h
+00:00:09   HDRTEST usr/include/asm-generic/ioctls.h
+00:00:09   HDRTEST usr/include/asm-generic/kvm_para.h
+00:00:09   HDRTEST usr/include/asm-generic/mman-common.h
+00:00:09   HDRTEST usr/include/asm-generic/ipcbuf.h
+00:00:09   HDRTEST usr/include/asm-generic/mman.h
+00:00:09   HDRTEST usr/include/asm-generic/msgbuf.h
+00:00:09   HDRTEST usr/include/asm-generic/param.h
+00:00:09   CC      arch/x86/entry/vsyscall/vsyscall_64.o
+00:00:09   AS      arch/x86/entry/vsyscall/vsyscall_emu_64.o
+00:00:09   AS      arch/x86/entry/entry.o
+00:00:09   CC      arch/x86/events/amd/core.o
+00:00:09   CC      arch/x86/entry/vdso/vma.o
+00:00:09   HDRTEST usr/include/asm-generic/poll.h
+00:00:09   AS      arch/x86/entry/entry_64.o
+00:00:09   HDRTEST usr/include/asm-generic/posix_types.h
+00:00:09   CC      arch/x86/entry/syscall_64.o
+00:00:09   CC      arch/x86/entry/common.o
+00:00:09   HDRTEST usr/include/asm-generic/sembuf.h
+00:00:09   AS      arch/x86/entry/entry_64_compat.o
+00:00:09   CC      kernel/sched/core.o
+00:00:09   HDRTEST usr/include/asm-generic/resource.h
+00:00:09   CC      arch/x86/xen/enlighten.o
+00:00:09   HDRTEST usr/include/asm-generic/setup.h
+00:00:09   CC      arch/x86/entry/vdso/extable.o
+00:00:09   CC      arch/x86/events/amd/ibs.o
+00:00:09   CC      kernel/sched/loadavg.o
+00:00:09   HDRTEST usr/include/asm-generic/shmbuf.h
+00:00:09   HDRTEST usr/include/asm-generic/siginfo.h
+00:00:09   HDRTEST usr/include/asm-generic/signal-defs.h
+00:00:10   HDRTEST usr/include/asm-generic/signal.h
+00:00:10   HDRTEST usr/include/asm-generic/socket.h
+00:00:10   HDRTEST usr/include/asm-generic/sockios.h
+00:00:10   HDRTEST usr/include/asm-generic/stat.h
+00:00:10   HDRTEST usr/include/asm-generic/statfs.h
+00:00:10   CC      arch/x86/events/intel/core.o
+00:00:10   HDRTEST usr/include/asm-generic/swab.h
+00:00:10   HDRTEST usr/include/asm-generic/termbits.h
+00:00:10   HDRTEST usr/include/asm-generic/termios.h
+00:00:10   HDRTEST usr/include/asm-generic/types.h
+00:00:10   HDRTEST usr/include/asm-generic/ucontext.h
+00:00:10   HDRTEST usr/include/asm-generic/unistd.h
+00:00:10   HDRTEST usr/include/drm/armada_drm.h
+00:00:10   CC      kernel/locking/mutex.o
+00:00:10   CC      certs/system_keyring.o
+00:00:10   HDRTEST usr/include/drm/amdgpu_drm.h
+00:00:10   HDRTEST usr/include/drm/drm.h
+00:00:10   HDRTEST usr/include/drm/drm_sarea.h
+00:00:10   HDRTEST usr/include/drm/drm_mode.h
+00:00:10   HDRTEST usr/include/drm/drm_fourcc.h
+00:00:10   CC      arch/x86/events/amd/uncore.o
+00:00:10   HDRTEST usr/include/drm/etnaviv_drm.h
+00:00:10   CC      arch/x86/entry/vdso/vdso32-setup.o
+00:00:10   CC      arch/x86/events/amd/iommu.o
+00:00:10   CC      arch/x86/platform/pvh/enlighten.o
+00:00:10   AR      arch/x86/entry/vsyscall/built-in.a
+00:00:10   HDRTEST usr/include/drm/exynos_drm.h
+00:00:10   LDS     arch/x86/entry/vdso/vdso.lds
+00:00:10   CC      arch/x86/xen/mmu.o
+00:00:10   GEN     usr/initramfs_data.cpio
+00:00:10   HDRTEST usr/include/drm/i810_drm.h
+00:00:10   HDRTEST usr/include/drm/lima_drm.h
+00:00:10   CC      kernel/locking/semaphore.o
+00:00:10   HDRTEST usr/include/drm/i915_drm.h
+00:00:10   CC      kernel/locking/rwsem.o
+00:00:10   CC      kernel/power/qos.o
+00:00:10   EXTRACT_CERTS   
+00:00:10   HDRTEST usr/include/drm/mga_drm.h
+00:00:10 Generating X.509 key generation config
+00:00:10   HDRTEST usr/include/drm/msm_drm.h
+00:00:10   CC      arch/x86/xen/time.o
+00:00:10   AS      arch/x86/entry/vdso/vdso-note.o
+00:00:10   CC      certs/common.o
+00:00:10   HDRTEST usr/include/drm/nouveau_drm.h
+00:00:10   CC      arch/x86/entry/vdso/vclock_gettime.o
+00:00:10   HDRTEST usr/include/drm/omap_drm.h
+00:00:10   HDRTEST usr/include/drm/panfrost_drm.h
+00:00:10   HDRTEST usr/include/drm/qxl_drm.h
+00:00:10   HDRTEST usr/include/drm/r128_drm.h
+00:00:10   AR      init/built-in.a
+00:00:10   CC      certs/blacklist.o
+00:00:11   HDRTEST usr/include/drm/radeon_drm.h
+00:00:11   CC      kernel/sched/clock.o
+00:00:11   CC      kernel/power/main.o
+00:00:11   HDRTEST usr/include/drm/savage_drm.h
+00:00:11   AS      arch/x86/platform/pvh/head.o
+00:00:11   HDRTEST usr/include/drm/sis_drm.h
+00:00:11   CC      mm/kfence/core.o
+00:00:11   AR      arch/x86/platform/pvh/built-in.a
+00:00:11   HDRTEST usr/include/drm/tegra_drm.h
+00:00:11   HDRTEST usr/include/drm/v3d_drm.h
+00:00:11   CC      arch/x86/events/intel/bts.o
+00:00:11   HDRTEST usr/include/drm/vc4_drm.h
+00:00:11   HDRTEST usr/include/drm/vgem_drm.h
+00:00:11   HDRTEST usr/include/drm/via_drm.h
+00:00:11   HDRTEST usr/include/drm/virtgpu_drm.h
+00:00:11   CC      mm/damon/core.o
+00:00:11   CC      arch/x86/events/zhaoxin/core.o
+00:00:11   HDRTEST usr/include/drm/vmwgfx_drm.h
+00:00:11   CC      certs/blacklist_nohashes.o
+00:00:11   HDRTEST usr/include/linux/android/binder.h
+00:00:11   CC      arch/x86/entry/vdso/vgetcpu.o
+00:00:11   CC [M]  arch/x86/events/amd/power.o
+00:00:11   CC      kernel/locking/percpu-rwsem.o
+00:00:11   HDRTEST usr/include/linux/android/binderfs.h
+00:00:11   CC      kernel/sched/cputime.o
+00:00:11   HDRTEST usr/include/linux/byteorder/big_endian.h
+00:00:11   HDRTEST usr/include/linux/byteorder/little_endian.h
+00:00:11 ###
+00:00:11   HDRTEST usr/include/linux/caif/caif_socket.h
+00:00:11 ### Now generating an X.509 key pair to be used for signing modules.
+00:00:11 ###
+00:00:11 ### If this takes a long time, you might wish to run rngd in the
+00:00:11 ### background to keep the supply of entropy topped up.  It
+00:00:11 ### needs to be run as root, and uses a hardware random
+00:00:11 ### number generator if one is available.
+00:00:11 ###
+00:00:11 .......+++++++++++++++++++++++++++++++++++++++++++++*....+...+............+..+...+......+.+..............+.+...+..+.+..............+...+.............+........+......+.+............+++++++++++++++++++++++++++++++++++++++++++++*......+  HDRTEST usr/include/linux/caif/if_caif.h
+00:00:11 ...+............+..+.+.....+....+........................+.....+  HDRTEST usr/include/linux/can/bcm.h
+00:00:11 ....+.....+......+......+.+...+  CC      arch/x86/xen/grant-table.o
+00:00:11 ..+..........+................................+  HDRTEST usr/include/linux/can/error.h
+00:00:11 ...+..................+.......+............+...+..+++  HDRTEST usr/include/linux/can/gw.h
+00:00:11 ++
+00:00:11 .......+..+.+.........+++++++++++++++++++++++++++++++++++++++++++++*...+.....+..........+.....+......+...+............+.+..+...+...+.+......+........+....+..+.+...+..+.......+...+..............+...+...............+.+.....+....+...+..+......+.+++++++++++++++++++++++++++++++++++++++++++++*.............+....+.....+...+..........+.........+  HDRTEST usr/include/linux/can/j1939.h
+00:00:11 .....+.+.........+......+..+...+..........+........+..........  HDRTEST usr/include/linux/can/isotp.h
+00:00:11 +.........+..+.............+........+....+...+............+.....+  HDRTEST usr/include/linux/can/netlink.h
+00:00:11 .+.....  AS      arch/x86/entry/vdso/vsgx.o
+00:00:11 +...+....+  CC      fs/notify/dnotify/dnotify.o
+00:00:11 ..+.............+..+....+  HDRTEST usr/include/linux/can/raw.h
+00:00:11 ............+..+......................+  HOSTCC  arch/x86/entry/vdso/vdso2c
+00:00:11 ...............+.....+.+........  CC      kernel/locking/spinlock.o
+00:00:11 +.........+  HDRTEST usr/include/linux/can/vxcan.h
+00:00:11 ...+...+............+....+...........+.............+...............+..+  HDRTEST usr/include/linux/cifs/cifs_mount.h
+00:00:11 ....+...+........+..........+..............+....+.....+......+  HDRTEST usr/include/linux/cifs/cifs_netlink.h
+00:00:11 ...............+....+.................+....+...+..+........................+.+  HDRTEST usr/include/linux/dvb/ca.h
+00:00:11 .....................+...+.....+.+........+...+..........+.....+  HDRTEST usr/include/linux/dvb/audio.h
+00:00:11 .......+...............................................+...............+......+.......+...........+......+  HDRTEST usr/include/linux/dvb/dmx.h
+00:00:11 ....+............+....................+.......+++++
+00:00:11   HDRTEST usr/include/linux/dvb/frontend.h
+00:00:11   CC      fs/notify/inotify/inotify_fsnotify.o
+00:00:11 -----
+00:00:11 ###
+00:00:11   CC      kernel/power/console.o
+00:00:11 ### Key pair generated.
+00:00:11   HDRTEST usr/include/linux/dvb/net.h
+00:00:11 ###
+00:00:11   EXTRACT_CERTS   certs/signing_key.pem
+00:00:11   AR      arch/x86/events/amd/built-in.a
+00:00:11   AS      certs/system_certificates.o
+00:00:11   AR      arch/x86/events/zhaoxin/built-in.a
+00:00:12   HDRTEST usr/include/linux/dvb/osd.h
+00:00:12   CC      mm/kfence/report.o
+00:00:12   CC      arch/x86/events/core.o
+00:00:12   AR      certs/built-in.a
+00:00:12   HDRTEST usr/include/linux/dvb/version.h
+00:00:12   CC      arch/x86/xen/suspend.o
+00:00:12   HDRTEST usr/include/linux/dvb/video.h
+00:00:12   LDS     arch/x86/entry/vdso/vdso32/vdso32.lds
+00:00:12   CC      kernel/locking/osq_lock.o
+00:00:12   HDRTEST usr/include/linux/genwqe/genwqe_card.h
+00:00:12   AS      arch/x86/entry/vdso/vdso32/note.o
+00:00:12   CC      mm/damon/vaddr.o
+00:00:12   HDRTEST usr/include/linux/hdlc/ioctl.h
+00:00:12   AS      arch/x86/entry/vdso/vdso32/system_call.o
+00:00:12   HDRTEST usr/include/linux/hsi/cs-protocol.h
+00:00:12   SHIPPED usr/initramfs_inc_data
+00:00:12   CC      arch/x86/events/intel/ds.o
+00:00:12   AS      arch/x86/entry/vdso/vdso32/sigreturn.o
+00:00:12   CC      arch/x86/hyperv/hv_init.o
+00:00:12   HDRTEST usr/include/linux/hsi/hsi_char.h
+00:00:12   CC      arch/x86/entry/vdso/vdso32/vclock_gettime.o
+00:00:12   CC      arch/x86/events/probe.o
+00:00:12   CC      kernel/power/process.o
+00:00:12   HDRTEST usr/include/linux/iio/buffer.h
+00:00:12   HDRTEST usr/include/linux/iio/types.h
+00:00:12   HDRTEST usr/include/linux/iio/events.h
+00:00:12   AR      fs/notify/dnotify/built-in.a
+00:00:12   AS      usr/initramfs_data.o
+00:00:12   HDRTEST usr/include/linux/isdn/capicmd.h
+00:00:12   HDRTEST usr/include/linux/misc/bcm_vk.h
+00:00:12   CC      kernel/printk/printk.o
+00:00:12   CC      kernel/locking/qspinlock.o
+00:00:12   CC      fs/notify/inotify/inotify_user.o
+00:00:12   HDRTEST usr/include/linux/mmc/ioctl.h
+00:00:12   HDRTEST usr/include/linux/netfilter/ipset/ip_set_hash.h
+00:00:12   HDRTEST usr/include/linux/netfilter/ipset/ip_set.h
+00:00:12   HDRTEST usr/include/linux/netfilter/ipset/ip_set_bitmap.h
+00:00:12   HDRTEST usr/include/linux/netfilter/ipset/ip_set_list.h
+00:00:12   CC      kernel/sched/idle.o
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_conntrack_common.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_conntrack_ftp.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_conntrack_sctp.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_conntrack_tuple_common.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_conntrack_tcp.h
+00:00:12   CC [M]  mm/kfence/kfence_test.o
+00:00:12   CC      arch/x86/xen/enlighten_hvm.o
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_log.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_nat.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_synproxy.h
+00:00:12   CC      ipc/compat.o
+00:00:12   VDSO    arch/x86/entry/vdso/vdso64.so.dbg
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_tables_compat.h
+00:00:12   HDRTEST usr/include/linux/netfilter/nf_tables.h
+00:00:12   VDSO    arch/x86/entry/vdso/vdso32.so.dbg
+00:00:12   AR      usr/built-in.a
+00:00:12   HDRTEST usr/include/linux/netfilter/nfnetlink.h
+00:00:12   CC      kernel/irq/irqdesc.o
+00:00:12   OBJCOPY arch/x86/entry/vdso/vdso64.so
+00:00:12   OBJCOPY arch/x86/entry/vdso/vdso32.so
+00:00:12   VDSO2C  arch/x86/entry/vdso/vdso-image-64.c
+00:00:12   HDRTEST usr/include/linux/netfilter/nfnetlink_acct.h
+00:00:12   VDSO2C  arch/x86/entry/vdso/vdso-image-32.c
+00:00:12   CC      arch/x86/entry/vdso/vdso-image-64.o
+00:00:12   HDRTEST usr/include/linux/netfilter/nfnetlink_conntrack.h
+00:00:12   AR      mm/damon/built-in.a
+00:00:12   HDRTEST usr/include/linux/netfilter/nfnetlink_cthelper.h
+00:00:12   CC      fs/crypto/crypto.o
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_compat.h
+00:00:13   CC      kernel/locking/rtmutex_api.o
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_cttimeout.h
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_hook.h
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_log.h
+00:00:13   CC      arch/x86/entry/vdso/vdso-image-32.o
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_osf.h
+00:00:13   CC      arch/x86/hyperv/mmu.o
+00:00:13   CC      kernel/power/suspend.o
+00:00:13   HDRTEST usr/include/linux/netfilter/nfnetlink_queue.h
+00:00:13   HDRTEST usr/include/linux/netfilter/x_tables.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_AUDIT.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_CHECKSUM.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_CLASSIFY.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_CONNMARK.h
+00:00:13   AR      arch/x86/entry/vdso/built-in.a
+00:00:13   CC      arch/x86/entry/syscall_32.o
+00:00:13   AR      fs/notify/inotify/built-in.a
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_CONNSECMARK.h
+00:00:13   CC      fs/notify/fanotify/fanotify.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_CT.h
+00:00:13   CC      ipc/util.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_DSCP.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_IDLETIMER.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_HMARK.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_LED.h
+00:00:13   CC      kernel/irq/handle.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_LOG.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_MARK.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_NFLOG.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_NFQUEUE.h
+00:00:13   CC      arch/x86/events/intel/knc.o
+00:00:13   CC      arch/x86/xen/mmu_hvm.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_RATEEST.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_SECMARK.h
+00:00:13   CC      arch/x86/realmode/init.o
+00:00:13   AR      mm/kfence/built-in.a
+00:00:13   CC      ipc/msgutil.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_SYNPROXY.h
+00:00:13   CC      kernel/locking/qrwlock.o
+00:00:13   CC      mm/filemap.o
+00:00:13   CC      fs/crypto/fname.o
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_TCPOPTSTRIP.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_TCPMSS.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_TEE.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_TPROXY.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_addrtype.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_bpf.h
+00:00:13   HDRTEST usr/include/linux/netfilter/xt_cgroup.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_cluster.h
+00:00:14   CC      kernel/irq/manage.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_comment.h
+00:00:14   CC [M]  kernel/locking/locktorture.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_connbytes.h
+00:00:14   CC      kernel/printk/printk_safe.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_connlabel.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_connlimit.h
+00:00:14   CC      kernel/power/suspend_test.o
+00:00:14   AR      arch/x86/entry/built-in.a
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_conntrack.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_connmark.h
+00:00:14   CC      arch/x86/hyperv/nested.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_dccp.h
+00:00:14   AS      arch/x86/realmode/rm/header.o
+00:00:14   CC      kernel/rcu/update.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_cpu.h
+00:00:14   CC      arch/x86/xen/suspend_hvm.o
+00:00:14   AS      arch/x86/realmode/rm/trampoline_64.o
+00:00:14   CC      ipc/msg.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_devgroup.h
+00:00:14   CC      security/keys/trusted-keys/trusted_core.o
+00:00:14   CC      arch/x86/events/intel/lbr.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_ecn.h
+00:00:14   AS      arch/x86/realmode/rm/stack.o
+00:00:14   CC      fs/notify/fanotify/fanotify_user.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_dscp.h
+00:00:14   AS      arch/x86/realmode/rm/reboot.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_esp.h
+00:00:14   AS      arch/x86/realmode/rm/wakeup_asm.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_ipcomp.h
+00:00:14   CC      arch/x86/realmode/rm/wakemain.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_hashlimit.h
+00:00:14 In file included from ./include/uapi/linux/posix_types.h:5,
+00:00:14                  from ./include/uapi/linux/types.h:14,
+00:00:14                  from ./include/linux/types.h:6,
+00:00:14                  from arch/x86/realmode/rm/wakeup.h:11,
+00:00:14                  from arch/x86/realmode/rm/wakemain.c:2:
+00:00:14 ./include/linux/stddef.h:11:9: error: cannot use keyword ‘false’ as enumeration constant
+00:00:14    11 |         false   = 0,
+00:00:14       |         ^~~~~
+00:00:14 ./include/linux/stddef.h:11:9: note: ‘false’ is a keyword with ‘-std=c23’ onwards
+00:00:14 ./include/linux/types.h:30:33: error: ‘bool’ cannot be defined via ‘typedef’
+00:00:14    30 | typedef _Bool                   bool;
+00:00:14       |                                 ^~~~
+00:00:14 ./include/linux/types.h:30:33: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
+00:00:14 ./include/linux/types.h:30:1: warning: useless type name in empty declaration
+00:00:14    30 | typedef _Bool                   bool;
+00:00:14       | ^~~~~~~
+00:00:14 make[5]: *** [scripts/Makefile.build:289: arch/x86/realmode/rm/wakemain.o] Error 1
+00:00:14 make[4]: *** [arch/x86/realmode/Makefile:22: arch/x86/realmode/rm/realmode.bin] Error 2
+00:00:14 make[3]: *** [scripts/Makefile.build:552: arch/x86/realmode] Error 2
+00:00:14 make[3]: *** Waiting for unfinished jobs....
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_helper.h
+00:00:14   CC      security/keys/encrypted-keys/encrypted.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_iprange.h
+00:00:14   CC      fs/crypto/hkdf.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_ipvs.h
+00:00:14   CC      kernel/printk/braille.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_l2tp.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_length.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_limit.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_mark.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_mac.h
+00:00:14   AR      kernel/locking/built-in.a
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_nfacct.h
+00:00:14   CC      fs/notify/fsnotify.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_multiport.h
+00:00:14   CC      arch/x86/hyperv/irqdomain.o
+00:00:14   CC      kernel/printk/printk_ringbuffer.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_osf.h
+00:00:14   CC      arch/x86/xen/platform-pci-unplug.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_owner.h
+00:00:14   CC      kernel/power/hibernate.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_pkttype.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_physdev.h
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_quota.h
+00:00:14   CC      security/keys/trusted-keys/trusted_tpm1.o
+00:00:14   HDRTEST usr/include/linux/netfilter/xt_policy.h
+00:00:14   CC      kernel/sched/fair.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_rateest.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_realm.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_recent.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_rpfilter.h
+00:00:15   CC      kernel/irq/spurious.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_sctp.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_set.h
+00:00:15   CC      fs/crypto/hooks.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_socket.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_state.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_statistic.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_string.h
+00:00:15   CC      ipc/sem.o
+00:00:15   CC      arch/x86/xen/setup.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_tcpmss.h
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_tcpudp.h
+00:00:15   CC      security/keys/encrypted-keys/ecryptfs_format.o
+00:00:15   CC      arch/x86/events/intel/p4.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_time.h
+00:00:15   CC      kernel/printk/index.o
+00:00:15   HDRTEST usr/include/linux/netfilter/xt_u32.h
+00:00:15   HDRTEST usr/include/linux/netfilter_arp/arp_tables.h
+00:00:15   CC      security/keys/encrypted-keys/masterkey_trusted.o
+00:00:15   CC      arch/x86/hyperv/hv_apic.o
+00:00:15   HDRTEST usr/include/linux/netfilter_arp/arpt_mangle.h
+00:00:15   CC      ipc/shm.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_802_3.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_arp.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_among.h
+00:00:15   CC      kernel/irq/resend.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_arpreply.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_ip.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_ip6.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_limit.h
+00:00:15   AR      fs/notify/fanotify/built-in.a
+00:00:15   CC      fs/notify/notification.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_log.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_nat.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_mark_m.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_mark_t.h
+00:00:15   AR      kernel/printk/built-in.a
+00:00:15   CC      kernel/sched/rt.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_nflog.h
+00:00:15   ASN.1   security/keys/trusted-keys/tpm2key.asn1.[ch]
+00:00:15   CC      fs/crypto/keyring.o
+00:00:15   CC      security/keys/trusted-keys/trusted_tpm2.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_pkttype.h
+00:00:15   CC      kernel/power/snapshot.o
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_redirect.h
+00:00:15   HDRTEST usr/include/linux/netfilter_bridge/ebt_stp.h
+00:00:16   AR      security/keys/encrypted-keys/built-in.a
+00:00:16   HDRTEST usr/include/linux/netfilter_bridge/ebt_vlan.h
+00:00:16   HDRTEST usr/include/linux/netfilter_bridge/ebtables.h
+00:00:16   CC      fs/verity/enable.o
+00:00:16   CC      kernel/irq/chip.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ip_tables.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_CLUSTERIP.h
+00:00:16   CC      kernel/rcu/sync.o
+00:00:16   CC      arch/x86/hyperv/hv_proc.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_ECN.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_LOG.h
+00:00:16   CC      arch/x86/events/intel/p6.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_REJECT.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_TTL.h
+00:00:16   CC      fs/notify/group.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_ah.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_ecn.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv4/ipt_ttl.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6_tables.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_HL.h
+00:00:16   CC      kernel/rcu/srcutree.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_LOG.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_NPT.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_ah.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_REJECT.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_frag.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_hl.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_mh.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_ipv6header.h
+00:00:16   CC      mm/mempool.o
+00:00:16   CC      security/keys/trusted-keys/tpm2key.asn1.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_opts.h
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_rt.h
+00:00:16   AR      security/keys/trusted-keys/built-in.a
+00:00:16   CC      arch/x86/events/utils.o
+00:00:16   CC      security/keys/gc.o
+00:00:16   HDRTEST usr/include/linux/netfilter_ipv6/ip6t_srh.h
+00:00:16   CC      fs/crypto/keysetup.o
+00:00:16   HDRTEST usr/include/linux/nfsd/cld.h
+00:00:16   CC      arch/x86/events/intel/pt.o
+00:00:16   CC      arch/x86/hyperv/hv_spinlock.o
+00:00:16   HDRTEST usr/include/linux/nfsd/debug.h
+00:00:16   CC      fs/verity/hash_algs.o
+00:00:16   HDRTEST usr/include/linux/nfsd/export.h
+00:00:16   CC      kernel/irq/dummychip.o
+00:00:16   HDRTEST usr/include/linux/nfsd/stats.h
+00:00:16   HDRTEST usr/include/linux/raid/md_p.h
+00:00:16   CC      ipc/syscall.o
+00:00:17   HDRTEST usr/include/linux/raid/md_u.h
+00:00:17   HDRTEST usr/include/linux/sched/types.h
+00:00:17   CC      fs/notify/mark.o
+00:00:17   HDRTEST usr/include/linux/spi/spi.h
+00:00:17   HDRTEST usr/include/linux/spi/spidev.h
+00:00:17   HDRTEST usr/include/linux/sunrpc/debug.h
+00:00:17   HDRTEST usr/include/linux/surface_aggregator/dtx.h
+00:00:17   HDRTEST usr/include/linux/surface_aggregator/cdev.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_bpf.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_connmark.h
+00:00:17   AR      arch/x86/hyperv/built-in.a
+00:00:17   CC      kernel/irq/devres.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_csum.h
+00:00:17   CC      kernel/rcu/tree.o
+00:00:17   GEN     security/selinux/flask.h security/selinux/av_permissions.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_ct.h
+00:00:17   CC      security/selinux/avc.o
+00:00:17   CC      kernel/power/swap.o
+00:00:17   CC      security/keys/key.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_ctinfo.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_defact.h
+00:00:17   CC      arch/x86/xen/apic.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_gact.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_gate.h
+00:00:17   CC      fs/verity/init.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_ife.h
+00:00:17   CC      mm/oom_kill.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_ipt.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_mirred.h
+00:00:17   CC      ipc/ipc_sysctl.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_mpls.h
+00:00:17   CC      arch/x86/xen/pmu.o
+00:00:17   CC      fs/crypto/keysetup_v1.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_nat.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_skbedit.h
+00:00:17   CC      kernel/irq/autoprobe.o
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_pedit.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_sample.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_skbmod.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_tunnel_key.h
+00:00:17   HDRTEST usr/include/linux/tc_act/tc_vlan.h
+00:00:17   CC      fs/notify/fdinfo.o
+00:00:17   HDRTEST usr/include/linux/tc_ematch/tc_em_cmp.h
+00:00:17   CC      fs/verity/measure.o
+00:00:17   HDRTEST usr/include/linux/tc_ematch/tc_em_ipt.h
+00:00:17   HDRTEST usr/include/linux/tc_ematch/tc_em_meta.h
+00:00:17   HDRTEST usr/include/linux/tc_ematch/tc_em_text.h
+00:00:18   HDRTEST usr/include/linux/tc_ematch/tc_em_nbyte.h
+00:00:18   CC [M]  arch/x86/events/intel/uncore.o
+00:00:18   CC      ipc/mqueue.o
+00:00:18   CC      kernel/livepatch/core.o
+00:00:18   HDRTEST usr/include/linux/usb/cdc-wdm.h
+00:00:18   HDRTEST usr/include/linux/usb/cdc.h
+00:00:18   HDRTEST usr/include/linux/usb/audio.h
+00:00:18   CC      kernel/irq/irqdomain.o
+00:00:18   HDRTEST usr/include/linux/usb/ch9.h
+00:00:18   HDRTEST usr/include/linux/usb/ch11.h
+00:00:18   HDRTEST usr/include/linux/usb/charger.h
+00:00:18   CC      security/keys/keyring.o
+00:00:18   HDRTEST usr/include/linux/usb/g_printer.h
+00:00:18   HDRTEST usr/include/linux/usb/functionfs.h
+00:00:18   CC      fs/verity/open.o
+00:00:18   HDRTEST usr/include/linux/usb/g_uvc.h
+00:00:18   CC      fs/crypto/policy.o
+00:00:18   HDRTEST usr/include/linux/usb/gadgetfs.h
+00:00:18   HDRTEST usr/include/linux/usb/midi.h
+00:00:18   AR      fs/notify/built-in.a
+00:00:18   HDRTEST usr/include/linux/usb/raw_gadget.h
+00:00:18   HDRTEST usr/include/linux/usb/tmc.h
+00:00:18   HDRTEST usr/include/linux/usb/video.h
+00:00:18   CC      kernel/dma/mapping.o
+00:00:18   HDRTEST usr/include/linux/a.out.h
+00:00:18   HDRTEST usr/include/linux/acct.h
+00:00:18   CC      kernel/power/user.o
+00:00:18   HDRTEST usr/include/linux/adb.h
+00:00:18   CC      crypto/asymmetric_keys/asymmetric_type.o
+00:00:18   HDRTEST usr/include/linux/acrn.h
+00:00:18   HDRTEST usr/include/linux/adfs_fs.h
+00:00:18   HDRTEST usr/include/linux/affs_hardblocks.h
+00:00:18   HDRTEST usr/include/linux/agpgart.h
+00:00:18   HDRTEST usr/include/linux/aio_abi.h
+00:00:18   CC      fs/verity/read_metadata.o
+00:00:18   HDRTEST usr/include/linux/am437x-vpfe.h
+00:00:18   HDRTEST usr/include/linux/apm_bios.h
+00:00:18   CC      security/selinux/hooks.o
+00:00:18   HDRTEST usr/include/linux/arcfb.h
+00:00:18   HDRTEST usr/include/linux/arm_sdei.h
+00:00:18   CC      kernel/livepatch/patch.o
+00:00:18   HDRTEST usr/include/linux/aspeed-lpc-ctrl.h
+00:00:18   HDRTEST usr/include/linux/aspeed-p2a-ctrl.h
+00:00:18   HDRTEST usr/include/linux/atalk.h
+00:00:19   CC      mm/fadvise.o
+00:00:19   HDRTEST usr/include/linux/atm.h
+00:00:19   HDRTEST usr/include/linux/atm_eni.h
+00:00:19   HDRTEST usr/include/linux/atm_he.h
+00:00:19   CC      kernel/irq/proc.o
+00:00:19   HDRTEST usr/include/linux/atm_idt77105.h
+00:00:19   CC      fs/crypto/bio.o
+00:00:19   HDRTEST usr/include/linux/atm_nicstar.h
+00:00:19   HDRTEST usr/include/linux/atm_tcp.h
+00:00:19   CC      crypto/asymmetric_keys/restrict.o
+00:00:19   HDRTEST usr/include/linux/atm_zatm.h
+00:00:19   HDRTEST usr/include/linux/atmapi.h
+00:00:19   CC      security/keys/keyctl.o
+00:00:19   HDRTEST usr/include/linux/atmarp.h
+00:00:19   HDRTEST usr/include/linux/atmbr2684.h
+00:00:19   CC [M]  arch/x86/events/intel/uncore_nhmex.o
+00:00:19   CC      kernel/dma/direct.o
+00:00:19   HDRTEST usr/include/linux/atmclip.h
+00:00:19   CC      kernel/power/poweroff.o
+00:00:19   HDRTEST usr/include/linux/atmdev.h
+00:00:19   HDRTEST usr/include/linux/atmioc.h
+00:00:19   HDRTEST usr/include/linux/atmlec.h
+00:00:19   HDRTEST usr/include/linux/atmmpc.h
+00:00:19   HDRTEST usr/include/linux/atmppp.h
+00:00:19   CC      kernel/livepatch/shadow.o
+00:00:19   CC      fs/verity/verify.o
+00:00:19   HDRTEST usr/include/linux/atmsap.h
+00:00:19   CC      crypto/asymmetric_keys/signature.o
+00:00:19   HDRTEST usr/include/linux/atmsvc.h
+00:00:19   CC      kernel/power/energy_model.o
+00:00:19   HDRTEST usr/include/linux/auto_dev-ioctl.h
+00:00:19   CC      ipc/namespace.o
+00:00:19   HDRTEST usr/include/linux/audit.h
+00:00:19   CC      kernel/irq/migration.o
+00:00:19   HDRTEST usr/include/linux/auxvec.h
+00:00:19   HDRTEST usr/include/linux/auto_fs.h
+00:00:19   HDRTEST usr/include/linux/auto_fs4.h
+00:00:19   CC      kernel/sched/deadline.o
+00:00:19   HDRTEST usr/include/linux/ax25.h
+00:00:19   CC      mm/maccess.o
+00:00:19   HDRTEST usr/include/linux/batadv_packet.h
+00:00:19   HDRTEST usr/include/linux/batman_adv.h
+00:00:19   CC      fs/crypto/inline_crypt.o
+00:00:19   HDRTEST usr/include/linux/baycom.h
+00:00:19   HDRTEST usr/include/linux/bcache.h
+00:00:19   HDRTEST usr/include/linux/bcm933xx_hcs.h
+00:00:19   CC      crypto/asymmetric_keys/public_key.o
+00:00:19   HDRTEST usr/include/linux/bfs_fs.h
+00:00:20   HDRTEST usr/include/linux/binfmts.h
+00:00:20   HDRTEST usr/include/linux/blkpg.h
+00:00:20   CC      kernel/irq/cpuhotplug.o
+00:00:20   HDRTEST usr/include/linux/blktrace_api.h
+00:00:20   CC      ipc/mq_sysctl.o
+00:00:20   CC      kernel/livepatch/state.o
+00:00:20   HDRTEST usr/include/linux/blkzoned.h
+00:00:20   AR      kernel/power/built-in.a
+00:00:20   HDRTEST usr/include/linux/bpf_common.h
+00:00:20   ASN.1   crypto/asymmetric_keys/x509.asn1.[ch]
+00:00:20   HDRTEST usr/include/linux/bpf_perf_event.h
+00:00:20   CC      kernel/dma/ops_helpers.o
+00:00:20   HDRTEST usr/include/linux/bpf.h
+00:00:20   CC [M]  crypto/async_tx/async_tx.o
+00:00:20   HDRTEST usr/include/linux/bpfilter.h
+00:00:20   AR      fs/verity/built-in.a
+00:00:20   CC      security/selinux/selinuxfs.o
+00:00:20   HDRTEST usr/include/linux/bpqether.h
+00:00:20   CC [M]  arch/x86/events/intel/uncore_snb.o
+00:00:20   HDRTEST usr/include/linux/bt-bmc.h
+00:00:20   CC      mm/page-writeback.o
+00:00:20   CC      security/keys/permission.o
+00:00:20   HDRTEST usr/include/linux/bsg.h
+00:00:20   HDRTEST usr/include/linux/btf.h
+00:00:20   HDRTEST usr/include/linux/btrfs.h
+00:00:20   AR      ipc/built-in.a
+00:00:20   CC [M]  crypto/async_tx/async_memcpy.o
+00:00:20   HDRTEST usr/include/linux/btrfs_tree.h
+00:00:20   HDRTEST usr/include/linux/can.h
+00:00:20   CC      kernel/irq/pm.o
+00:00:20   HDRTEST usr/include/linux/capability.h
+00:00:20   HDRTEST usr/include/linux/capi.h
+00:00:20   HDRTEST usr/include/linux/cciss_defs.h
+00:00:20   AR      fs/crypto/built-in.a
+00:00:20   ASN.1   crypto/asymmetric_keys/x509_akid.asn1.[ch]
+00:00:20   HDRTEST usr/include/linux/cciss_ioctl.h
+00:00:20   CC      crypto/asymmetric_keys/x509_public_key.o
+00:00:20   CC      kernel/livepatch/transition.o
+00:00:20   CC      fs/nfs_common/nfs_ssc.o
+00:00:20   HDRTEST usr/include/linux/ccs.h
+00:00:20   CC      kernel/dma/dummy.o
+00:00:20   HDRTEST usr/include/linux/cfm_bridge.h
+00:00:20   HDRTEST usr/include/linux/cdrom.h
+00:00:20   HDRTEST usr/include/linux/cec-funcs.h
+00:00:20   CC      fs/iomap/trace.o
+00:00:20   HDRTEST usr/include/linux/cgroupstats.h
+00:00:20   CC      security/keys/process_keys.o
+00:00:20   HDRTEST usr/include/linux/cec.h
+00:00:20   HDRTEST usr/include/linux/chio.h
+00:00:20   CC      kernel/rcu/rcu_segcblist.o
+00:00:20   HDRTEST usr/include/linux/close_range.h
+00:00:20   HDRTEST usr/include/linux/cm4000_cs.h
+00:00:20   HDRTEST usr/include/linux/cn_proc.h
+00:00:20   CC [M]  crypto/async_tx/async_xor.o
+00:00:20   HDRTEST usr/include/linux/coff.h
+00:00:21   HDRTEST usr/include/linux/coda.h
+00:00:21   HDRTEST usr/include/linux/const.h
+00:00:21   CC [M]  arch/x86/events/intel/uncore_snbep.o
+00:00:21   ASN.1   crypto/asymmetric_keys/pkcs7.asn1.[ch]
+00:00:21   CC      crypto/asymmetric_keys/pkcs7_trust.o
+00:00:21   HDRTEST usr/include/linux/connector.h
+00:00:21   HDRTEST usr/include/linux/coresight-stm.h
+00:00:21   CC      kernel/dma/contiguous.o
+00:00:21   HDRTEST usr/include/linux/cramfs_fs.h
+00:00:21   HDRTEST usr/include/linux/cryptouser.h
+00:00:21   HDRTEST usr/include/linux/cuda.h
+00:00:21   CC      kernel/irq/msi.o
+00:00:21   HDRTEST usr/include/linux/cxl_mem.h
+00:00:21   HDRTEST usr/include/linux/cyclades.h
+00:00:21   HDRTEST usr/include/linux/cycx_cfm.h
+00:00:21   HDRTEST usr/include/linux/dccp.h
+00:00:21   CC [M]  kernel/rcu/rcutorture.o
+00:00:21   HDRTEST usr/include/linux/dcbnl.h
+00:00:21   CC      crypto/asymmetric_keys/pkcs7_verify.o
+00:00:21   HDRTEST usr/include/linux/devlink.h
+00:00:21   HDRTEST usr/include/linux/dlm_device.h
+00:00:21   HDRTEST usr/include/linux/dlm.h
+00:00:21   HDRTEST usr/include/linux/dlm_netlink.h
+00:00:21   HDRTEST usr/include/linux/dlm_plock.h
+00:00:21   CC [M]  fs/nfs_common/nfsacl.o
+00:00:21   HDRTEST usr/include/linux/dlmconstants.h
+00:00:21   HDRTEST usr/include/linux/dm-ioctl.h
+00:00:21   CC [M]  crypto/async_tx/async_pq.o
+00:00:21   CC      security/keys/request_key.o
+00:00:21   CC      fs/iomap/buffered-io.o
+00:00:21   HDRTEST usr/include/linux/dm-log-userspace.h
+00:00:21   CC      kernel/dma/swiotlb.o
+00:00:21   HDRTEST usr/include/linux/dma-heap.h
+00:00:21   HDRTEST usr/include/linux/dma-buf.h
+00:00:21   HDRTEST usr/include/linux/dns_resolver.h
+00:00:21   HDRTEST usr/include/linux/dqblk_xfs.h
+00:00:21   CC      crypto/asymmetric_keys/verify_pefile.o
+00:00:21   HDRTEST usr/include/linux/edd.h
+00:00:21   AR      kernel/livepatch/built-in.a
+00:00:21   HDRTEST usr/include/linux/efs_fs_sb.h
+00:00:21   CC      kernel/sched/wait.o
+00:00:21   AR      kernel/rcu/built-in.a
+00:00:21   CC      kernel/sched/wait_bit.o
+00:00:21   HDRTEST usr/include/linux/elf-em.h
+00:00:21   CC      arch/x86/xen/suspend_pv.o
+00:00:21   HDRTEST usr/include/linux/elf-fdpic.h
+00:00:21   HDRTEST usr/include/linux/errqueue.h
+00:00:21   HDRTEST usr/include/linux/errno.h
+00:00:22   HDRTEST usr/include/linux/elf.h
+00:00:22   CC      kernel/irq/affinity.o
+00:00:22   HDRTEST usr/include/linux/erspan.h
+00:00:22   HDRTEST usr/include/linux/ethtool.h
+00:00:22   CC      mm/readahead.o
+00:00:22   HDRTEST usr/include/linux/ethtool_netlink.h
+00:00:22   HDRTEST usr/include/linux/eventpoll.h
+00:00:22   HDRTEST usr/include/linux/f2fs.h
+00:00:22   CC [M]  fs/nfs_common/grace.o
+00:00:22   CC      security/selinux/netlink.o
+00:00:22   HDRTEST usr/include/linux/fadvise.h
+00:00:22   ASN.1   crypto/asymmetric_keys/mscode.asn1.[ch]
+00:00:22   HDRTEST usr/include/linux/falloc.h
+00:00:22   ASN.1   crypto/asymmetric_keys/pkcs8.asn1.[ch]
+00:00:22   CC      crypto/asymmetric_keys/x509.asn1.o
+00:00:22   HDRTEST usr/include/linux/fanotify.h
+00:00:22   HDRTEST usr/include/linux/fb.h
+00:00:22   CC      crypto/asymmetric_keys/x509_akid.asn1.o
+00:00:22   HDRTEST usr/include/linux/fcntl.h
+00:00:22   HDRTEST usr/include/linux/fd.h
+00:00:22   CC      crypto/asymmetric_keys/x509_cert_parser.o
+00:00:22   CC      security/keys/request_key_auth.o
+00:00:22   HDRTEST usr/include/linux/fdreg.h
+00:00:22   CC [M]  crypto/async_tx/async_raid6_recov.o
+00:00:22   HDRTEST usr/include/linux/fib_rules.h
+00:00:22   HDRTEST usr/include/linux/fiemap.h
+00:00:22   HDRTEST usr/include/linux/filter.h
+00:00:22   HDRTEST usr/include/linux/firewire-cdev.h
+00:00:22   CC      kernel/irq/matrix.o
+00:00:22   CC      kernel/sched/swait.o
+00:00:22   HDRTEST usr/include/linux/fou.h
+00:00:22   HDRTEST usr/include/linux/firewire-constants.h
+00:00:22   HDRTEST usr/include/linux/fpga-dfl.h
+00:00:22   CC      kernel/dma/pool.o
+00:00:22   HDRTEST usr/include/linux/fs.h
+00:00:22   HDRTEST usr/include/linux/fscrypt.h
+00:00:22   HDRTEST usr/include/linux/fsi.h
+00:00:22   CC [M]  arch/x86/events/intel/uncore_discovery.o
+00:00:22   HDRTEST usr/include/linux/fsl_hypervisor.h
+00:00:22   LD [M]  fs/nfs_common/nfs_acl.o
+00:00:22   HDRTEST usr/include/linux/fsl_mc.h
+00:00:22   CC      security/selinux/nlmsgtab.o
+00:00:22   AR      fs/nfs_common/built-in.a
+00:00:22   HDRTEST usr/include/linux/fsmap.h
+00:00:22   HDRTEST usr/include/linux/fsverity.h
+00:00:22   CC      crypto/asymmetric_keys/pkcs7.asn1.o
+00:00:22   HDRTEST usr/include/linux/fuse.h
+00:00:22   HDRTEST usr/include/linux/futex.h
+00:00:22   CC      security/keys/user_defined.o
+00:00:22   CC      block/partitions/core.o
+00:00:22   CC      crypto/asymmetric_keys/pkcs7_parser.o
+00:00:22   CC      crypto/api.o
+00:00:22   HDRTEST usr/include/linux/gameport.h
+00:00:23   HDRTEST usr/include/linux/gen_stats.h
+00:00:23   CC      arch/x86/xen/p2m.o
+00:00:23   HDRTEST usr/include/linux/genetlink.h
+00:00:23   CC      mm/swap.o
+00:00:23   HDRTEST usr/include/linux/gfs2_ondisk.h
+00:00:23   CC      crypto/cipher.o
+00:00:23   HDRTEST usr/include/linux/gpio.h
+00:00:23   CC      fs/iomap/direct-io.o
+00:00:23   HDRTEST usr/include/linux/gsmmux.h
+00:00:23   HDRTEST usr/include/linux/gtp.h
+00:00:23   HDRTEST usr/include/linux/hash_info.h
+00:00:23   AR      kernel/dma/built-in.a
+00:00:23   HDRTEST usr/include/linux/hdlc.h
+00:00:23   CC      block/partitions/aix.o
+00:00:23   HDRTEST usr/include/linux/hdlcdrv.h
+00:00:23   CC [M]  crypto/async_tx/raid6test.o
+00:00:23   HDRTEST usr/include/linux/hdreg.h
+00:00:23   HDRTEST usr/include/linux/hid.h
+00:00:23   HDRTEST usr/include/linux/hiddev.h
+00:00:23   HDRTEST usr/include/linux/hidraw.h
+00:00:23   CC      crypto/asymmetric_keys/mscode_parser.o
+00:00:23   HDRTEST usr/include/linux/hpet.h
+00:00:23   HDRTEST usr/include/linux/hsr_netlink.h
+00:00:23   CC      security/keys/compat.o
+00:00:23   HDRTEST usr/include/linux/hw_breakpoint.h
+00:00:23   CC      fs/quota/dquot.o
+00:00:23   HDRTEST usr/include/linux/hyperv.h
+00:00:23   HDRTEST usr/include/linux/i2c-dev.h
+00:00:23   AR      kernel/irq/built-in.a
+00:00:23   HDRTEST usr/include/linux/i2c.h
+00:00:23   CC [M]  arch/x86/events/intel/cstate.o
+00:00:23   HDRTEST usr/include/linux/i2o-dev.h
+00:00:23   HDRTEST usr/include/linux/i8k.h
+00:00:23   CC      fs/proc/task_mmu.o
+00:00:23   CC      kernel/sched/completion.o
+00:00:23   CC      io_uring/io_uring.o
+00:00:23   HDRTEST usr/include/linux/idxd.h
+00:00:23   HDRTEST usr/include/linux/icmp.h
+00:00:23   CC      crypto/asymmetric_keys/mscode.asn1.o
+00:00:23   CC      security/selinux/netif.o
+00:00:23   HDRTEST usr/include/linux/icmpv6.h
+00:00:23   HDRTEST usr/include/linux/if_addr.h
+00:00:23   CC [M]  crypto/asymmetric_keys/pkcs8.asn1.o
+00:00:23   CC      arch/x86/events/msr.o
+00:00:23   HDRTEST usr/include/linux/if.h
+00:00:23   CC [M]  crypto/asymmetric_keys/pkcs8_parser.o
+00:00:23   HDRTEST usr/include/linux/if_addrlabel.h
+00:00:23   HDRTEST usr/include/linux/if_alg.h
+00:00:23   HDRTEST usr/include/linux/if_arcnet.h
+00:00:23   HDRTEST usr/include/linux/if_arp.h
+00:00:23   CC      block/partitions/mac.o
+00:00:24   HDRTEST usr/include/linux/if_bridge.h
+00:00:24   CC      block/bdev.o
+00:00:24   HDRTEST usr/include/linux/if_bonding.h
+00:00:24   CC      fs/iomap/fiemap.o
+00:00:24   HDRTEST usr/include/linux/if_cablemodem.h
+00:00:24   CC      security/keys/compat_dh.o
+00:00:24   HDRTEST usr/include/linux/if_eql.h
+00:00:24   CC      kernel/entry/common.o
+00:00:24   HDRTEST usr/include/linux/if_ether.h
+00:00:24   HDRTEST usr/include/linux/if_fc.h
+00:00:24   HDRTEST usr/include/linux/if_fddi.h
+00:00:24   HDRTEST usr/include/linux/if_hippi.h
+00:00:24   HDRTEST usr/include/linux/if_infiniband.h
+00:00:24   LD [M]  arch/x86/events/intel/intel-uncore.o
+00:00:24   AR      crypto/asymmetric_keys/built-in.a
+00:00:24   LD [M]  arch/x86/events/intel/intel-cstate.o
+00:00:24   LD [M]  crypto/asymmetric_keys/pkcs8_key_parser.o
+00:00:24   HDRTEST usr/include/linux/if_link.h
+00:00:24   AR      arch/x86/events/intel/built-in.a
+00:00:24   CC      crypto/compress.o
+00:00:24   CC      fs/quota/quota_v2.o
+00:00:24   HDRTEST usr/include/linux/if_ltalk.h
+00:00:24   HDRTEST usr/include/linux/if_packet.h
+00:00:24   HDRTEST usr/include/linux/if_macsec.h
+00:00:24   CC [M]  arch/x86/events/rapl.o
+00:00:24   HDRTEST usr/include/linux/if_phonet.h
+00:00:24   HDRTEST usr/include/linux/if_plip.h
+00:00:24   HDRTEST usr/include/linux/if_ppp.h
+00:00:24   HDRTEST usr/include/linux/if_pppol2tp.h
+00:00:24   HDRTEST usr/include/linux/if_slip.h
+00:00:24   CC      security/keys/proc.o
+00:00:24   HDRTEST usr/include/linux/if_team.h
+00:00:24   HDRTEST usr/include/linux/if_pppox.h
+00:00:24   CC      block/partitions/ldm.o
+00:00:24   HDRTEST usr/include/linux/if_tun.h
+00:00:24   CC      mm/truncate.o
+00:00:24   CC      crypto/fips.o
+00:00:24   HDRTEST usr/include/linux/if_tunnel.h
+00:00:24   CC      fs/iomap/iter.o
+00:00:24   HDRTEST usr/include/linux/if_vlan.h
+00:00:24   CC      kernel/sched/cpupri.o
+00:00:24   HDRTEST usr/include/linux/if_x25.h
+00:00:24   HDRTEST usr/include/linux/ife.h
+00:00:24   HDRTEST usr/include/linux/igmp.h
+00:00:24   CC      arch/x86/xen/enlighten_pv.o
+00:00:24   HDRTEST usr/include/linux/if_xdp.h
+00:00:24   CC      security/selinux/netnode.o
+00:00:24   HDRTEST usr/include/linux/ila.h
+00:00:24   HDRTEST usr/include/linux/in.h
+00:00:24   HDRTEST usr/include/linux/in6.h
+00:00:25   CC      crypto/algapi.o
+00:00:25   HDRTEST usr/include/linux/in_route.h
+00:00:25   CC      kernel/time/time.o
+00:00:25   HDRTEST usr/include/linux/inet_diag.h
+00:00:25   CC      kernel/entry/syscall_user_dispatch.o
+00:00:25   HDRTEST usr/include/linux/inotify.h
+00:00:25   HDRTEST usr/include/linux/input-event-codes.h
+00:00:25   HDRTEST usr/include/linux/io_uring.h
+00:00:25   CC      security/keys/sysctl.o
+00:00:25   HDRTEST usr/include/linux/input.h
+00:00:25   AR      arch/x86/events/built-in.a
+00:00:25   HDRTEST usr/include/linux/ioam6_genl.h
+00:00:25   CC      kernel/time/timer.o
+00:00:25   HDRTEST usr/include/linux/ioam6_iptunnel.h
+00:00:25   HDRTEST usr/include/linux/ioam6.h
+00:00:25   CC      fs/proc/inode.o
+00:00:25   HDRTEST usr/include/linux/ioctl.h
+00:00:25   HDRTEST usr/include/linux/iommu.h
+00:00:25   CC      fs/quota/quota_tree.o
+00:00:25   HDRTEST usr/include/linux/ioprio.h
+00:00:25   CC      fs/iomap/seek.o
+00:00:25   HDRTEST usr/include/linux/ip.h
+00:00:25   CC      kernel/entry/kvm.o
+00:00:25   HDRTEST usr/include/linux/ip6_tunnel.h
+00:00:25   HDRTEST usr/include/linux/ip_vs.h
+00:00:25   HDRTEST usr/include/linux/ipc.h
+00:00:25   HDRTEST usr/include/linux/ipmi.h
+00:00:25   HDRTEST usr/include/linux/ipmi_bmc.h
+00:00:25   CC      security/keys/persistent.o
+00:00:25   HDRTEST usr/include/linux/ipmi_msgdefs.h
+00:00:25   HDRTEST usr/include/linux/ipsec.h
+00:00:25   CC      mm/vmscan.o
+00:00:25   HDRTEST usr/include/linux/ipv6.h
+00:00:25   CC      block/partitions/msdos.o
+00:00:25   HDRTEST usr/include/linux/ipv6_route.h
+00:00:25   HDRTEST usr/include/linux/irqnr.h
+00:00:25   HDRTEST usr/include/linux/iso_fs.h
+00:00:25   HDRTEST usr/include/linux/isst_if.h
+00:00:25   HDRTEST usr/include/linux/ivtv.h
+00:00:25   CC      kernel/sched/cpudeadline.o
+00:00:25   HDRTEST usr/include/linux/ivtvfb.h
+00:00:25   CC      fs/iomap/swapfile.o
+00:00:25   HDRTEST usr/include/linux/jffs2.h
+00:00:25   HDRTEST usr/include/linux/joystick.h
+00:00:25   CC      security/selinux/netport.o
+00:00:25   HDRTEST usr/include/linux/kcmp.h
+00:00:26   HDRTEST usr/include/linux/kcm.h
+00:00:26   CC      fs/proc/root.o
+00:00:26   HDRTEST usr/include/linux/kcov.h
+00:00:26   CC      fs/kernfs/mount.o
+00:00:26   CC      crypto/scatterwalk.o
+00:00:26   HDRTEST usr/include/linux/kd.h
+00:00:26   HDRTEST usr/include/linux/kdev_t.h
+00:00:26   CC      fs/quota/quota.o
+00:00:26   CC      security/keys/dh.o
+00:00:26   HDRTEST usr/include/linux/kernel-page-flags.h
+00:00:26   HDRTEST usr/include/linux/kernel.h
+00:00:26   HDRTEST usr/include/linux/kernelcapi.h
+00:00:26   HDRTEST usr/include/linux/kexec.h
+00:00:26   AR      kernel/entry/built-in.a
+00:00:26   CC      kernel/sched/topology.o
+00:00:26   HDRTEST usr/include/linux/keyboard.h
+00:00:26   HDRTEST usr/include/linux/keyctl.h
+00:00:26   HDRTEST usr/include/linux/kfd_ioctl.h
+00:00:26   CC      security/keys/keyctl_pkey.o
+00:00:26   HDRTEST usr/include/linux/kvm_para.h
+00:00:26   HDRTEST usr/include/linux/kvm.h
+00:00:26   HDRTEST usr/include/linux/l2tp.h
+00:00:26   HDRTEST usr/include/linux/landlock.h
+00:00:26   HDRTEST usr/include/linux/limits.h
+00:00:26   HDRTEST usr/include/linux/lirc.h
+00:00:26   HDRTEST usr/include/linux/libc-compat.h
+00:00:26   CC      fs/proc/base.o
+00:00:26   HDRTEST usr/include/linux/llc.h
+00:00:26   CC      crypto/proc.o
+00:00:26   CC      block/partitions/osf.o
+00:00:26   CC      fs/kernfs/inode.o
+00:00:26   HDRTEST usr/include/linux/loop.h
+00:00:26   AR      fs/iomap/built-in.a
+00:00:26   CC      fs/proc/generic.o
+00:00:26   HDRTEST usr/include/linux/lp.h
+00:00:26   HDRTEST usr/include/linux/lwtunnel.h
+00:00:26   HDRTEST usr/include/linux/magic.h
+00:00:26   CC      block/fops.o
+00:00:26   HDRTEST usr/include/linux/major.h
+00:00:26   CC      kernel/time/hrtimer.o
+00:00:26   HDRTEST usr/include/linux/map_to_7segment.h
+00:00:26   HDRTEST usr/include/linux/matroxfb.h
+00:00:26   HDRTEST usr/include/linux/max2175.h
+00:00:26   CC      security/keys/big_key.o
+00:00:26   HDRTEST usr/include/linux/mctp.h
+00:00:26   HDRTEST usr/include/linux/mdio.h
+00:00:26   HDRTEST usr/include/linux/media-bus-format.h
+00:00:26   HDRTEST usr/include/linux/media.h
+00:00:26   CC      mm/shmem.o
+00:00:27   CC      crypto/aead.o
+00:00:27   HDRTEST usr/include/linux/mei.h
+00:00:27   CC      security/selinux/status.o
+00:00:27   HDRTEST usr/include/linux/membarrier.h
+00:00:27   HDRTEST usr/include/linux/memfd.h
+00:00:27   HDRTEST usr/include/linux/mempolicy.h
+00:00:27   HDRTEST usr/include/linux/meye.h
+00:00:27   HDRTEST usr/include/linux/mii.h
+00:00:27   HDRTEST usr/include/linux/minix_fs.h
+00:00:27   HDRTEST usr/include/linux/mman.h
+00:00:27   CC      fs/quota/kqid.o
+00:00:27   CC      block/partitions/sgi.o
+00:00:27   HDRTEST usr/include/linux/mmtimer.h
+00:00:27   HDRTEST usr/include/linux/module.h
+00:00:27   HDRTEST usr/include/linux/mount.h
+00:00:27   HDRTEST usr/include/linux/mpls_iptunnel.h
+00:00:27   CC      fs/kernfs/dir.o
+00:00:27   CC      block/partitions/sun.o
+00:00:27   HDRTEST usr/include/linux/mpls.h
+00:00:27   HDRTEST usr/include/linux/mqueue.h
+00:00:27   HDRTEST usr/include/linux/mptcp.h
+00:00:27   HDRTEST usr/include/linux/mroute.h
+00:00:27   HDRTEST usr/include/linux/mrp_bridge.h
+00:00:27   HDRTEST usr/include/linux/mroute6.h
+00:00:27   HDRTEST usr/include/linux/msdos_fs.h
+00:00:27   HDRTEST usr/include/linux/msg.h
+00:00:27   AR      security/keys/built-in.a
+00:00:27   CC      fs/quota/netlink.o
+00:00:27   CC      block/bio.o
+00:00:27   CC      kernel/sched/stop_task.o
+00:00:27   HDRTEST usr/include/linux/mtio.h
+00:00:27   HDRTEST usr/include/linux/nbd-netlink.h
+00:00:27   CC      crypto/geniv.o
+00:00:27   HDRTEST usr/include/linux/nbd.h
+00:00:27   HDRTEST usr/include/linux/ncsi.h
+00:00:27   HDRTEST usr/include/linux/ndctl.h
+00:00:27   HDRTEST usr/include/linux/neighbour.h
+00:00:27   HDRTEST usr/include/linux/net.h
+00:00:27   HDRTEST usr/include/linux/net_dropmon.h
+00:00:27   CC      kernel/time/timekeeping.o
+00:00:27   CC      arch/x86/xen/mmu_pv.o
+00:00:27   HDRTEST usr/include/linux/net_namespace.h
+00:00:27   HDRTEST usr/include/linux/net_tstamp.h
+00:00:27   HDRTEST usr/include/linux/netconf.h
+00:00:28   HDRTEST usr/include/linux/netdevice.h
+00:00:28   CC      security/selinux/ss/ebitmap.o
+00:00:28   CC      block/partitions/efi.o
+00:00:28   HDRTEST usr/include/linux/netfilter.h
+00:00:28   HDRTEST usr/include/linux/netfilter_arp.h
+00:00:28   HDRTEST usr/include/linux/netfilter_bridge.h
+00:00:28   CC      kernel/futex/core.o
+00:00:28   HDRTEST usr/include/linux/netfilter_ipv4.h
+00:00:28   HDRTEST usr/include/linux/netfilter_ipv6.h
+00:00:28   HDRTEST usr/include/linux/netlink.h
+00:00:28   AR      fs/quota/built-in.a
+00:00:28   HDRTEST usr/include/linux/netlink_diag.h
+00:00:28   HDRTEST usr/include/linux/netrom.h
+00:00:28   HDRTEST usr/include/linux/nexthop.h
+00:00:28   CC      fs/kernfs/file.o
+00:00:28   HDRTEST usr/include/linux/nfc.h
+00:00:28   AR      drivers/irqchip/built-in.a
+00:00:28   HDRTEST usr/include/linux/nfs2.h
+00:00:28   CC      crypto/skcipher.o
+00:00:28   HDRTEST usr/include/linux/nfs.h
+00:00:28   AR      drivers/bus/mhi/host/built-in.a
+00:00:28   CC      fs/proc/array.o
+00:00:28   CC [M]  drivers/bus/mhi/host/init.o
+00:00:28   HDRTEST usr/include/linux/nfs4.h
+00:00:28   HDRTEST usr/include/linux/nfs3.h
+00:00:28   HDRTEST usr/include/linux/nfs4_mount.h
+00:00:28   HDRTEST usr/include/linux/nfs_fs.h
+00:00:28   HDRTEST usr/include/linux/nfs_idmap.h
+00:00:28   HDRTEST usr/include/linux/nfs_mount.h
+00:00:28   HDRTEST usr/include/linux/nfsacl.h
+00:00:28   HDRTEST usr/include/linux/nilfs2_api.h
+00:00:28   CC      kernel/cgroup/cgroup.o
+00:00:28   CC      kernel/sched/pelt.o
+00:00:28   HDRTEST usr/include/linux/nilfs2_ondisk.h
+00:00:28   HDRTEST usr/include/linux/nitro_enclaves.h
+00:00:28   HDRTEST usr/include/linux/nl80211-vnd-intel.h
+00:00:28   HDRTEST usr/include/linux/nsfs.h
+00:00:28   HDRTEST usr/include/linux/nubus.h
+00:00:28   AR      block/partitions/built-in.a
+00:00:28   HDRTEST usr/include/linux/nvme_ioctl.h
+00:00:28   CC      security/tomoyo/audit.o
+00:00:28   HDRTEST usr/include/linux/nvram.h
+00:00:28   HDRTEST usr/include/linux/nl80211.h
+00:00:29   HDRTEST usr/include/linux/omap3isp.h
+00:00:29   HDRTEST usr/include/linux/omapfb.h
+00:00:29   CC      io_uring/io-wq.o
+00:00:29   HDRTEST usr/include/linux/oom.h
+00:00:29   CC      kernel/time/ntp.o
+00:00:29   CC      fs/kernfs/symlink.o
+00:00:29   HDRTEST usr/include/linux/openat2.h
+00:00:29   HDRTEST usr/include/linux/openvswitch.h
+00:00:29   CC      block/elevator.o
+00:00:29   HDRTEST usr/include/linux/packet_diag.h
+00:00:29   CC      security/selinux/ss/hashtab.o
+00:00:29   HDRTEST usr/include/linux/parport.h
+00:00:29   HDRTEST usr/include/linux/param.h
+00:00:29   HDRTEST usr/include/linux/pci.h
+00:00:29   HDRTEST usr/include/linux/patchkey.h
+00:00:29   CC      mm/util.o
+00:00:29   HDRTEST usr/include/linux/pcitest.h
+00:00:29   HDRTEST usr/include/linux/pci_regs.h
+00:00:29   CC [M]  drivers/bus/mhi/host/main.o
+00:00:29   HDRTEST usr/include/linux/perf_event.h
+00:00:29   CC      crypto/seqiv.o
+00:00:29   HDRTEST usr/include/linux/personality.h
+00:00:29   CC      fs/proc/fd.o
+00:00:29   HDRTEST usr/include/linux/pfkeyv2.h
+00:00:29   HDRTEST usr/include/linux/pg.h
+00:00:29   HDRTEST usr/include/linux/phantom.h
+00:00:29   HDRTEST usr/include/linux/pidfd.h
+00:00:29   CC      security/selinux/ss/symtab.o
+00:00:29   HDRTEST usr/include/linux/phonet.h
+00:00:29   AR      fs/kernfs/built-in.a
+00:00:29   HDRTEST usr/include/linux/pkt_cls.h
+00:00:29   HDRTEST usr/include/linux/pkt_sched.h
+00:00:29   HDRTEST usr/include/linux/pktcdvd.h
+00:00:29   CC      kernel/time/clocksource.o
+00:00:29   HDRTEST usr/include/linux/poll.h
+00:00:29   HDRTEST usr/include/linux/pmu.h
+00:00:29   AR      kernel/futex/built-in.a
+00:00:29   POLICY  security/tomoyo/builtin-policy.h
+00:00:29   HDRTEST usr/include/linux/posix_acl.h
+00:00:29   CC      kernel/time/jiffies.o
+00:00:29   CC      kernel/debug/debug_core.o
+00:00:29   HDRTEST usr/include/linux/posix_types.h
+00:00:29   HDRTEST usr/include/linux/ppdev.h
+00:00:29   CC      security/selinux/ss/sidtab.o
+00:00:29   HDRTEST usr/include/linux/posix_acl_xattr.h
+00:00:29   HDRTEST usr/include/linux/ppp-comp.h
+00:00:29   HDRTEST usr/include/linux/ppp-ioctl.h
+00:00:29   CC      security/tomoyo/condition.o
+00:00:30   CC      crypto/ahash.o
+00:00:30   HDRTEST usr/include/linux/ppp_defs.h
+00:00:30   CC      kernel/sched/autogroup.o
+00:00:30   HDRTEST usr/include/linux/pr.h
+00:00:30   HDRTEST usr/include/linux/pps.h
+00:00:30   CC      fs/proc/proc_tty.o
+00:00:30   HDRTEST usr/include/linux/prctl.h
+00:00:30   CC      mm/mmzone.o
+00:00:30   HDRTEST usr/include/linux/psample.h
+00:00:30   CC      security/selinux/ss/avtab.o
+00:00:30   HDRTEST usr/include/linux/psci.h
+00:00:30   CC      block/blk-core.o
+00:00:30   HDRTEST usr/include/linux/psp-sev.h
+00:00:30   HDRTEST usr/include/linux/ptp_clock.h
+00:00:30   HDRTEST usr/include/linux/ptrace.h
+00:00:30   HDRTEST usr/include/linux/qemu_fw_cfg.h
+00:00:30   HDRTEST usr/include/linux/qnx4_fs.h
+00:00:30   AR      io_uring/built-in.a
+00:00:30   CC [M]  drivers/bus/mhi/host/pm.o
+00:00:30   HDRTEST usr/include/linux/qnxtypes.h
+00:00:30   CC      security/yama/yama_lsm.o
+00:00:30   HDRTEST usr/include/linux/quota.h
+00:00:30   HDRTEST usr/include/linux/qrtr.h
+00:00:30   HDRTEST usr/include/linux/radeonfb.h
+00:00:30   HDRTEST usr/include/linux/random.h
+00:00:30   CC      kernel/time/timer_list.o
+00:00:30   HDRTEST usr/include/linux/rds.h
+00:00:30   CC      fs/proc/cmdline.o
+00:00:30   HDRTEST usr/include/linux/reboot.h
+00:00:30   AR      drivers/phy/allwinner/built-in.a
+00:00:30   HDRTEST usr/include/linux/reiserfs_fs.h
+00:00:30   AR      drivers/phy/amlogic/built-in.a
+00:00:30   CC      mm/vmstat.o
+00:00:30   HDRTEST usr/include/linux/reiserfs_xattr.h
+00:00:30   AR      drivers/phy/broadcom/built-in.a
+00:00:30   HDRTEST usr/include/linux/remoteproc_cdev.h
+00:00:30   AR      drivers/phy/cadence/built-in.a
+00:00:30   HDRTEST usr/include/linux/resource.h
+00:00:30   AR      drivers/phy/freescale/built-in.a
+00:00:30   AR      drivers/phy/hisilicon/built-in.a
+00:00:30   HDRTEST usr/include/linux/rfkill.h
+00:00:30   CC      kernel/debug/gdbstub.o
+00:00:30   AR      drivers/phy/ingenic/built-in.a
+00:00:30   HDRTEST usr/include/linux/rio_cm_cdev.h
+00:00:30   AR      drivers/phy/intel/built-in.a
+00:00:30   HDRTEST usr/include/linux/rio_mport_cdev.h
+00:00:30   CC      crypto/shash.o
+00:00:30   AR      drivers/phy/lantiq/built-in.a
+00:00:30   HDRTEST usr/include/linux/romfs_fs.h
+00:00:30   AR      drivers/phy/marvell/built-in.a
+00:00:30   HDRTEST usr/include/linux/rkisp1-config.h
+00:00:30   AR      drivers/phy/mediatek/built-in.a
+00:00:30   HDRTEST usr/include/linux/rose.h
+00:00:30   AR      drivers/phy/microchip/built-in.a
+00:00:30   HDRTEST usr/include/linux/route.h
+00:00:30   AR      drivers/phy/motorola/built-in.a
+00:00:30   CC      fs/proc/consoles.o
+00:00:30   AR      drivers/phy/mscc/built-in.a
+00:00:30   HDRTEST usr/include/linux/rpl.h
+00:00:30   AR      drivers/phy/qualcomm/built-in.a
+00:00:30   HDRTEST usr/include/linux/rpl_iptunnel.h
+00:00:31   AR      security/yama/built-in.a
+00:00:31   AR      drivers/phy/ralink/built-in.a
+00:00:31   CC      fs/proc/cpuinfo.o
+00:00:31   HDRTEST usr/include/linux/rpmsg.h
+00:00:31   AR      drivers/phy/renesas/built-in.a
+00:00:31   HDRTEST usr/include/linux/rpmsg_types.h
+00:00:31   AR      drivers/phy/rockchip/built-in.a
+00:00:31   HDRTEST usr/include/linux/rseq.h
+00:00:31   AR      drivers/phy/samsung/built-in.a
+00:00:31   HDRTEST usr/include/linux/rtc.h
+00:00:31   CC      kernel/time/timeconv.o
+00:00:31   CC      kernel/sched/stats.o
+00:00:31   AR      drivers/phy/socionext/built-in.a
+00:00:31   HDRTEST usr/include/linux/rtnetlink.h
+00:00:31   AR      drivers/phy/st/built-in.a
+00:00:31   CC      arch/x86/xen/irq.o
+00:00:31   HDRTEST usr/include/linux/rxrpc.h
+00:00:31   AR      drivers/phy/tegra/built-in.a
+00:00:31   HDRTEST usr/include/linux/scc.h
+00:00:31   AR      drivers/phy/ti/built-in.a
+00:00:31   HDRTEST usr/include/linux/sched.h
+00:00:31   AR      drivers/phy/xilinx/built-in.a
+00:00:31   CC      drivers/phy/phy-core.o
+00:00:31   HDRTEST usr/include/linux/scif_ioctl.h
+00:00:31   HDRTEST usr/include/linux/screen_info.h
+00:00:31   CC      security/selinux/ss/policydb.o
+00:00:31   HDRTEST usr/include/linux/sctp.h
+00:00:31   CC      kernel/time/timecounter.o
+00:00:31   HDRTEST usr/include/linux/seccomp.h
+00:00:31   HDRTEST usr/include/linux/securebits.h
+00:00:31   CC      security/tomoyo/domain.o
+00:00:31   CC      block/blk-sysfs.o
+00:00:31   HDRTEST usr/include/linux/sed-opal.h
+00:00:31   CC      kernel/time/alarmtimer.o
+00:00:31   CC      fs/proc/devices.o
+00:00:31   CC [M]  drivers/bus/mhi/host/boot.o
+00:00:31   HDRTEST usr/include/linux/seg6.h
+00:00:31   HDRTEST usr/include/linux/seg6_genl.h
+00:00:31   HDRTEST usr/include/linux/seg6_hmac.h
+00:00:31   HDRTEST usr/include/linux/seg6_iptunnel.h
+00:00:31   HDRTEST usr/include/linux/seg6_local.h
+00:00:31   AR      kernel/debug/built-in.a
+00:00:31   HDRTEST usr/include/linux/selinux_netlink.h
+00:00:31   CC      kernel/time/posix-timers.o
+00:00:31   CC      crypto/akcipher.o
+00:00:31   HDRTEST usr/include/linux/sem.h
+00:00:31   HDRTEST usr/include/linux/serial_core.h
+00:00:31   HDRTEST usr/include/linux/serial.h
+00:00:31   HDRTEST usr/include/linux/serial_reg.h
+00:00:31   CC      kernel/sched/debug.o
+00:00:31   HDRTEST usr/include/linux/serio.h
+00:00:31   HDRTEST usr/include/linux/signal.h
+00:00:31   HDRTEST usr/include/linux/shm.h
+00:00:31   HDRTEST usr/include/linux/signalfd.h
+00:00:31   HDRTEST usr/include/linux/smc.h
+00:00:31   HDRTEST usr/include/linux/smiapp.h
+00:00:31   HDRTEST usr/include/linux/smc_diag.h
+00:00:32   HDRTEST usr/include/linux/snmp.h
+00:00:32   CC      kernel/cgroup/rstat.o
+00:00:32   HDRTEST usr/include/linux/sock_diag.h
+00:00:32   CC      fs/proc/interrupts.o
+00:00:32   CC      mm/backing-dev.o
+00:00:32   HDRTEST usr/include/linux/socket.h
+00:00:32   HDRTEST usr/include/linux/sockios.h
+00:00:32   HDRTEST usr/include/linux/sonypi.h
+00:00:32   HDRTEST usr/include/linux/sonet.h
+00:00:32   CC      fs/sysfs/file.o
+00:00:32   HDRTEST usr/include/linux/sound.h
+00:00:32   HDRTEST usr/include/linux/soundcard.h
+00:00:32   CC      crypto/kpp.o
+00:00:32   AR      drivers/phy/built-in.a
+00:00:32   CC [M]  drivers/bus/mhi/host/pci_generic.o
+00:00:32   HDRTEST usr/include/linux/stat.h
+00:00:32   HDRTEST usr/include/linux/stm.h
+00:00:32   HDRTEST usr/include/linux/stddef.h
+00:00:32   CC      block/blk-flush.o
+00:00:32   HDRTEST usr/include/linux/string.h
+00:00:32   CC [M]  sound/core/oss/mixer_oss.o
+00:00:32   HDRTEST usr/include/linux/suspend_ioctls.h
+00:00:32   CC      fs/sysfs/dir.o
+00:00:32   CC      fs/proc/loadavg.o
+00:00:32   HDRTEST usr/include/linux/swab.h
+00:00:32   HDRTEST usr/include/linux/switchtec_ioctl.h
+00:00:32   HDRTEST usr/include/linux/sync_file.h
+00:00:32   CC      security/tomoyo/environ.o
+00:00:32   HDRTEST usr/include/linux/synclink.h
+00:00:32   HDRTEST usr/include/linux/sysinfo.h
+00:00:32   HDRTEST usr/include/linux/sysctl.h
+00:00:32   HDRTEST usr/include/linux/target_core_user.h
+00:00:32   HDRTEST usr/include/linux/taskstats.h
+00:00:32   CC      kernel/cgroup/namespace.o
+00:00:32   CC      fs/configfs/inode.o
+00:00:32   HDRTEST usr/include/linux/tcp.h
+00:00:32   HDRTEST usr/include/linux/tcp_metrics.h
+00:00:32   HDRTEST usr/include/linux/tee.h
+00:00:32   HDRTEST usr/include/linux/thermal.h
+00:00:32   HDRTEST usr/include/linux/termios.h
+00:00:32   CC      fs/configfs/file.o
+00:00:32   CC      kernel/time/posix-cpu-timers.o
+00:00:32   HDRTEST usr/include/linux/time.h
+00:00:32   CC      fs/sysfs/symlink.o
+00:00:32   CC      crypto/dh.o
+00:00:32   HDRTEST usr/include/linux/timerfd.h
+00:00:32   CC      fs/proc/meminfo.o
+00:00:32   HDRTEST usr/include/linux/time_types.h
+00:00:32   HDRTEST usr/include/linux/times.h
+00:00:32   HDRTEST usr/include/linux/timex.h
+00:00:33   HDRTEST usr/include/linux/tiocl.h
+00:00:33   LD [M]  drivers/bus/mhi/host/mhi.o
+00:00:33   LD [M]  drivers/bus/mhi/host/mhi_pci_generic.o
+00:00:33   HDRTEST usr/include/linux/tipc.h
+00:00:33   AR      drivers/bus/mhi/built-in.a
+00:00:33   HDRTEST usr/include/linux/tipc_config.h
+00:00:33   AR      drivers/bus/built-in.a
+00:00:33   HDRTEST usr/include/linux/tipc_netlink.h
+00:00:33   CC      block/blk-settings.o
+00:00:33   AR      drivers/pinctrl/actions/built-in.a
+00:00:33   HDRTEST usr/include/linux/tipc_sockets_diag.h
+00:00:33   AR      drivers/pinctrl/bcm/built-in.a
+00:00:33   HDRTEST usr/include/linux/tls.h
+00:00:33   AR      drivers/pinctrl/freescale/built-in.a
+00:00:33   HDRTEST usr/include/linux/toshiba.h
+00:00:33   CC      drivers/pinctrl/intel/pinctrl-baytrail.o
+00:00:33   HDRTEST usr/include/linux/tty_flags.h
+00:00:33   CC      kernel/cgroup/cgroup-v1.o
+00:00:33   HDRTEST usr/include/linux/types.h
+00:00:33   CC      mm/mm_init.o
+00:00:33   HDRTEST usr/include/linux/tty.h
+00:00:33   HDRTEST usr/include/linux/udf_fs_i.h
+00:00:33   CC [M]  sound/core/oss/pcm_oss.o
+00:00:33   CC      fs/sysfs/mount.o
+00:00:33   HDRTEST usr/include/linux/udmabuf.h
+00:00:33   CC      crypto/dh_helper.o
+00:00:33   CC      drivers/gpio/gpiolib.o
+00:00:33   HDRTEST usr/include/linux/udp.h
+00:00:33   CC      fs/configfs/dir.o
+00:00:33   HDRTEST usr/include/linux/uhid.h
+00:00:33   HDRTEST usr/include/linux/uinput.h
+00:00:33   CC      kernel/sched/cpuacct.o
+00:00:33   CC      security/tomoyo/file.o
+00:00:33   HDRTEST usr/include/linux/uio.h
+00:00:33   HDRTEST usr/include/linux/uleds.h
+00:00:33   HDRTEST usr/include/linux/ultrasound.h
+00:00:33   CC      security/selinux/ss/services.o
+00:00:33   HDRTEST usr/include/linux/um_timetravel.h
+00:00:33   HDRTEST usr/include/linux/un.h
+00:00:33   CC      fs/proc/stat.o
+00:00:33   HDRTEST usr/include/linux/unix_diag.h
+00:00:33   HDRTEST usr/include/linux/unistd.h
+00:00:33   ASN.1   crypto/rsapubkey.asn1.[ch]
+00:00:33   ASN.1   crypto/rsaprivkey.asn1.[ch]
+00:00:33   CC      crypto/rsa.o
+00:00:33   HDRTEST usr/include/linux/usbdevice_fs.h
+00:00:33   CC      kernel/time/posix-clock.o
+00:00:33   HDRTEST usr/include/linux/usbip.h
+00:00:33   HDRTEST usr/include/linux/userfaultfd.h
+00:00:33   HDRTEST usr/include/linux/userio.h
+00:00:33   CC      mm/percpu.o
+00:00:33   HDRTEST usr/include/linux/utime.h
+00:00:33   HDRTEST usr/include/linux/utsname.h
+00:00:33   HDRTEST usr/include/linux/uvcvideo.h
+00:00:33   HDRTEST usr/include/linux/uuid.h
+00:00:33   CC      block/blk-ioc.o
+00:00:33   CC      fs/sysfs/group.o
+00:00:33   HDRTEST usr/include/linux/v4l2-common.h
+00:00:34   HDRTEST usr/include/linux/v4l2-controls.h
+00:00:34   HDRTEST usr/include/linux/v4l2-dv-timings.h
+00:00:34   HDRTEST usr/include/linux/v4l2-mediabus.h
+00:00:34   CC      drivers/pinctrl/intel/pinctrl-cherryview.o
+00:00:34   HDRTEST usr/include/linux/v4l2-subdev.h
+00:00:34   HDRTEST usr/include/linux/vbox_err.h
+00:00:34   CC      fs/proc/uptime.o
+00:00:34   HDRTEST usr/include/linux/vbox_vmmdev_types.h
+00:00:34   HDRTEST usr/include/linux/vboxguest.h
+00:00:34   HDRTEST usr/include/linux/vdpa.h
+00:00:34   CC      crypto/rsa_helper.o
+00:00:34   HDRTEST usr/include/linux/vduse.h
+00:00:34   CC      kernel/cgroup/freezer.o
+00:00:34   HDRTEST usr/include/linux/veth.h
+00:00:34   HDRTEST usr/include/linux/vfio_ccw.h
+00:00:34   HDRTEST usr/include/linux/vfio_zdev.h
+00:00:34   CC      kernel/time/itimer.o
+00:00:34   CC      crypto/rsa-pkcs1pad.o
+00:00:34   HDRTEST usr/include/linux/vfio.h
+00:00:34   HDRTEST usr/include/linux/vhost.h
+00:00:34   HDRTEST usr/include/linux/vhost_types.h
+00:00:34   CC      fs/configfs/symlink.o
+00:00:34   HDRTEST usr/include/linux/virtio_9p.h
+00:00:34   AR      fs/sysfs/built-in.a
+00:00:34   HDRTEST usr/include/linux/videodev2.h
+00:00:34   CC      fs/proc/util.o
+00:00:34   CC [M]  sound/i2c/other/ak4xxx-adda.o
+00:00:34   HDRTEST usr/include/linux/virtio_balloon.h
+00:00:34   HDRTEST usr/include/linux/virtio_blk.h
+00:00:34   CC      kernel/sched/cpufreq.o
+00:00:34   HDRTEST usr/include/linux/virtio_bt.h
+00:00:34   CC      block/blk-map.o
+00:00:34   HDRTEST usr/include/linux/virtio_config.h
+00:00:34   HDRTEST usr/include/linux/virtio_console.h
+00:00:34   HDRTEST usr/include/linux/virtio_crypto.h
+00:00:34   CC      security/tomoyo/gc.o
+00:00:34   HDRTEST usr/include/linux/virtio_fs.h
+00:00:34   HDRTEST usr/include/linux/virtio_gpio.h
+00:00:34   HDRTEST usr/include/linux/virtio_gpu.h
+00:00:34   HDRTEST usr/include/linux/virtio_i2c.h
+00:00:34   HDRTEST usr/include/linux/virtio_ids.h
+00:00:34   HDRTEST usr/include/linux/virtio_input.h
+00:00:34   CC      fs/proc/version.o
+00:00:34   CC [M]  sound/core/oss/pcm_plugin.o
+00:00:34   HDRTEST usr/include/linux/virtio_iommu.h
+00:00:34   CC      fs/configfs/mount.o
+00:00:34   CC      kernel/cgroup/legacy_freezer.o
+00:00:34   CC      drivers/pinctrl/intel/pinctrl-intel.o
+00:00:34   HDRTEST usr/include/linux/virtio_mem.h
+00:00:35   HDRTEST usr/include/linux/virtio_mmio.h
+00:00:35   HDRTEST usr/include/linux/virtio_pci.h
+00:00:35   HDRTEST usr/include/linux/virtio_net.h
+00:00:35   ASN.1   crypto/ecdsasignature.asn1.[ch]
+00:00:35   CC      crypto/acompress.o
+00:00:35   HDRTEST usr/include/linux/virtio_pmem.h
+00:00:35   HDRTEST usr/include/linux/virtio_pcidev.h
+00:00:35   CC      kernel/time/clockevents.o
+00:00:35   HDRTEST usr/include/linux/virtio_ring.h
+00:00:35   HDRTEST usr/include/linux/virtio_rng.h
+00:00:35   HDRTEST usr/include/linux/virtio_scmi.h
+00:00:35   CC [M]  sound/i2c/other/ak4114.o
+00:00:35   HDRTEST usr/include/linux/virtio_scsi.h
+00:00:35   CC      fs/proc/softirqs.o
+00:00:35   HDRTEST usr/include/linux/virtio_types.h
+00:00:35   HDRTEST usr/include/linux/virtio_snd.h
+00:00:35   HDRTEST usr/include/linux/virtio_vsock.h
+00:00:35   HDRTEST usr/include/linux/vm_sockets.h
+00:00:35   HDRTEST usr/include/linux/vm_sockets_diag.h
+00:00:35   CC      drivers/gpio/gpiolib-devres.o
+00:00:35   HDRTEST usr/include/linux/vmcore.h
+00:00:35   CC      fs/configfs/item.o
+00:00:35   HDRTEST usr/include/linux/vsockmon.h
+00:00:35   HDRTEST usr/include/linux/vt.h
+00:00:35   CC      block/blk-exec.o
+00:00:35   HDRTEST usr/include/linux/wait.h
+00:00:35   HDRTEST usr/include/linux/vtpm_proxy.h
+00:00:35   CC      kernel/cgroup/pids.o
+00:00:35   HDRTEST usr/include/linux/watch_queue.h
+00:00:35   CC      kernel/sched/cpufreq_schedutil.o
+00:00:35   HDRTEST usr/include/linux/watchdog.h
+00:00:35   HDRTEST usr/include/linux/wireguard.h
+00:00:35   CC      fs/proc/namespaces.o
+00:00:35   CC [M]  sound/core/oss/io.o
+00:00:35   HDRTEST usr/include/linux/wireless.h
+00:00:35   CC      crypto/scompress.o
+00:00:35   HDRTEST usr/include/linux/wmi.h
+00:00:35   CC      kernel/time/tick-common.o
+00:00:35   HDRTEST usr/include/linux/wwan.h
+00:00:35   CC      security/selinux/ss/conditional.o
+00:00:35   HDRTEST usr/include/linux/x25.h
+00:00:35   AR      fs/configfs/built-in.a
+00:00:35   HDRTEST usr/include/linux/xattr.h
+00:00:35   CC      security/tomoyo/group.o
+00:00:35   CC      fs/proc/self.o
+00:00:35   CC      mm/slab_common.o
+00:00:35   HDRTEST usr/include/linux/xdp_diag.h
+00:00:35   HDRTEST usr/include/linux/xfrm.h
+00:00:35   HDRTEST usr/include/linux/xilinx-v4l2-controls.h
+00:00:35   CC [M]  sound/i2c/other/ak4113.o
+00:00:35   CC      drivers/gpio/gpiolib-legacy.o
+00:00:36   HDRTEST usr/include/linux/zorro.h
+00:00:36   HDRTEST usr/include/linux/zorro_ids.h
+00:00:36   CC [M]  drivers/pinctrl/intel/pinctrl-lynxpoint.o
+00:00:36   HDRTEST usr/include/linux/version.h
+00:00:36   HDRTEST usr/include/misc/uacce/hisi_qm.h
+00:00:36   HDRTEST usr/include/misc/uacce/uacce.h
+00:00:36   HDRTEST usr/include/misc/cxl.h
+00:00:36   CC      block/blk-merge.o
+00:00:36   HDRTEST usr/include/misc/fastrpc.h
+00:00:36   CC      kernel/cgroup/rdma.o
+00:00:36   HDRTEST usr/include/misc/habanalabs.h
+00:00:36   CC [M]  sound/core/oss/copy.o
+00:00:36   HDRTEST usr/include/misc/ocxl.h
+00:00:36   HDRTEST usr/include/misc/pvpanic.h
+00:00:36   HDRTEST usr/include/misc/xilinx_sdfec.h
+00:00:36   HDRTEST usr/include/mtd/inftl-user.h
+00:00:36   CC [M]  drivers/pinctrl/intel/pinctrl-alderlake.o
+00:00:36   CC      fs/proc/thread_self.o
+00:00:36   HDRTEST usr/include/mtd/mtd-abi.h
+00:00:36   HDRTEST usr/include/mtd/mtd-user.h
+00:00:36   CC      crypto/algboss.o
+00:00:36   HDRTEST usr/include/mtd/nftl-user.h
+00:00:36   HDRTEST usr/include/mtd/ubi-user.h
+00:00:36   CC      drivers/gpio/gpiolib-cdev.o
+00:00:36   HDRTEST usr/include/rdma/hfi/hfi1_ioctl.h
+00:00:36   HDRTEST usr/include/rdma/hfi/hfi1_user.h
+00:00:36   HDRTEST usr/include/rdma/bnxt_re-abi.h
+00:00:36   CC      kernel/time/tick-broadcast.o
+00:00:36   HDRTEST usr/include/rdma/cxgb4-abi.h
+00:00:36   HDRTEST usr/include/rdma/efa-abi.h
+00:00:36   LD [M]  sound/i2c/other/snd-ak4xxx-adda.o
+00:00:36   CC [M]  sound/i2c/other/pt2258.o
+00:00:36   HDRTEST usr/include/rdma/hns-abi.h
+00:00:36   CC [M]  sound/core/oss/linear.o
+00:00:36   HDRTEST usr/include/rdma/ib_user_ioctl_cmds.h
+00:00:36   HDRTEST usr/include/rdma/ib_user_ioctl_verbs.h
+00:00:36   CC [M]  sound/core/seq/oss/seq_oss.o
+00:00:36   CC [M]  drivers/pinctrl/intel/pinctrl-broxton.o
+00:00:36   HDRTEST usr/include/rdma/ib_user_mad.h
+00:00:36   CC      fs/proc/proc_sysctl.o
+00:00:36   HDRTEST usr/include/rdma/ib_user_sa.h
+00:00:36   CC      security/tomoyo/load_policy.o
+00:00:36   HDRTEST usr/include/rdma/ib_user_verbs.h
+00:00:36   CC      kernel/cgroup/cpuset.o
+00:00:36   HDRTEST usr/include/rdma/irdma-abi.h
+00:00:36   HDRTEST usr/include/rdma/mlx4-abi.h
+00:00:36   CC      kernel/sched/membarrier.o
+00:00:36   HDRTEST usr/include/rdma/mlx5_user_ioctl_cmds.h
+00:00:37   CC      security/selinux/ss/mls.o
+00:00:37   HDRTEST usr/include/rdma/mlx5-abi.h
+00:00:37   HDRTEST usr/include/rdma/mlx5_user_ioctl_verbs.h
+00:00:37   HDRTEST usr/include/rdma/mthca-abi.h
+00:00:37   HDRTEST usr/include/rdma/ocrdma-abi.h
+00:00:37   LD [M]  sound/i2c/other/snd-ak4114.o
+00:00:37   LD [M]  sound/i2c/other/snd-ak4113.o
+00:00:37   HDRTEST usr/include/rdma/qedr-abi.h
+00:00:37   LD [M]  sound/i2c/other/snd-pt2258.o
+00:00:37   HDRTEST usr/include/rdma/rdma_netlink.h
+00:00:37   CC [M]  sound/i2c/cs8427.o
+00:00:37   CC      crypto/testmgr.o
+00:00:37   HDRTEST usr/include/rdma/rdma_user_cm.h
+00:00:37   HDRTEST usr/include/rdma/rdma_user_ioctl.h
+00:00:37   CC      kernel/time/tick-broadcast-hrtimer.o
+00:00:37   CC [M]  sound/core/oss/mulaw.o
+00:00:37   CC [M]  drivers/pinctrl/intel/pinctrl-cannonlake.o
+00:00:37   HDRTEST usr/include/rdma/rdma_user_ioctl_cmds.h
+00:00:37   CC [M]  sound/core/seq/oss/seq_oss_init.o
+00:00:37   HDRTEST usr/include/rdma/rdma_user_rxe.h
+00:00:37   HDRTEST usr/include/rdma/rvt-abi.h
+00:00:37   HDRTEST usr/include/rdma/siw-abi.h
+00:00:37   HDRTEST usr/include/rdma/vmw_pvrdma-abi.h
+00:00:37   HDRTEST usr/include/scsi/fc/fc_gs.h
+00:00:37   CC      mm/compaction.o
+00:00:37   HDRTEST usr/include/scsi/fc/fc_fs.h
+00:00:37   HDRTEST usr/include/scsi/fc/fc_els.h
+00:00:37   CC      block/blk-timeout.o
+00:00:37   HDRTEST usr/include/scsi/fc/fc_ns.h
+00:00:37   HDRTEST usr/include/scsi/cxlflash_ioctl.h
+00:00:37   HDRTEST usr/include/scsi/scsi_bsg_fc.h
+00:00:37   CC      kernel/time/tick-oneshot.o
+00:00:37   HDRTEST usr/include/scsi/scsi_bsg_ufs.h
+00:00:37   HDRTEST usr/include/scsi/scsi_netlink.h
+00:00:37   HDRTEST usr/include/scsi/scsi_netlink_fc.h
+00:00:37   CC [M]  drivers/pinctrl/intel/pinctrl-cedarfork.o
+00:00:37   HDRTEST usr/include/sound/sof/abi.h
+00:00:37   HDRTEST usr/include/sound/sof/fw.h
+00:00:37   HDRTEST usr/include/sound/sof/header.h
+00:00:37   CC [M]  sound/core/oss/route.o
+00:00:37   CC [M]  sound/core/seq/oss/seq_oss_timer.o
+00:00:37   HDRTEST usr/include/sound/sof/tokens.h
+00:00:37   CC      security/tomoyo/memory.o
+00:00:37   CC [M]  sound/i2c/i2c.o
+00:00:37   HDRTEST usr/include/sound/asequencer.h
+00:00:37   CC      drivers/gpio/gpiolib-acpi.o
+00:00:37   HDRTEST usr/include/sound/asoc.h
+00:00:37   HDRTEST usr/include/sound/asound_fm.h
+00:00:37   HDRTEST usr/include/sound/asound.h
+00:00:38   HDRTEST usr/include/sound/compress_offload.h
+00:00:38   CC      fs/proc/proc_net.o
+00:00:38   CC      kernel/time/tick-sched.o
+00:00:38   HDRTEST usr/include/sound/compress_params.h
+00:00:38   HDRTEST usr/include/sound/emu10k1.h
+00:00:38   HDRTEST usr/include/sound/hdsp.h
+00:00:38   CC      kernel/sched/isolation.o
+00:00:38   HDRTEST usr/include/sound/firewire.h
+00:00:38   CC      block/blk-lib.o
+00:00:38   HDRTEST usr/include/sound/hdspm.h
+00:00:38   CC      security/selinux/ss/context.o
+00:00:38   CC [M]  drivers/pinctrl/intel/pinctrl-denverton.o
+00:00:38   HDRTEST usr/include/sound/sb16_csp.h
+00:00:38   HDRTEST usr/include/sound/sfnt_info.h
+00:00:38   HDRTEST usr/include/sound/snd_sst_tokens.h
+00:00:38   HDRTEST usr/include/sound/skl-tplg-interface.h
+00:00:38   CC      arch/x86/xen/multicalls.o
+00:00:38   CC [M]  sound/core/oss/rate.o
+00:00:38   HDRTEST usr/include/sound/tlv.h
+00:00:38   CC [M]  sound/core/seq/oss/seq_oss_ioctl.o
+00:00:38   LD [M]  sound/i2c/snd-cs8427.o
+00:00:38   LD [M]  sound/i2c/snd-i2c.o
+00:00:38   HDRTEST usr/include/sound/usb_stream.h
+00:00:38   HDRTEST usr/include/video/edid.h
+00:00:38   CC      fs/devpts/inode.o
+00:00:38   HDRTEST usr/include/video/sisfb.h
+00:00:38   HDRTEST usr/include/video/uvesafb.h
+00:00:38   HDRTEST usr/include/xen/evtchn.h
+00:00:38   HDRTEST usr/include/xen/gntalloc.h
+00:00:38   HDRTEST usr/include/xen/gntdev.h
+00:00:38   HDRTEST usr/include/xen/privcmd.h
+00:00:38   HDRTEST usr/include/asm/a.out.h
+00:00:38   HDRTEST usr/include/asm/bitsperlong.h
+00:00:38   CC [M]  drivers/pinctrl/intel/pinctrl-elkhartlake.o
+00:00:38   HDRTEST usr/include/asm/auxvec.h
+00:00:38   CC      kernel/cgroup/misc.o
+00:00:38   HDRTEST usr/include/asm/boot.h
+00:00:38   CC      fs/proc/kcore.o
+00:00:38   HDRTEST usr/include/asm/bootparam.h
+00:00:38   HDRTEST usr/include/asm/byteorder.h
+00:00:38   HDRTEST usr/include/asm/debugreg.h
+00:00:38   CC      drivers/gpio/gpio-crystalcove.o
+00:00:38   HDRTEST usr/include/asm/hw_breakpoint.h
+00:00:38   CC [M]  sound/core/seq/oss/seq_oss_event.o
+00:00:38   HDRTEST usr/include/asm/hwcap2.h
+00:00:38   LD [M]  sound/core/oss/snd-mixer-oss.o
+00:00:38   HDRTEST usr/include/asm/ist.h
+00:00:38   LD [M]  sound/core/oss/snd-pcm-oss.o
+00:00:38   CC      security/tomoyo/mount.o
+00:00:38   CC      block/blk-mq.o
+00:00:38   HDRTEST usr/include/asm/kvm.h
+00:00:38   CC      block/blk-mq-tag.o
+00:00:38   AS      arch/x86/xen/xen-asm.o
+00:00:38   HDRTEST usr/include/asm/e820.h
+00:00:39   HDRTEST usr/include/asm/kvm_perf.h
+00:00:39   CC      arch/x86/xen/enlighten_pvh.o
+00:00:39   CC      kernel/time/vsyscall.o
+00:00:39   HDRTEST usr/include/asm/kvm_para.h
+00:00:39   AR      fs/devpts/built-in.a
+00:00:39   HDRTEST usr/include/asm/ldt.h
+00:00:39   CC      security/selinux/xfrm.o
+00:00:39   HDRTEST usr/include/asm/mce.h
+00:00:39   CC [M]  drivers/pinctrl/intel/pinctrl-emmitsburg.o
+00:00:39   CC      crypto/cmac.o
+00:00:39   HDRTEST usr/include/asm/mman.h
+00:00:39   HDRTEST usr/include/asm/msr.h
+00:00:39   HDRTEST usr/include/asm/msgbuf.h
+00:00:39   CC      kernel/sched/psi.o
+00:00:39   HDRTEST usr/include/asm/mtrr.h
+00:00:39   CC      net/core/sock.o
+00:00:39   HDRTEST usr/include/asm/perf_regs.h
+00:00:39   HDRTEST usr/include/asm/posix_types.h
+00:00:39   AR      kernel/cgroup/built-in.a
+00:00:39   HDRTEST usr/include/asm/posix_types_32.h
+00:00:39   CC      net/ethernet/eth.o
+00:00:39   HDRTEST usr/include/asm/posix_types_64.h
+00:00:39   CC [M]  drivers/gpio/gpio-mmio.o
+00:00:39   HDRTEST usr/include/asm/posix_types_x32.h
+00:00:39   CC [M]  sound/core/seq/oss/seq_oss_rw.o
+00:00:39   HDRTEST usr/include/asm/prctl.h
+00:00:39   CC      kernel/time/timekeeping_debug.o
+00:00:39   HDRTEST usr/include/asm/processor-flags.h
+00:00:39   HDRTEST usr/include/asm/ptrace-abi.h
+00:00:39   CC      fs/proc/vmcore.o
+00:00:39   CC      crypto/hmac.o
+00:00:39   HDRTEST usr/include/asm/ptrace.h
+00:00:39   HDRTEST usr/include/asm/setup.h
+00:00:39   CC [M]  drivers/pinctrl/intel/pinctrl-geminilake.o
+00:00:39   HDRTEST usr/include/asm/sembuf.h
+00:00:39   HDRTEST usr/include/asm/sigcontext32.h
+00:00:39   CC      arch/x86/xen/trace.o
+00:00:39   HDRTEST usr/include/asm/sgx.h
+00:00:39   HDRTEST usr/include/asm/shmbuf.h
+00:00:39   HDRTEST usr/include/asm/sigcontext.h
+00:00:39   CC      mm/vmacache.o
+00:00:39   HDRTEST usr/include/asm/siginfo.h
+00:00:39   HDRTEST usr/include/asm/signal.h
+00:00:39   HDRTEST usr/include/asm/stat.h
+00:00:39   HDRTEST usr/include/asm/statfs.h
+00:00:39   HDRTEST usr/include/asm/svm.h
+00:00:39   CC      fs/netfs/read_helper.o
+00:00:39   CC [M]  sound/core/seq/oss/seq_oss_synth.o
+00:00:39   HDRTEST usr/include/asm/swab.h
+00:00:39   HDRTEST usr/include/asm/ucontext.h
+00:00:39   CC      security/tomoyo/network.o
+00:00:39   HDRTEST usr/include/asm/unistd.h
+00:00:39   CC [M]  drivers/gpio/gpio-aggregator.o
+00:00:39   HDRTEST usr/include/asm/vm86.h
+00:00:40   CC [M]  drivers/pinctrl/intel/pinctrl-icelake.o
+00:00:40   HDRTEST usr/include/asm/vmx.h
+00:00:40   HDRTEST usr/include/asm/vsyscall.h
+00:00:40   HDRTEST usr/include/asm/unistd_64.h
+00:00:40   CC      crypto/crypto_null.o
+00:00:40   HDRTEST usr/include/asm/unistd_32.h
+00:00:40   CC      kernel/time/namespace.o
+00:00:40   HDRTEST usr/include/asm/unistd_x32.h
+00:00:40   HDRTEST usr/include/asm/bpf_perf_event.h
+00:00:40   CC      mm/interval_tree.o
+00:00:40   CC      security/selinux/netlabel.o
+00:00:40   HDRTEST usr/include/asm/errno.h
+00:00:40   HDRTEST usr/include/asm/fcntl.h
+00:00:40   HDRTEST usr/include/asm/ioctl.h
+00:00:40   HDRTEST usr/include/asm/ioctls.h
+00:00:40   HDRTEST usr/include/asm/ipcbuf.h
+00:00:40   HDRTEST usr/include/asm/param.h
+00:00:40   CC      fs/proc/kmsg.o
+00:00:40   HDRTEST usr/include/asm/poll.h
+00:00:40   HDRTEST usr/include/asm/resource.h
+00:00:40   HDRTEST usr/include/asm/socket.h
+00:00:40   CC [M]  drivers/pinctrl/intel/pinctrl-jasperlake.o
+00:00:40   HDRTEST usr/include/asm/sockios.h
+00:00:40   AR      net/ethernet/built-in.a
+00:00:40   CC      crypto/md5.o
+00:00:40   HDRTEST usr/include/asm/termbits.h
+00:00:40   CC [M]  sound/core/seq/oss/seq_oss_midi.o
+00:00:40   HDRTEST usr/include/asm/termios.h
+00:00:40   HDRTEST usr/include/asm/types.h
+00:00:40   CC [M]  drivers/gpio/gpio-amd-fch.o
+00:00:40   CC      fs/netfs/stats.o
+00:00:40   CC [M]  sound/drivers/opl3/opl3_lib.o
+00:00:40   CC      kernel/sched/core_sched.o
+00:00:40   CC [M]  kernel/time/time_test.o
+00:00:40   CC      fs/proc/page.o
+00:00:40   CC [M]  drivers/pinctrl/intel/pinctrl-lakefield.o
+00:00:40   CC      crypto/sha1_generic.o
+00:00:41   CC      mm/list_lru.o
+00:00:41   CC      arch/x86/xen/smp.o
+00:00:41   CC [M]  drivers/gpio/gpio-amdpt.o
+00:00:41   AR      kernel/time/built-in.a
+00:00:41   CC      security/tomoyo/realpath.o
+00:00:41   AR      drivers/pinctrl/mvebu/built-in.a
+00:00:41   CC [M]  sound/core/sound.o
+00:00:41   AR      fs/netfs/built-in.a
+00:00:41   CC [M]  sound/core/seq/oss/seq_oss_readq.o
+00:00:41   CC      fs/proc/bootconfig.o
+00:00:41   CC [M]  sound/drivers/opl3/opl3_synth.o
+00:00:41   CC      block/blk-stat.o
+00:00:41   CC [M]  sound/isa/sb/sb_common.o
+00:00:41   CC [M]  drivers/pinctrl/intel/pinctrl-lewisburg.o
+00:00:41   CC      security/selinux/ibpkey.o
+00:00:41   CC      crypto/sha256_generic.o
+00:00:41   CC [M]  drivers/gpio/gpio-arizona.o
+00:00:41   CC      drivers/pwm/core.o
+00:00:41   AR      fs/proc/built-in.a
+00:00:41   CC      fs/fscache/cache.o
+00:00:41   CC [M]  sound/core/seq/oss/seq_oss_writeq.o
+00:00:41   CC      net/core/request_sock.o
+00:00:41   CC      arch/x86/xen/smp_pv.o
+00:00:41   AR      virt/lib/built-in.a
+00:00:41   CC [M]  virt/lib/irqbypass.o
+00:00:41   CC [M]  sound/drivers/opl3/opl3_seq.o
+00:00:41   CC [M]  drivers/pinctrl/intel/pinctrl-sunrisepoint.o
+00:00:41   AR      kernel/sched/built-in.a
+00:00:41   CC      kernel/trace/trace_clock.o
+00:00:41   CC [M]  sound/isa/sb/sb_mixer.o
+00:00:41   CC      mm/workingset.o
+00:00:41   CC      block/blk-mq-sysfs.o
+00:00:42   CC      crypto/sha512_generic.o
+00:00:42   AR      virt/built-in.a
+00:00:42   CC      block/blk-mq-cpumap.o
+00:00:42   CC      security/tomoyo/securityfs_if.o
+00:00:42   LD [M]  sound/core/seq/oss/snd-seq-oss.o
+00:00:42   CC [M]  sound/core/seq/seq.o
+00:00:42   CC      kernel/trace/ftrace.o
+00:00:42   CC [M]  drivers/pinctrl/intel/pinctrl-tigerlake.o
+00:00:42   CC [M]  sound/drivers/opl3/opl3_midi.o
+00:00:42   CC      fs/fscache/cookie.o
+00:00:42   CC [M]  drivers/gpio/gpio-bd9571mwv.o
+00:00:42   CC      security/selinux/ima.o
+00:00:42   CC      drivers/pwm/sysfs.o
+00:00:42   LD [M]  sound/isa/sb/snd-sb-common.o
+00:00:42   CC [M]  sound/core/seq/seq_lock.o
+00:00:42   CC      net/core/skbuff.o
+00:00:42   CC      drivers/pwm/pwm-crc.o
+00:00:42   CC      crypto/sha3_generic.o
+00:00:42   AR      drivers/pinctrl/intel/built-in.a
+00:00:42   CC      security/lockdown/lockdown.o
+00:00:42   CC      mm/debug.o
+00:00:42   CC      block/blk-mq-sched.o
+00:00:42   AR      drivers/pinctrl/nomadik/built-in.a
+00:00:42   CC      arch/x86/xen/smp_hvm.o
+00:00:42   AR      drivers/pinctrl/sprd/built-in.a
+00:00:42   AR      drivers/pinctrl/ti/built-in.a
+00:00:42   AR      drivers/pinctrl/mediatek/built-in.a
+00:00:42   CC [M]  sound/drivers/opl3/opl3_drums.o
+00:00:42   AR      drivers/pinctrl/cirrus/built-in.a
+00:00:42   CC [M]  sound/core/seq/seq_clientmgr.o
+00:00:43   CC      drivers/pinctrl/core.o
+00:00:43   AR      security/selinux/built-in.a
+00:00:43   CC [M]  drivers/pwm/pwm-cros-ec.o
+00:00:43   CC      net/802/fc.o
+00:00:43   CC [M]  drivers/gpio/gpio-dln2.o
+00:00:43   CC      crypto/blake2b_generic.o
+00:00:43   CC [M]  sound/pci/ac97/ac97_codec.o
+00:00:43   CC      security/tomoyo/tomoyo.o
+00:00:43   AR      security/lockdown/built-in.a
+00:00:43   CC [M]  sound/pci/ali5451/ali5451.o
+00:00:43   CC      fs/fscache/fsdef.o
+00:00:43   CC [M]  sound/drivers/opl3/opl3_oss.o
+00:00:43   CC [M]  drivers/pwm/pwm-dwc.o
+00:00:43   CC      arch/x86/xen/spinlock.o
+00:00:43   CC      mm/gup.o
+00:00:43   CC [M]  drivers/gpio/gpio-exar.o
+00:00:43   CC      block/ioctl.o
+00:00:43   CC [M]  net/802/p8022.o
+00:00:43   CC      fs/fscache/io.o
+00:00:43   LD [M]  sound/drivers/opl3/snd-opl3-lib.o
+00:00:43   LD [M]  sound/drivers/opl3/snd-opl3-synth.o
+00:00:43   CC      crypto/gf128mul.o
+00:00:43   CC [M]  sound/drivers/mpu401/mpu401_uart.o
+00:00:44   CC      drivers/pinctrl/pinctrl-utils.o
+00:00:44   CC [M]  drivers/pwm/pwm-lpss.o
+00:00:44   CC [M]  sound/core/seq/seq_memory.o
+00:00:44   CC      arch/x86/xen/debugfs.o
+00:00:44   CC      security/tomoyo/util.o
+00:00:44   CC [M]  drivers/gpio/gpio-ich.o
+00:00:44   LD [M]  sound/pci/ali5451/snd-ali5451.o
+00:00:44   CC      drivers/pinctrl/pinmux.o
+00:00:44   CC      fs/fscache/main.o
+00:00:44   CC      crypto/ecb.o
+00:00:44   CC      kernel/trace/ring_buffer.o
+00:00:44   CC [M]  drivers/pwm/pwm-lpss-pci.o
+00:00:44   CC [M]  sound/drivers/mpu401/mpu401.o
+00:00:44   CC [M]  net/802/psnap.o
+00:00:44   CC      arch/x86/xen/vga.o
+00:00:44   CC      block/genhd.o
+00:00:44   CC [M]  sound/core/seq/seq_queue.o
+00:00:44   CC      crypto/cbc.o
+00:00:44   CC [M]  drivers/gpio/gpio-it87.o
+00:00:44   LD [M]  sound/drivers/mpu401/snd-mpu401-uart.o
+00:00:44   CC      arch/x86/xen/pci-swiotlb-xen.o
+00:00:44   LD [M]  sound/drivers/mpu401/snd-mpu401.o
+00:00:45   CC [M]  sound/drivers/vx/vx_core.o
+00:00:45   CC [M]  drivers/pwm/pwm-lpss-platform.o
+00:00:45   CC      drivers/pinctrl/pinconf.o
+00:00:45   CC      mm/mmap_lock.o
+00:00:45   CC      crypto/cts.o
+00:00:45   CC [M]  net/802/stp.o
+00:00:45   CC [M]  drivers/gpio/gpio-pca953x.o
+00:00:45   CC [M]  sound/core/seq/seq_fifo.o
+00:00:45   AR      drivers/pwm/built-in.a
+00:00:45   CC      security/tomoyo/common.o
+00:00:45   CC      arch/x86/xen/efi.o
+00:00:45   CC      drivers/pinctrl/pinconf-generic.o
+00:00:45   CC      fs/fscache/netfs.o
+00:00:45   CC      arch/x86/pci/i386.o
+00:00:45   CC      net/sched/sch_generic.o
+00:00:45   CC      block/ioprio.o
+00:00:45   CC [M]  sound/drivers/vx/vx_hwdep.o
+00:00:45   CC      crypto/lrw.o
+00:00:45   CC [M]  sound/core/seq/seq_prioq.o
+00:00:45   CC [M]  net/802/garp.o
+00:00:46   CC      mm/highmem.o
+00:00:46   CC      drivers/pinctrl/pinctrl-amd.o
+00:00:46   AR      arch/x86/xen/built-in.a
+00:00:46 make[2]: *** [Makefile:1906: arch/x86] Error 2
+00:00:46 make[2]: *** Waiting for unfinished jobs....
+00:00:46   CC      net/core/datagram.o
+00:00:46   CC      fs/fscache/object.o
+00:00:46   CC [M]  sound/pci/ac97/ac97_pcm.o
+00:00:46   CC      arch/x86/pci/init.o
+00:00:46   CC [M]  sound/drivers/vx/vx_pcm.o
+00:00:46   CC      kernel/trace/trace.o
+00:00:46   CC [M]  drivers/gpio/gpio-pca9570.o
+00:00:46   CC      crypto/xts.o
+00:00:46   CC      net/sched/sch_mq.o
+00:00:46   CC [M]  sound/core/seq/seq_timer.o
+00:00:46   CC      block/badblocks.o
+00:00:46   CC      mm/memory.o
+00:00:46   CC      arch/x86/pci/mmconfig_64.o
+00:00:46   CC [M]  net/802/mrp.o
+00:00:46   AR      drivers/pinctrl/built-in.a
+00:00:46   CC      security/bpf/hooks.o
+00:00:47   CC [M]  sound/pci/ac97/ac97_proc.o
+00:00:47   CC      fs/fscache/operation.o
+00:00:47   CC [M]  sound/core/seq/seq_system.o
+00:00:47   CC      crypto/ctr.o
+00:00:47   CC [M]  drivers/gpio/gpio-pci-idio-16.o
+00:00:47   CC      block/blk-rq-qos.o
+00:00:47   CC [M]  sound/drivers/vx/vx_mixer.o
+00:00:47   CC [M]  sound/pci/asihpi/asihpi.o
+00:00:47   AR      security/bpf/built-in.a
+00:00:47   CC      arch/x86/pci/direct.o
+00:00:47   CC      net/sched/sch_frag.o
+00:00:47   AR      kernel/bpf/preload/built-in.a
+00:00:47   CC      net/core/stream.o
+00:00:47   CC [M]  kernel/bpf/preload/bpf_preload_kern.o
+00:00:47   CC      crypto/gcm.o
+00:00:47   CC [M]  sound/core/seq/seq_ports.o
+00:00:47   AR      security/tomoyo/built-in.a
+00:00:47   CC      security/landlock/setup.o
+00:00:47   LD [M]  sound/pci/ac97/snd-ac97-codec.o
+00:00:47   CC [M]  drivers/gpio/gpio-virtio.o
+00:00:47   CC [M]  sound/pci/asihpi/hpioctl.o
+00:00:47   CC      block/disk-events.o
+00:00:47   AR      net/802/built-in.a
+00:00:47   CC [M]  sound/drivers/pcsp/pcsp.o
+00:00:47   CC      fs/fscache/page.o
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py --header \
+00:00:47 	--file /builds/9400817560/workdir/tools/include/uapi/linux/bpf.h > /builds/9400817560/workdir/kernel/bpf/preload/bpf_helper_defs.h
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:55: SyntaxWarning: invalid escape sequence '\w'
+00:00:47   arg_re = re.compile('((\w+ )*?(\w+|...))( (\**)(\w+))?$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:57: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   proto_re = re.compile('(.+) (\**)(\w+)\(((([^,]+)(, )?){1,5})\)$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:104: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?(.+)$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:108: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   end_re = re.compile(' \* ?NOTES$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:123: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?((.+) \**\w+\((((const )?(struct )?(\w+|\.\.\.)( \**\w+)?)(, )?){1,5}\))$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:131: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?(?:\t| {5,8})Description$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:145: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?(?:\t| {5,8})(?:\t| {8})(.*)')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:154: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?(?:\t| {5,8})Return$')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:168: SyntaxWarning: invalid escape sequence '\*'
+00:00:47   p = re.compile(' \* ?(?:\t| {5,8})(?:\t| {8})(.*)')
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:355: SyntaxWarning: invalid escape sequence '\ '
+00:00:47   footer = '''
+00:00:47 /builds/9400817560/workdir/scripts/bpf_doc.py:457: SyntaxWarning: invalid escape sequence '\ '
+00:00:47   one_arg += ' {}**\ '.format(a['star'].replace('*', '\\*'))
+00:00:47   CC [M]  sound/drivers/vx/vx_cmd.o
+00:00:48   CC      arch/x86/pci/mmconfig-shared.o
+00:00:48   CC      security/landlock/syscalls.o
+00:00:48   CC [M]  sound/core/seq/seq_info.o
+00:00:48   CC      crypto/ccm.o
+00:00:48   CC [M]  drivers/gpio/gpio-wcove.o
+00:00:48   CC [M]  sound/drivers/pcsp/pcsp_lib.o
+00:00:48   CC [M]  sound/drivers/vx/vx_uer.o
+00:00:48   CC      net/core/gen_stats.o
+00:00:48   CC      net/core/scm.o
+00:00:48   CC      net/sched/sch_api.o
+00:00:48   CC      block/bsg.o
+00:00:48   CC [M]  sound/core/seq/seq_dummy.o
+00:00:48   CC [M]  sound/pci/asihpi/hpimsginit.o
+00:00:48   CC      arch/x86/pci/xen.o
+00:00:48   CC      security/landlock/object.o
+00:00:48   CC      fs/fscache/proc.o
+00:00:49   LD [M]  drivers/gpio/gpio-generic.o
+00:00:49   AR      drivers/gpio/built-in.a
+00:00:49   LD [M]  sound/drivers/vx/snd-vx-lib.o
+00:00:49   CC [M]  sound/drivers/pcsp/pcsp_mixer.o
+00:00:49   CC [M]  sound/core/init.o
+00:00:49   CC [M]  sound/core/seq/seq_midi.o
+00:00:49   CC      drivers/pci/pcie/portdrv_core.o
+00:00:49   CC      security/landlock/ruleset.o
+00:00:49   CC [M]  sound/pci/asihpi/hpicmn.o
+00:00:49   CC      crypto/cryptd.o
+00:00:49   CC      block/bsg-lib.o
+00:00:49   CC      drivers/pci/hotplug/pci_hotplug_core.o
+00:00:49   CC [M]  sound/drivers/pcsp/pcsp_input.o
+00:00:49   CC      fs/fscache/stats.o
+00:00:49   CC      security/landlock/cred.o
+00:00:49   CC      net/core/gen_estimator.o
+00:00:49   CC [M]  sound/core/seq/seq_midi_emul.o
+00:00:49   CC      arch/x86/pci/fixup.o
+00:00:49   CC      drivers/pci/pcie/portdrv_pci.o
+00:00:49   LD [M]  sound/drivers/pcsp/snd-pcsp.o
+00:00:49   CC [M]  sound/drivers/dummy.o
+00:00:49   CC      net/sched/sch_blackhole.o
+00:00:49   CC      kernel/trace/trace_output.o
+00:00:49   CC [M]  sound/pci/asihpi/hpifunc.o
+00:00:49   CC      block/blk-cgroup.o
+00:00:50   CC      crypto/aes_generic.o
+00:00:50   CC      drivers/pci/hotplug/acpi_pcihp.o
+00:00:50   CC      security/landlock/ptrace.o
+00:00:50   AR      fs/fscache/built-in.a
+00:00:50   CC      fs/ext4/balloc.o
+00:00:50   CC      mm/mincore.o
+00:00:50   CC [M]  sound/core/seq/seq_midi_event.o
+00:00:50   CC      kernel/bpf/core.o
+00:00:50   CC      drivers/pci/pcie/err.o
+00:00:50   CC      arch/x86/pci/acpi.o
+00:00:50   CC      security/landlock/fs.o
+00:00:50   CC      net/core/net_namespace.o
+00:00:50   CC      net/sched/cls_api.o
+00:00:50   CC [M]  sound/drivers/aloop.o
+00:00:50   CC      drivers/pci/hotplug/pciehp_core.o
+00:00:50   CC [M]  sound/core/seq/seq_virmidi.o
+00:00:50   CC      crypto/deflate.o
+00:00:50   CC      drivers/pci/pcie/rcec.o
+00:00:51   CC      mm/mlock.o
+00:00:51   CC      kernel/trace/trace_seq.o
+00:00:51   CC      arch/x86/pci/legacy.o
+00:00:51   AR      security/landlock/built-in.a
+00:00:51   LD [M]  sound/core/seq/snd-seq.o
+00:00:51   CC      security/integrity/ima/ima_fs.o
+00:00:51   LD [M]  sound/core/seq/snd-seq-dummy.o
+00:00:51   CC      drivers/pci/hotplug/pciehp_ctrl.o
+00:00:51   LD [M]  sound/core/seq/snd-seq-midi.o
+00:00:51   LD [M]  sound/core/seq/snd-seq-midi-emul.o
+00:00:51   LD [M]  sound/core/seq/snd-seq-midi-event.o
+00:00:51   LD [M]  sound/core/seq/snd-seq-virmidi.o
+00:00:51   CC [M]  sound/core/memory.o
+00:00:51   CC      block/blk-cgroup-rwstat.o
+00:00:51   CC      crypto/crc32c_generic.o
+00:00:51   CC [M]  sound/pci/asihpi/hpidebug.o
+00:00:51   CC      fs/ext4/bitmap.o
+00:00:51   CC      kernel/trace/trace_stat.o
+00:00:51   CC      drivers/pci/pcie/aspm.o
+00:00:51   CC      arch/x86/pci/irq.o
+00:00:51   CC [M]  sound/core/control.o
+00:00:51   CC      crypto/crct10dif_common.o
+00:00:51   CC [M]  sound/drivers/virmidi.o
+00:00:51   CC      security/integrity/ima/ima_queue.o
+00:00:51   CC      drivers/pci/hotplug/pciehp_pci.o
+00:00:51   CC      net/core/secure_seq.o
+00:00:52   CC [M]  sound/pci/asihpi/hpidspcd.o
+00:00:52   CC      crypto/crct10dif_generic.o
+00:00:52   CC      block/blk-throttle.o
+00:00:52   CC      mm/mmap.o
+00:00:52   CC      security/integrity/evm/evm_main.o
+00:00:52   CC [M]  sound/drivers/serial-u16550.o
+00:00:52   CC      fs/ext4/block_validity.o
+00:00:52   CC      kernel/trace/trace_printk.o
+00:00:52   CC      crypto/authenc.o
+00:00:52   CC      drivers/pci/pcie/aer.o
+00:00:52   CC      drivers/pci/hotplug/pciehp_hpc.o
+00:00:52   CC [M]  sound/pci/asihpi/hpios.o
+00:00:52   CC      security/integrity/ima/ima_init.o
+00:00:52   CC      arch/x86/pci/numachip.o
+00:00:52   CC [M]  sound/drivers/mtpav.o
+00:00:52   CC      security/integrity/evm/evm_crypto.o
+00:00:52   CC      kernel/trace/pid_list.o
+00:00:53   CC      net/core/flow_dissector.o
+00:00:53   CC      fs/ext4/dir.o
+00:00:53   CC      net/sched/act_api.o
+00:00:53   CC [M]  sound/core/misc.o
+00:00:53   CC [M]  sound/pci/asihpi/hpi6000.o
+00:00:53   CC      security/integrity/ima/ima_main.o
+00:00:53   CC      crypto/authencesn.o
+00:00:53   CC      arch/x86/pci/common.o
+00:00:53   CC [M]  sound/drivers/mts64.o
+00:00:53   CC      drivers/pci/hotplug/shpchp_core.o
+00:00:53   CC      security/integrity/evm/evm_secfs.o
+00:00:53   CC      kernel/trace/tracing_map.o
+00:00:53   CC      drivers/pci/pcie/pme.o
+00:00:53   CC [M]  sound/core/device.o
+00:00:53   CC      block/blk-ioprio.o
+00:00:53   CC      security/integrity/evm/evm_posix_acl.o
+00:00:53   CC      arch/x86/pci/early.o
+00:00:54   CC [M]  sound/drivers/portman2x4.o
+00:00:54   CC [M]  sound/pci/asihpi/hpi6205.o
+00:00:54   CC      fs/ext4/ext4_jbd2.o
+00:00:54   CC      security/integrity/ima/ima_crypto.o
+00:00:54   CC      crypto/lzo.o
+00:00:54   CC      drivers/pci/hotplug/shpchp_ctrl.o
+00:00:54   CC [M]  sound/core/info.o
+00:00:54   CC      mm/mmu_gather.o
+00:00:54   CC      drivers/pci/pcie/dpc.o
+00:00:54   CC      block/blk-iolatency.o
+00:00:54   AR      security/integrity/evm/built-in.a
+00:00:54   CC      kernel/events/core.o
+00:00:54   CC      arch/x86/pci/bus_numa.o
+00:00:54   CC      kernel/trace/trace_sched_switch.o
+00:00:54   CC      crypto/lzo-rle.o
+00:00:54   LD [M]  sound/drivers/snd-dummy.o
+00:00:54   CC      net/sched/sch_fifo.o
+00:00:54   LD [M]  sound/drivers/snd-aloop.o
+00:00:54   LD [M]  sound/drivers/snd-virmidi.o
+00:00:54   LD [M]  sound/drivers/snd-serial-u16550.o
+00:00:54   LD [M]  sound/drivers/snd-mtpav.o
+00:00:54   LD [M]  sound/drivers/snd-mts64.o
+00:00:54   LD [M]  sound/drivers/snd-portman2x4.o
+00:00:54   CC      net/core/sysctl_net_core.o
+00:00:54   CC      kernel/events/ring_buffer.o
+00:00:54   CC [M]  sound/core/info_oss.o
+00:00:54   CC      drivers/pci/hotplug/shpchp_pci.o
+00:00:54   CC      drivers/pci/pcie/ptm.o
+00:00:54   CC      security/integrity/ima/ima_api.o
+00:00:55   CC      mm/mprotect.o
+00:00:55   CC      arch/x86/pci/amd_bus.o
+00:00:55   CC [M]  sound/pci/asihpi/hpimsgx.o
+00:00:55   CC      crypto/xxhash_generic.o
+00:00:55   CC      fs/ext4/extents.o
+00:00:55   CC      kernel/trace/trace_functions.o
+00:00:55   CC [M]  sound/core/isadma.o
+00:00:55   CC      crypto/842.o
+00:00:55   CC      net/sched/sch_fq_codel.o
+00:00:55   CC      drivers/pci/hotplug/shpchp_sysfs.o
+00:00:55   CC      drivers/pci/pcie/edr.o
+00:00:55   CC      block/blk-iocost.o
+00:00:55   CC      security/integrity/ima/ima_policy.o
+00:00:55   CC      net/netlink/af_netlink.o
+00:00:55   CC [M]  sound/core/sound_oss.o
+00:00:55   AR      arch/x86/pci/built-in.a
+00:00:55   CC      crypto/rng.o
+00:00:55   CC [U]  kernel/bpf/preload/iterators/iterators.o
+00:00:55   CC      net/core/dev.o
+00:00:55   AR      drivers/pci/controller/dwc/built-in.a
+00:00:55   AR      drivers/pci/controller/mobiveil/built-in.a
+00:00:55   CC [M]  drivers/pci/controller/pci-hyperv.o
+00:00:56   LD [M]  sound/pci/asihpi/snd-asihpi.o
+00:00:56   CC      drivers/pci/hotplug/shpchp_hpc.o
+00:00:56   CC [M]  sound/pci/au88x0/au8810.o
+00:00:56   CC [M]  drivers/pci/pcie/aer_inject.o
+00:00:56   CC      kernel/trace/trace_sched_wakeup.o
+00:00:56   CC      mm/mremap.o
+00:00:56   CC [M]  sound/core/vmaster.o
+00:00:56   CC      crypto/drbg.o
+00:00:56   CC      net/sched/cls_cgroup.o
+00:00:56   CC [M]  sound/core/ctljack.o
+00:00:56   AR      drivers/pci/pcie/built-in.a
+00:00:56   CC      drivers/video/console/dummycon.o
+00:00:56   CC      drivers/pci/hotplug/acpiphp_core.o
+00:00:56   CC      security/integrity/ima/ima_template.o
+00:00:57   CC      kernel/trace/trace_hwlat.o
+00:00:57   CC [M]  sound/core/jack.o
+00:00:57   CC [M]  drivers/pci/controller/pci-hyperv-intf.o
+00:00:57   CC      drivers/video/console/vgacon.o
+00:00:57   CC      mm/msync.o
+00:00:57   CC      drivers/pci/hotplug/acpiphp_glue.o
+00:00:57   CC      block/mq-deadline.o
+00:00:57   CC      security/integrity/ima/ima_template_lib.o
+00:00:57   CC      crypto/jitterentropy.o
+00:00:57   CC [M]  sound/core/control_led.o
+00:00:57   CC      net/sched/ematch.o
+00:00:57   CC [M]  drivers/pci/controller/vmd.o
+00:00:57   CC      crypto/jitterentropy-kcapi.o
+00:00:57   CC      net/netlink/genetlink.o
+00:00:57   CC      kernel/trace/trace_osnoise.o
+00:00:58   CC      mm/page_vma_mapped.o
+00:00:58   CC [M]  sound/pci/au88x0/au8820.o
+00:00:58   CC      crypto/ghash-generic.o
+00:00:58   AR      drivers/video/console/built-in.a
+00:00:58   CC      drivers/video/logo/logo.o
+00:00:58   CC [M]  sound/core/hwdep.o
+00:00:58   CC      security/integrity/ima/ima_appraise.o
+00:00:58   CC [M]  drivers/pci/hotplug/acpiphp_ibm.o
+00:00:58   CC      crypto/af_alg.o
+00:00:58   CC      fs/ext4/extents_status.o
+00:00:58   AR      drivers/pci/controller/built-in.a
+00:00:58   CC [M]  net/sched/act_police.o
+00:00:58   CC [M]  sound/core/timer.o
+00:00:58   HOSTCC  drivers/video/logo/pnmtologo
+00:00:58   CC      block/kyber-iosched.o
+00:00:58   LOGO    drivers/video/logo/logo_linux_clut224.c
+00:00:58   CC      drivers/video/logo/logo_linux_clut224.o
+00:00:58   CC      mm/pagewalk.o
+00:00:58   AR      drivers/video/logo/built-in.a
+00:00:59   CC      fs/ext4/file.o
+00:00:59   CC      drivers/video/backlight/backlight.o
+00:00:59   AR      drivers/pci/hotplug/built-in.a
+00:00:59   AR      drivers/pci/switch/built-in.a
+00:00:59   CC [M]  drivers/pci/switch/switchtec.o
+00:00:59   CC      security/integrity/ima/ima_modsig.o
+00:00:59   CC      net/netlink/policy.o
+00:00:59   CC      kernel/trace/trace_nop.o
+00:00:59   CC [M]  net/sched/act_gact.o
+00:00:59   CC      kernel/events/callchain.o
+00:00:59   CC      mm/pgtable-generic.o
+00:00:59   CC      security/integrity/ima/ima_asymmetric_keys.o
+00:00:59   CC [M]  sound/pci/au88x0/au8830.o
+00:00:59   CC      kernel/trace/trace_stack.o
+00:00:59   CC [M]  drivers/video/backlight/lcd.o
+00:00:59   CC [M]  sound/core/hrtimer.o
+00:00:59   CC      crypto/algif_hash.o
+00:00:59   CC      net/netlink/diag.o
+00:01:00   CC      kernel/bpf/syscall.o
+00:01:00   CC      block/bfq-iosched.o
+00:01:00   CC      drivers/pci/access.o
+00:01:00   CC      fs/ext4/fsmap.o
+00:01:00   CC      kernel/events/hw_breakpoint.o
+00:01:00   CC      security/integrity/ima/ima_queue_keys.o
+00:01:00   CC [M]  sound/core/pcm.o
+00:01:00   CC [M]  net/sched/act_mirred.o
+00:01:00   CC      mm/rmap.o
+00:01:00   CC      kernel/trace/trace_mmiotrace.o
+00:01:00   CC [M]  drivers/video/backlight/platform_lcd.o
+00:01:00   CC      security/integrity/ima/ima_efi.o
+00:01:00   CC      drivers/pci/bus.o
+00:01:00   AR      net/netlink/built-in.a
+00:01:01   CC      security/integrity/iint.o
+00:01:01   CC      kernel/events/uprobes.o
+00:01:01   CC      crypto/algif_skcipher.o
+00:01:01   CC [M]  sound/core/pcm_native.o
+00:01:01 rm -f /builds/9400817560/workdir/kernel/bpf/preload/libbpf.a; ar rcs /builds/9400817560/workdir/kernel/bpf/preload/libbpf.a /builds/9400817560/workdir/kernel/bpf/preload/staticobjs/libbpf-in.o
+00:01:01   LD [U]  kernel/bpf/preload/bpf_preload_umd
+00:01:01   CC [M]  net/sched/act_sample.o
+00:01:01   AS [M]  kernel/bpf/preload/bpf_preload_umd_blob.o
+00:01:01   CC      kernel/trace/trace_functions_graph.o
+00:01:01   LD [M]  kernel/bpf/preload/bpf_preload.o
+00:01:01   CC      kernel/fork.o
+00:01:01   CC      net/core/dev_addr_lists.o
+00:01:01   CC [M]  drivers/video/backlight/apple_bl.o
+00:01:01   CC      security/commoncap.o
+00:01:01   CC      fs/ext4/fsync.o
+00:01:01   CC      drivers/pci/probe.o
+00:01:01   AR      security/integrity/ima/built-in.a
+00:01:01   CC      security/integrity/integrity_audit.o
+00:01:02   CC      mm/vmalloc.o
+00:01:02   CC      crypto/algif_rng.o
+00:01:02   LD [M]  sound/pci/au88x0/snd-au8810.o
+00:01:02   LD [M]  sound/pci/au88x0/snd-au8820.o
+00:01:02   CC      security/integrity/digsig.o
+00:01:02   LD [M]  sound/pci/au88x0/snd-au8830.o
+00:01:02   CC [M]  net/sched/act_nat.o
+00:01:02   CC [M]  sound/pci/ctxfi/xfi.o
+00:01:02   CC [M]  drivers/video/backlight/ktd253-backlight.o
+00:01:02   CC      kernel/trace/blktrace.o
+00:01:02   CC      net/core/dst.o
+00:01:02   CC      kernel/bpf/verifier.o
+00:01:02   AR      kernel/events/built-in.a
+00:01:02   CC [M]  sound/pci/ctxfi/ctatc.o
+00:01:02   CC      block/bfq-wf2q.o
+00:01:02   CC      fs/ext4/hash.o
+00:01:02   CC [M]  net/sched/act_pedit.o
+00:01:02   CC      security/integrity/digsig_asymmetric.o
+00:01:02   CC      block/bfq-cgroup.o
+00:01:03   CC      drivers/pci/host-bridge.o
+00:01:03   CC [M]  drivers/video/backlight/lp855x_bl.o
+00:01:03   CC      crypto/algif_aead.o
+00:01:03   CC [M]  sound/core/pcm_lib.o
+00:01:03   CC      security/integrity/platform_certs/platform_keyring.o
+00:01:03   CC      drivers/idle/intel_idle.o
+00:01:03   CC      fs/ext4/ialloc.o
+00:01:03   CC      net/core/netevent.o
+00:01:03   CC      drivers/video/fbdev/core/fb_cmdline.o
+00:01:03   CC      drivers/pci/remove.o
+00:01:03   CC [M]  sound/pci/ctxfi/ctvmem.o
+00:01:03   CC      security/integrity/platform_certs/efi_parser.o
+00:01:03   AR      drivers/video/fbdev/omap2/omapfb/dss/built-in.a
+00:01:03   CC      block/bio-integrity.o
+00:01:03   AR      drivers/video/fbdev/omap2/omapfb/displays/built-in.a
+00:01:03   AR      drivers/video/fbdev/omap2/omapfb/built-in.a
+00:01:03   AR      drivers/video/fbdev/omap2/built-in.a
+00:01:03   CC      kernel/trace/fgraph.o
+00:01:03   CC      net/bpf/test_run.o
+00:01:03   CC [M]  net/sched/act_simple.o
+00:01:03   CC [M]  drivers/video/backlight/pwm_bl.o
+00:01:04   CC      security/integrity/platform_certs/load_uefi.o
+00:01:04   CC      drivers/pci/pci.o
+00:01:04   CC      crypto/ecc.o
+00:01:04   CC      net/core/neighbour.o
+00:01:04   CC [M]  sound/pci/ctxfi/ctpcm.o
+00:01:04   CC      drivers/video/fbdev/core/fb_notify.o
+00:01:04   AR      drivers/idle/built-in.a
+00:01:04   CC [M]  sound/pci/ctxfi/ctmixer.o
+00:01:04   CC      mm/process_vm_access.o
+00:01:04   CC      block/blk-integrity.o
+00:01:04   CC [M]  sound/core/pcm_misc.o
+00:01:04   CC      security/integrity/platform_certs/keyring_handler.o
+00:01:04   CC [M]  net/sched/act_skbedit.o
+00:01:04   CC      kernel/trace/trace_events.o
+00:01:04   CC [M]  drivers/video/backlight/rt4831-backlight.o
+00:01:04   CC [M]  sound/pci/ca0106/ca0106_main.o
+00:01:05   CC      drivers/video/fbdev/core/fbmem.o
+00:01:05   CC      mm/page_alloc.o
+00:01:05   CC [M]  sound/pci/ctxfi/ctresource.o
+00:01:05   CC [M]  sound/core/pcm_memory.o
+00:01:05   AR      security/integrity/built-in.a
+00:01:05   CC      security/min_addr.o
+00:01:05   CC      fs/ext4/indirect.o
+00:01:05   AR      net/bpf/built-in.a
+00:01:05   CC      mm/shuffle.o
+00:01:05   CC      block/t10-pi.o
+00:01:05   CC [M]  drivers/video/backlight/arcxcnn_bl.o
+00:01:05   CC      security/security.o
+00:01:05   CC [M]  sound/pci/ctxfi/ctsrc.o
+00:01:05   CC      crypto/ecdh.o
+00:01:05   CC [M]  sound/core/memalloc.o
+00:01:05   CC      fs/ext4/inline.o
+00:01:05   CC [M]  net/sched/act_csum.o
+00:01:05   CC [M]  sound/pci/ca0106/ca0106_mixer.o
+00:01:06   CC      block/blk-mq-pci.o
+00:01:06   CC      crypto/ecdh_helper.o
+00:01:06   AR      drivers/video/backlight/built-in.a
+00:01:06   CC [M]  sound/core/pcm_timer.o
+00:01:06   CC      kernel/exec_domain.o
+00:01:06   CC [M]  sound/pci/ctxfi/ctamixer.o
+00:01:06   CC      drivers/video/fbdev/core/fbmon.o
+00:01:06   CC      drivers/pci/pci-driver.o
+00:01:06   CC      kernel/trace/trace_export.o
+00:01:06   CC      crypto/xor.o
+00:01:06   CC [M]  sound/pci/ca0106/ca_midi.o
+00:01:06   CC      net/core/rtnetlink.o
+00:01:06   CC [M]  sound/pci/ctxfi/ctdaio.o
+00:01:06   CC      block/blk-mq-virtio.o
+00:01:06   CC [M]  sound/core/sgbuf.o
+00:01:07   CC      crypto/hash_info.o
+00:01:07   CC      drivers/video/fbdev/xen-fbfront.o
+00:01:07   CC [M]  sound/pci/ca0106/ca0106_proc.o
+00:01:07   CC      crypto/simd.o
+00:01:07   CC [M]  net/sched/act_mpls.o
+00:01:07   CC      drivers/pci/search.o
+00:01:07   CC      kernel/trace/trace_syscalls.o
+00:01:07   CC      fs/ext4/inode.o
+00:01:07   CC [M]  sound/core/pcm_drm_eld.o
+00:01:07   CC [M]  sound/pci/ctxfi/ctimap.o
+00:01:07   CC      block/blk-mq-rdma.o
+00:01:07   CC [M]  crypto/crypto_engine.o
+00:01:07   LD [M]  sound/pci/ca0106/snd-ca0106.o
+00:01:07   CC [M]  crypto/echainiv.o
+00:01:07   CC      kernel/panic.o
+00:01:07   CC      drivers/video/fbdev/core/fbcmap.o
+00:01:07   CC [M]  sound/pci/ctxfi/cthardware.o
+00:01:07   CC      drivers/pci/pci-sysfs.o
+00:01:07   CC      security/inode.o
+00:01:08   CC [M]  sound/core/pcm_dmaengine.o
+00:01:08   CC      kernel/bpf/inode.o
+00:01:08   CC      net/ethtool/ioctl.o
+00:01:08   CC      kernel/trace/trace_event_perf.o
+00:01:08   CC      mm/init-mm.o
+00:01:08   CC [M]  net/sched/act_vlan.o
+00:01:08   CC [M]  crypto/crypto_user_base.o
+00:01:08   CC [M]  sound/pci/ctxfi/cttimer.o
+00:01:08   CC      security/lsm_audit.o
+00:01:08   CC      net/ethtool/common.o
+00:01:08   CC      block/blk-zoned.o
+00:01:08   CC [M]  sound/synth/emux/emux.o
+00:01:08   CC      drivers/video/fbdev/core/fbsysfs.o
+00:01:08   CC [M]  sound/core/seq_device.o
+00:01:08   CC      drivers/pci/rom.o
+00:01:08   CC      kernel/trace/trace_events_filter.o
+00:01:09   CC [M]  sound/pci/ctxfi/cthw20k2.o
+00:01:09   CC [M]  sound/synth/emux/emux_synth.o
+00:01:09   CC [M]  net/sched/act_bpf.o
+00:01:09   CC      kernel/bpf/helpers.o
+00:01:09   CC      mm/memblock.o
+00:01:09   CC [M]  sound/core/rawmidi.o
+00:01:09   CC [M]  sound/usb/misc/ua101.o
+00:01:09   CC      drivers/pci/setup-res.o
+00:01:09   CC [M]  crypto/xcbc.o
+00:01:09   CC      block/blk-wbt.o
+00:01:09   CC      drivers/video/fbdev/core/modedb.o
+00:01:09   CC      security/device_cgroup.o
+00:01:09   CC [M]  sound/synth/emux/emux_seq.o
+00:01:09   CC [M]  crypto/md4.o
+00:01:09   CC      net/core/utils.o
+00:01:10   CC      drivers/pci/irq.o
+00:01:10   CC      mm/memory_hotplug.o
+00:01:10   CC [M]  sound/pci/ctxfi/cthw20k1.o
+00:01:10   CC      kernel/trace/trace_events_trigger.o
+00:01:10   CC [M]  net/sched/act_connmark.o
+00:01:10   CC [M]  sound/synth/emux/emux_nrpn.o
+00:01:10   CC      net/ethtool/netlink.o
+00:01:10   CC [M]  crypto/rmd160.o
+00:01:10   CC      kernel/bpf/tnum.o
+00:01:10   LD [M]  sound/usb/misc/snd-ua101.o
+00:01:10   AR      security/built-in.a
+00:01:10   CC      drivers/video/hdmi.o
+00:01:10   CC [M]  sound/usb/usx2y/usbusx2y.o
+00:01:10   CC      kernel/bpf/bpf_iter.o
+00:01:10   CC [M]  sound/core/compress_offload.o
+00:01:10   CC      drivers/pci/vpd.o
+00:01:10   CC [M]  sound/synth/emux/emux_effect.o
+00:01:10   CC      drivers/video/fbdev/core/fbcvt.o
+00:01:10   CC      block/blk-mq-debugfs.o
+00:01:10   CC      net/core/link_watch.o
+00:01:10   CC      fs/ext4/ioctl.o
+00:01:10   CC [M]  crypto/streebog_generic.o
+00:01:11   CC [M]  sound/usb/usx2y/usX2Yhwdep.o
+00:01:11   CC [M]  sound/synth/emux/emux_hwdep.o
+00:01:11   CC      drivers/char/ipmi/ipmi_dmi.o
+00:01:11   CC      kernel/trace/trace_eprobe.o
+00:01:11   CC [M]  net/sched/act_ctinfo.o
+00:01:11   CC      drivers/pci/setup-bus.o
+00:01:11   LD [M]  sound/pci/ctxfi/snd-ctxfi.o
+00:01:11   CC [M]  sound/pci/cs46xx/cs46xx.o
+00:01:11   LD [M]  sound/core/snd.o
+00:01:11   CC      net/ethtool/bitset.o
+00:01:11   CC      kernel/bpf/map_iter.o
+00:01:11   LD [M]  sound/core/snd-ctl-led.o
+00:01:11   LD [M]  sound/core/snd-hwdep.o
+00:01:11   LD [M]  sound/core/snd-timer.o
+00:01:11   LD [M]  sound/core/snd-hrtimer.o
+00:01:11   LD [M]  sound/core/snd-pcm.o
+00:01:11   LD [M]  sound/core/snd-pcm-dmaengine.o
+00:01:11   LD [M]  sound/core/snd-seq-device.o
+00:01:11   LD [M]  sound/core/snd-rawmidi.o
+00:01:11   CC      drivers/video/fbdev/core/fb_defio.o
+00:01:11   LD [M]  sound/core/snd-compress.o
+00:01:11   CC [M]  crypto/wp512.o
+00:01:11   CC [M]  sound/synth/emux/soundfont.o
+00:01:11   CC      kernel/bpf/task_iter.o
+00:01:11   CC      mm/madvise.o
+00:01:11   CC      block/blk-mq-debugfs-zoned.o
+00:01:11   CC      drivers/char/ipmi/ipmi_plat_data.o
+00:01:11   CC [M]  sound/usb/usx2y/usx2yhwdeppcm.o
+00:01:11   CC [M]  sound/pci/cs46xx/cs46xx_lib.o
+00:01:11   CC      net/core/filter.o
+00:01:12   CC [M]  drivers/char/ipmi/ipmi_msghandler.o
+00:01:12   CC      block/sed-opal.o
+00:01:12   CC [M]  crypto/pcbc.o
+00:01:12   CC      net/core/sock_diag.o
+00:01:12   CC      drivers/video/fbdev/core/fbcon.o
+00:01:12   CC [M]  sound/synth/emux/emux_proc.o
+00:01:12   CC      kernel/trace/trace_events_synth.o
+00:01:12   CC      kernel/bpf/prog_iter.o
+00:01:12   CC [M]  net/sched/act_skbmod.o
+00:01:12   CC      fs/ext4/mballoc.o
+00:01:12   CC [M]  crypto/adiantum.o
+00:01:12   CC      net/ethtool/strset.o
+00:01:12   CC      drivers/pci/vc.o
+00:01:12   CC [M]  sound/synth/emux/emux_oss.o
+00:01:12   CC [M]  sound/usb/usx2y/us122l.o
+00:01:12   CC      mm/page_io.o
+00:01:13   CC      kernel/bpf/hashtab.o
+00:01:13   CC [M]  crypto/nhpoly1305.o
+00:01:13   CC [M]  net/sched/act_ife.o
+00:01:13   LD [M]  sound/synth/emux/snd-emux-synth.o
+00:01:13   CC [M]  sound/synth/util_mem.o
+00:01:13   CC      drivers/pci/mmap.o
+00:01:13   CC      block/blk-pm.o
+00:01:13   CC [M]  sound/pci/cs46xx/dsp_spos.o
+00:01:13   CC [M]  crypto/chacha20poly1305.o
+00:01:13   CC      kernel/cpu.o
+00:01:13   LD [M]  sound/synth/snd-util-mem.o
+00:01:13   CC [M]  sound/usb/caiaq/device.o
+00:01:13   CC      net/ethtool/linkinfo.o
+00:01:13   CC      kernel/trace/trace_events_hist.o
+00:01:13   LD [M]  sound/usb/usx2y/snd-usb-usx2y.o
+00:01:13   LD [M]  sound/usb/usx2y/snd-usb-us122l.o
+00:01:13   CC      mm/swap_state.o
+00:01:13   CC      drivers/acpi/acpica/dsargs.o
+00:01:13   CC      drivers/pci/setup-irq.o
+00:01:13   CC      block/keyslot-manager.o
+00:01:14   CC [M]  drivers/char/ipmi/ipmi_devintf.o
+00:01:14   CC      drivers/acpi/acpica/dscontrol.o
+00:01:14   CC      drivers/video/fbdev/core/bitblit.o
+00:01:14   CC [M]  net/sched/act_meta_mark.o
+00:01:14   CC [M]  crypto/aegis128-core.o
+00:01:14   CC [M]  sound/usb/caiaq/audio.o
+00:01:14   CC      drivers/pci/msi.o
+00:01:14   CC      drivers/acpi/acpica/dsdebug.o
+00:01:14   CC      net/ethtool/linkmodes.o
+00:01:14   CC [M]  sound/pci/cs46xx/dsp_spos_scb_lib.o
+00:01:14   CC [M]  drivers/char/ipmi/ipmi_si_intf.o
+00:01:14   CC      kernel/bpf/arraymap.o
+00:01:14   CC      block/blk-crypto.o
+00:01:14   CC      drivers/acpi/acpica/dsfield.o
+00:01:14   CC      mm/swapfile.o
+00:01:14   CC [M]  net/sched/act_meta_skbprio.o
+00:01:15   CC [M]  crypto/pcrypt.o
+00:01:15   CC      drivers/video/fbdev/core/softcursor.o
+00:01:15   CC      drivers/pnp/pnpacpi/core.o
+00:01:15   CC [M]  sound/usb/caiaq/midi.o
+00:01:15   CC      drivers/acpi/acpica/dsinit.o
+00:01:15   CC      drivers/pci/proc.o
+00:01:15   CC      block/holder.o
+00:01:15   CC [M]  crypto/des_generic.o
+00:01:15   LD [M]  sound/pci/cs46xx/snd-cs46xx.o
+00:01:15   CC      net/ethtool/linkstate.o
+00:01:15   CC [M]  sound/pci/lola/lola.o
+00:01:15   CC [M]  net/sched/act_meta_skbtcindex.o
+00:01:15   CC      drivers/acpi/acpica/dsmethod.o
+00:01:15   CC [M]  drivers/char/ipmi/ipmi_kcs_sm.o
+00:01:15   CC      drivers/pnp/pnpacpi/rsparser.o
+00:01:15   CC [M]  sound/usb/caiaq/control.o
+00:01:15   CC [M]  crypto/fcrypt.o
+00:01:15   CC      drivers/video/fbdev/core/tileblit.o
+00:01:15   CC      kernel/bpf/percpu_freelist.o
+00:01:15   CC      kernel/trace/bpf_trace.o
+00:01:16   AR      block/built-in.a
+00:01:16   CC      drivers/acpi/acpica/dsmthdat.o
+00:01:16   CC [M]  net/netfilter/ipset/ip_set_core.o
+00:01:16   CC      drivers/pci/slot.o
+00:01:16   CC      kernel/bpf/bpf_lru_list.o
+00:01:16   CC      fs/ext4/migrate.o
+00:01:16   CC [M]  crypto/blowfish_generic.o
+00:01:16   CC [M]  drivers/char/ipmi/ipmi_smic_sm.o
+00:01:16   CC [M]  net/sched/act_tunnel_key.o
+00:01:16   CC [M]  sound/usb/caiaq/input.o
+00:01:16   CC [M]  sound/pci/lola/lola_pcm.o
+00:01:16   CC      drivers/acpi/acpica/dsobject.o
+00:01:16   AR      drivers/pnp/pnpacpi/built-in.a
+00:01:16   CC      drivers/pnp/core.o
+00:01:16   CC      net/ethtool/debug.o
+00:01:16   CC      kernel/bpf/lpm_trie.o
+00:01:16   CC      drivers/pci/pci-acpi.o
+00:01:16   CC      drivers/video/fbdev/core/fbcon_rotate.o
+00:01:16   CC      drivers/acpi/acpica/dsopcode.o
+00:01:16   CC [M]  crypto/blowfish_common.o
+00:01:16   CC [M]  drivers/char/ipmi/ipmi_bt_sm.o
+00:01:17   CC      drivers/pnp/card.o
+00:01:17   LD [M]  sound/usb/caiaq/snd-usb-caiaq.o
+00:01:17   CC      fs/ext4/mmp.o
+00:01:17   CC [M]  sound/usb/6fire/chip.o
+00:01:17   CC [M]  sound/pci/lola/lola_clock.o
+00:01:17   CC      mm/swap_slots.o
+00:01:17   CC      drivers/acpi/acpica/dspkginit.o
+00:01:17   CC      net/core/dev_ioctl.o
+00:01:17   CC [M]  crypto/twofish_generic.o
+00:01:17   CC      net/ethtool/wol.o
+00:01:17   CC [M]  drivers/char/ipmi/ipmi_si_hotmod.o
+00:01:17   CC      drivers/video/fbdev/core/fbcon_cw.o
+00:01:17   CC      drivers/pci/quirks.o
+00:01:17   CC [M]  net/sched/act_ct.o
+00:01:17   CC      kernel/trace/trace_kprobe.o
+00:01:17   CC      drivers/acpi/acpica/dsutils.o
+00:01:17   CC [M]  sound/usb/6fire/comm.o
+00:01:17   CC      drivers/pnp/driver.o
+00:01:17   CC [M]  sound/pci/lola/lola_mixer.o
+00:01:17   CC      kernel/bpf/map_in_map.o
+00:01:17   CC      fs/ext4/move_extent.o
+00:01:17   CC      mm/dmapool.o
+00:01:17   CC [M]  net/netfilter/ipset/ip_set_getport.o
+00:01:17   CC [M]  crypto/twofish_common.o
+00:01:18   CC [M]  drivers/char/ipmi/ipmi_si_hardcode.o
+00:01:18   CC      drivers/acpi/acpica/dswexec.o
+00:01:18   CC [M]  sound/usb/6fire/midi.o
+00:01:18   CC      drivers/pnp/resource.o
+00:01:18   CC      kernel/bpf/local_storage.o
+00:01:18   CC      net/ethtool/features.o
+00:01:18   LD [M]  sound/pci/lola/snd-lola.o
+00:01:18   CC      net/core/tso.o
+00:01:18   CC      mm/hugetlb.o
+00:01:18   CC      drivers/video/fbdev/core/fbcon_ud.o
+00:01:18   CC      drivers/acpi/acpica/dswload.o
+00:01:18   CC [M]  sound/pci/lx6464es/lx6464es.o
+00:01:18   CC [M]  drivers/char/ipmi/ipmi_si_platform.o
+00:01:18   CC [M]  sound/usb/6fire/control.o
+00:01:18   CC      fs/ext4/namei.o
+00:01:18   CC      drivers/acpi/acpica/dswload2.o
+00:01:18   CC      drivers/pnp/manager.o
+00:01:18   CC [M]  net/netfilter/ipset/pfxlen.o
+00:01:19   CC      kernel/trace/error_report-traces.o
+00:01:19   CC [M]  drivers/char/ipmi/ipmi_si_port_io.o
+00:01:19   CC      kernel/bpf/queue_stack_maps.o
+00:01:19   CC [M]  sound/usb/6fire/firmware.o
+00:01:19   CC [M]  sound/pci/lx6464es/lx_core.o
+00:01:19   CC      drivers/acpi/acpica/dswscope.o
+00:01:19   CC      net/ethtool/privflags.o
+00:01:19   CC [M]  net/sched/act_gate.o
+00:01:19   CC      drivers/pnp/support.o
+00:01:19   CC      drivers/video/fbdev/core/fbcon_ccw.o
+00:01:19   CC      net/core/sock_reuseport.o
+00:01:19   CC      drivers/pci/ats.o
+00:01:19   CC [M]  crypto/serpent_generic.o
+00:01:19   CC [M]  drivers/char/ipmi/ipmi_si_mem_io.o
+00:01:19   CC      drivers/acpi/acpica/dswstate.o
+00:01:19   CC      kernel/trace/power-traces.o
+00:01:19   CC      kernel/bpf/ringbuf.o
+00:01:19   CC [M]  sound/usb/6fire/pcm.o
+00:01:19   CC      drivers/pnp/interface.o
+00:01:20   CC [M]  net/netfilter/ipset/ip_set_bitmap_ip.o
+00:01:20   CC      drivers/acpi/acpica/evevent.o
+00:01:20   CC [M]  drivers/char/ipmi/ipmi_si_pci.o
+00:01:20   CC      drivers/pci/iov.o
+00:01:20   LD [M]  sound/pci/lx6464es/snd-lx6464es.o
+00:01:20   CC [M]  sound/pci/echoaudio/darla20.o
+00:01:20   CC [M]  net/sched/sch_htb.o
+00:01:20   CC      net/ethtool/rings.o
+00:01:20   CC      drivers/pnp/quirks.o
+00:01:20   CC      drivers/video/fbdev/core/cfbfillrect.o
+00:01:20   CC      drivers/acpi/acpica/evgpe.o
+00:01:20   LD [M]  sound/usb/6fire/snd-usb-6fire.o
+00:01:20   CC [M]  crypto/aes_ti.o
+00:01:20   CC [M]  sound/usb/hiface/chip.o
+00:01:20   CC      kernel/bpf/bpf_local_storage.o
+00:01:20   CC      net/core/fib_notifier.o
+00:01:20   CC [M]  drivers/char/ipmi/ipmi_ssif.o
+00:01:20   CC [M]  crypto/camellia_generic.o
+00:01:20   CC      drivers/acpi/acpica/evgpeblk.o
+00:01:21   CC      kernel/trace/rpm-traces.o
+00:01:21   CC      drivers/pci/pci-label.o
+00:01:21   CC      drivers/pnp/system.o
+00:01:21   CC [M]  sound/usb/hiface/pcm.o
+00:01:21   CC [M]  net/netfilter/ipset/ip_set_bitmap_ipmac.o
+00:01:21   CC      net/ethtool/channels.o
+00:01:21   CC      drivers/acpi/acpica/evgpeinit.o
+00:01:21   CC      drivers/video/fbdev/core/cfbcopyarea.o
+00:01:21   CC      net/core/xdp.o
+00:01:21   CC [M]  sound/pci/echoaudio/gina20.o
+00:01:21   AR      drivers/pnp/built-in.a
+00:01:21   CC [M]  net/netfilter/ipset/ip_set_bitmap_port.o
+00:01:21   CC      fs/ext4/page-io.o
+00:01:21   CC      drivers/pci/pci-stub.o
+00:01:21   CC      drivers/acpi/acpica/evgpeutil.o
+00:01:21   CC      kernel/bpf/bpf_task_storage.o
+00:01:21   CC      kernel/trace/trace_dynevent.o
+00:01:21   LD [M]  sound/usb/hiface/snd-usb-hiface.o
+00:01:21   CC [M]  sound/usb/bcd2000/bcd2000.o
+00:01:21   CC      mm/hugetlb_vmemmap.o
+00:01:21   CC [M]  net/sched/sch_hfsc.o
+00:01:22   CC [M]  drivers/char/ipmi/ipmi_watchdog.o
+00:01:22   CC [M]  crypto/cast_common.o
+00:01:22   CC      drivers/acpi/acpica/evglock.o
+00:01:22   CC      drivers/pci/p2pdma.o
+00:01:22   CC      net/ethtool/coalesce.o
+00:01:22   CC      drivers/video/fbdev/core/cfbimgblt.o
+00:01:22   CC [M]  crypto/cast5_generic.o
+00:01:22   LD [M]  sound/usb/bcd2000/snd-bcd2000.o
+00:01:22   CC      mm/mempolicy.o
+00:01:22   CC [M]  sound/usb/line6/capture.o
+00:01:22   CC      kernel/trace/trace_probe.o
+00:01:22   CC      drivers/acpi/acpica/evhandler.o
+00:01:22   CC [M]  drivers/pci/pci-pf-stub.o
+00:01:22   CC      kernel/bpf/bpf_inode_storage.o
+00:01:22   CC      fs/ext4/readpage.o
+00:01:22   CC [M]  net/netfilter/ipset/ip_set_hash_ip.o
+00:01:22   CC      net/core/flow_offload.o
+00:01:22   CC [M]  drivers/char/ipmi/ipmi_poweroff.o
+00:01:22   CC [M]  sound/pci/echoaudio/layla20.o
+00:01:22   CC      drivers/acpi/acpica/evmisc.o
+00:01:22   CC [M]  crypto/cast6_generic.o
+00:01:23   CC [M]  sound/usb/card.o
+00:01:23   CC [M]  drivers/pci/xen-pcifront.o
+00:01:23   CC [M]  sound/usb/line6/driver.o
+00:01:23   CC      drivers/video/fbdev/core/sysfillrect.o
+00:01:23   CC [M]  net/sched/sch_red.o
+00:01:23   CC      drivers/acpi/acpica/evregion.o
+00:01:23   CC      net/ethtool/pause.o
+00:01:23   CC [M]  crypto/chacha_generic.o
+00:01:23   LD [M]  drivers/char/ipmi/ipmi_si.o
+00:01:23   AR      drivers/char/ipmi/built-in.a
+00:01:23   CC      drivers/acpi/numa/srat.o
+00:01:23   CC      kernel/bpf/disasm.o
+00:01:23   CC      fs/ext4/resize.o
+00:01:23   CC      kernel/trace/trace_uprobe.o
+00:01:23   CC      net/core/net-sysfs.o
+00:01:23   CC      drivers/acpi/acpica/evrgnini.o
+00:01:23   CC [M]  crypto/poly1305_generic.o
+00:01:23   CC [M]  sound/usb/line6/midi.o
+00:01:23   CC      drivers/video/fbdev/vesafb.o
+00:01:24   AR      drivers/pci/built-in.a
+00:01:24   AR      net/ipv4/netfilter/built-in.a
+00:01:24   CC [M]  net/ipv4/netfilter/nf_defrag_ipv4.o
+00:01:24   CC [M]  crypto/michael_mic.o
+00:01:24   CC      drivers/acpi/acpica/evsci.o
+00:01:24   CC      drivers/video/fbdev/core/syscopyarea.o
+00:01:24   CC      kernel/bpf/trampoline.o
+00:01:24   CC      drivers/acpi/numa/hmat.o
+00:01:24   CC      net/ethtool/eee.o
+00:01:24   CC      mm/sparse.o
+00:01:24   CC [M]  sound/usb/line6/midibuf.o
+00:01:24   CC [M]  net/sched/sch_gred.o
+00:01:24   CC      drivers/acpi/acpica/evxface.o
+00:01:24   CC [M]  sound/pci/echoaudio/darla24.o
+00:01:24   CC [M]  crypto/crc32_generic.o
+00:01:24   CC      kernel/exit.o
+00:01:24   CC [M]  crypto/lz4.o
+00:01:24   CC [M]  sound/usb/line6/pcm.o
+00:01:24   CC [M]  net/netfilter/ipset/ip_set_hash_ipmac.o
+00:01:24   CC      kernel/trace/trace_boot.o
+00:01:24   CC      drivers/acpi/acpica/evxfevnt.o
+00:01:25   AR      drivers/acpi/numa/built-in.a
+00:01:25   CC      drivers/video/fbdev/core/sysimgblt.o
+00:01:25   CC      kernel/softirq.o
+00:01:25   CC      fs/ext4/super.o
+00:01:25   CC      kernel/bpf/btf.o
+00:01:25   CC [M]  net/ipv4/netfilter/nf_socket_ipv4.o
+00:01:25   CC      net/ethtool/tsinfo.o
+00:01:25   CC [M]  crypto/lz4hc.o
+00:01:25   CC      net/core/page_pool.o
+00:01:25   CC      mm/sparse-vmemmap.o
+00:01:25   CC      drivers/acpi/acpica/evxfgpe.o
+00:01:25   CC [M]  crypto/ansi_cprng.o
+00:01:25   CC [M]  sound/usb/line6/playback.o
+00:01:25   CC [M]  kernel/trace/ring_buffer_benchmark.o
+00:01:25   CC      drivers/acpi/acpica/evxfregn.o
+00:01:25   CC [M]  sound/pci/echoaudio/gina24.o
+00:01:25   CC [M]  crypto/tcrypt.o
+00:01:25   CC      drivers/video/fbdev/core/fb_sys_fops.o
+00:01:25   CC [M]  net/sched/sch_ingress.o
+00:01:26   CC [M]  sound/pci/emu10k1/emu10k1.o
+00:01:26   CC      net/ethtool/cabletest.o
+00:01:26   CC      mm/mmu_notifier.o
+00:01:26   CC      drivers/acpi/acpica/exconcat.o
+00:01:26   CC      net/core/net-procfs.o
+00:01:26   CC [M]  net/ipv4/netfilter/nf_tproxy_ipv4.o
+00:01:26   CC [M]  sound/usb/line6/pod.o
+00:01:26   AR      kernel/trace/built-in.a
+00:01:26   CC      fs/jbd2/transaction.o
+00:01:26   CC [M]  sound/pci/hda/hda_bind.o
+00:01:26   CC      drivers/acpi/acpica/exconfig.o
+00:01:26   CC [M]  sound/pci/emu10k1/emu10k1_main.o
+00:01:26   AR      drivers/video/fbdev/core/built-in.a
+00:01:26   CC      drivers/video/fbdev/efifb.o
+00:01:26   CC [M]  net/sched/sch_sfb.o
+00:01:26   CC [M]  sound/usb/line6/podhd.o
+00:01:26   CC      mm/ksm.o
+00:01:26   CC      drivers/acpi/acpica/exconvrt.o
+00:01:27   CC      net/core/netpoll.o
+00:01:27   CC [M]  sound/pci/hda/hda_codec.o
+00:01:27   CC      net/ethtool/tunnels.o
+00:01:27   CC [M]  net/netfilter/ipset/ip_set_hash_ipmark.o
+00:01:27   CC [M]  net/ipv4/netfilter/nf_reject_ipv4.o
+00:01:27   CC      drivers/acpi/acpica/excreate.o
+00:01:27   CC [M]  sound/usb/line6/toneport.o
+00:01:27   CC [M]  sound/pci/echoaudio/layla24.o
+00:01:27   CC [M]  sound/pci/emu10k1/irq.o
+00:01:27   AR      drivers/video/fbdev/built-in.a
+00:01:27   AR      drivers/video/built-in.a
+00:01:27   CC      drivers/acpi/acpica/exdebug.o
+00:01:27   CC [M]  net/netfilter/ipvs/ip_vs_conn.o
+00:01:27   CC [M]  crypto/zstd.o
+00:01:27   CC      fs/jbd2/commit.o
+00:01:27   CC [M]  net/sched/sch_sfq.o
+00:01:28   CC [M]  sound/usb/line6/variax.o
+00:01:28   CC [M]  sound/pci/emu10k1/memory.o
+00:01:28   CC      drivers/acpi/acpica/exdump.o
+00:01:28   CC      net/ethtool/fec.o
+00:01:28   CC      kernel/bpf/dispatcher.o
+00:01:28   CC [M]  crypto/essiv.o
+00:01:28   CC      net/core/fib_rules.o
+00:01:28   CC [M]  net/ipv4/netfilter/nf_nat_h323.o
+00:01:28   CC      drivers/acpi/acpica/exfield.o
+00:01:28   CC      mm/page_poison.o
+00:01:28   LD [M]  sound/usb/line6/snd-usb-line6.o
+00:01:28   LD [M]  sound/usb/line6/snd-usb-pod.o
+00:01:28   LD [M]  sound/usb/line6/snd-usb-podhd.o
+00:01:28   LD [M]  sound/usb/line6/snd-usb-toneport.o
+00:01:28   LD [M]  sound/usb/line6/snd-usb-variax.o
+00:01:28   CC [M]  sound/usb/clock.o
+00:01:28   CC      drivers/acpi/acpica/exfldio.o
+00:01:28   CC [M]  sound/pci/emu10k1/voice.o
+00:01:28   CC [M]  sound/pci/hda/hda_jack.o
+00:01:28   CC      fs/jbd2/recovery.o
+00:01:28   CC      mm/slub.o
+00:01:29   CC [M]  crypto/curve25519-generic.o
+00:01:29   CC      kernel/bpf/devmap.o
+00:01:29   CC [M]  sound/pci/echoaudio/mona.o
+00:01:29   CC      net/ethtool/eeprom.o
+00:01:29   CC [M]  net/netfilter/ipvs/ip_vs_core.o
+00:01:29   CC [M]  net/sched/sch_tbf.o
+00:01:29   CC      drivers/acpi/acpica/exmisc.o
+00:01:29   CC [M]  sound/usb/endpoint.o
+00:01:29   CC [M]  sound/pci/emu10k1/emumpu401.o
+00:01:29   ASN.1   crypto/ecrdsa_params.asn1.[ch]
+00:01:29   ASN.1   crypto/ecrdsa_pub_key.asn1.[ch]
+00:01:29   CC [M]  net/netfilter/ipset/ip_set_hash_ipport.o
+00:01:29   CC [M]  crypto/ecrdsa_params.asn1.o
+00:01:29   CC [M]  crypto/ecrdsa_pub_key.asn1.o
+00:01:29   LD [M]  crypto/crypto_user.o
+00:01:29   LD [M]  crypto/aegis128.o
+00:01:29   CC      drivers/acpi/acpica/exmutex.o
+00:01:29   CC [M]  crypto/ecrdsa.o
+00:01:29   CC [M]  net/ipv4/netfilter/nf_nat_pptp.o
+00:01:29   CC [M]  sound/pci/hda/hda_auto_parser.o
+00:01:29   CC      net/core/net-traces.o
+00:01:29   CC      fs/jbd2/checkpoint.o
+00:01:30   CC [M]  sound/pci/emu10k1/emupcm.o
+00:01:30   CC      drivers/acpi/acpica/exnames.o
+00:01:30   CC      net/ethtool/stats.o
+00:01:30   CC      crypto/rsapubkey.asn1.o
+00:01:30   CC [M]  net/sched/sch_teql.o
+00:01:30   CC      crypto/rsaprivkey.asn1.o
+00:01:30   CC      kernel/bpf/cpumap.o
+00:01:30   CC      crypto/ecdsa.o
+00:01:30   CC [M]  sound/usb/format.o
+00:01:30   CC      drivers/acpi/acpica/exoparg1.o
+00:01:30   CC [M]  sound/pci/echoaudio/mia.o
+00:01:30   CC      fs/jbd2/revoke.o
+00:01:30   CC [M]  sound/pci/hda/hda_sysfs.o
+00:01:30   ASN.1   net/ipv4/netfilter/nf_nat_snmp_basic.asn1.[ch]
+00:01:30   CC [M]  net/ipv4/netfilter/nft_reject_ipv4.o
+00:01:30   CC      drivers/acpi/acpica/exoparg2.o
+00:01:31   CC      crypto/ecdsasignature.asn1.o
+00:01:31   CC [M]  net/netfilter/ipvs/ip_vs_ctl.o
+00:01:31   CC [M]  sound/usb/helper.o
+00:01:31   CC      net/ethtool/phc_vclocks.o
+00:01:31   CC [M]  net/sched/sch_prio.o
+00:01:31   CC [M]  sound/pci/emu10k1/io.o
+00:01:31   LD [M]  crypto/ecrdsa_generic.o
+00:01:31   AR      crypto/built-in.a
+00:01:31   CC [M]  sound/pci/echoaudio/echo3g.o
+00:01:31   CC      drivers/acpi/acpica/exoparg3.o
+00:01:31   CC      kernel/bpf/offload.o
+00:01:31   CC      fs/jbd2/journal.o
+00:01:31   CC [M]  sound/pci/hda/hda_controller.o
+00:01:31   CC [M]  sound/usb/implicit.o
+00:01:31   CC      drivers/acpi/acpica/exoparg6.o
+00:01:31   CC [M]  net/ipv4/netfilter/nft_fib_ipv4.o
+00:01:31   CC      fs/ext4/symlink.o
+00:01:31   CC [M]  sound/pci/emu10k1/emumixer.o
+00:01:31   CC [M]  net/netfilter/ipset/ip_set_hash_ipportip.o
+00:01:32   CC      drivers/acpi/acpica/exprep.o
+00:01:32   CC [M]  net/sched/sch_multiq.o
+00:01:32   AR      net/ethtool/built-in.a
+00:01:32   CC      kernel/bpf/net_namespace.o
+00:01:32   CC [M]  sound/usb/mixer.o
+00:01:32   CC      kernel/bpf/stackmap.o
+00:01:32   CC      mm/memtest.o
+00:01:32   CC      drivers/acpi/acpica/exregion.o
+00:01:32   CC      fs/ext4/sysfs.o
+00:01:32   CC      fs/ramfs/inode.o
+00:01:32   CC [M]  sound/pci/hda/hda_proc.o
+00:01:32   CC      mm/migrate.o
+00:01:32   CC [M]  net/ipv4/netfilter/nft_dup_ipv4.o
+00:01:32   CC      drivers/acpi/acpica/exresnte.o
+00:01:32   CC [M]  sound/pci/emu10k1/emufx.o
+00:01:32   CC [M]  sound/pci/echoaudio/indigo.o
+00:01:33   CC [M]  net/sched/sch_netem.o
+00:01:33   CC      kernel/resource.o
+00:01:33   CC      drivers/acpi/acpica/exresolv.o
+00:01:33   CC      kernel/bpf/cgroup.o
+00:01:33   CC      fs/ext4/xattr.o
+00:01:33   CC      fs/ramfs/file-mmu.o
+00:01:33   CC      net/core/drop_monitor.o
+00:01:33   CC [M]  net/netfilter/ipvs/ip_vs_sched.o
+00:01:33   CC      drivers/acpi/acpica/exresop.o
+00:01:33   CC [M]  sound/pci/hda/hda_hwdep.o
+00:01:33   AR      fs/jbd2/built-in.a
+00:01:33   CC      kernel/sysctl.o
+00:01:33   CC [M]  net/ipv4/netfilter/ip_tables.o
+00:01:33   AR      fs/ramfs/built-in.a
+00:01:33   AR      drivers/amba/built-in.a
+00:01:33   CC [M]  net/netfilter/ipset/ip_set_hash_ipportnet.o
+00:01:33   CC [M]  sound/usb/mixer_quirks.o
+00:01:33   CC      drivers/acpi/acpica/exserial.o
+00:01:34   CC      net/xfrm/xfrm_policy.o
+00:01:34   CC [M]  sound/pci/hda/hda_beep.o
+00:01:34   CC [M]  sound/pci/echoaudio/indigoio.o
+00:01:34   CC      net/ipv4/route.o
+00:01:34   CC      drivers/acpi/acpica/exstore.o
+00:01:34   CC [M]  net/sched/sch_drr.o
+00:01:34   CC [M]  net/netfilter/ipvs/ip_vs_xmit.o
+00:01:34   CC      net/core/selftests.o
+00:01:34   CC [M]  sound/pci/emu10k1/timer.o
+00:01:34   CC      drivers/acpi/acpica/exstoren.o
+00:01:34   CC [M]  sound/pci/hda/hda_generic.o
+00:01:34   CC      kernel/bpf/reuseport_array.o
+00:01:35   CC [M]  sound/usb/mixer_scarlett.o
+00:01:35   CC      drivers/acpi/acpica/exstorob.o
+00:01:35   CC      fs/ext4/xattr_hurd.o
+00:01:35   CC      mm/huge_memory.o
+00:01:35   CC [M]  sound/pci/emu10k1/p16v.o
+00:01:35   CC [M]  sound/firewire/dice/dice-transaction.o
+00:01:35   CC [M]  net/ipv4/netfilter/iptable_filter.o
+00:01:35   CC [M]  net/sched/sch_plug.o
+00:01:35   CC      drivers/acpi/acpica/exsystem.o
+00:01:35   CC [M]  sound/pci/echoaudio/indigodj.o
+00:01:35   CC [M]  sound/usb/mixer_scarlett_gen2.o
+00:01:35   CC      fs/ext4/xattr_trusted.o
+00:01:35   CC      drivers/acpi/acpica/extrace.o
+00:01:35   CC      net/core/timestamping.o
+00:01:35   CC [M]  sound/firewire/dice/dice-stream.o
+00:01:35   CC [M]  sound/pci/emu10k1/emuproc.o
+00:01:35   CC      kernel/bpf/bpf_struct_ops.o
+00:01:36   CC [M]  net/sched/sch_ets.o
+00:01:36   CC      drivers/acpi/acpica/exutils.o
+00:01:36   CC [M]  net/netfilter/ipvs/ip_vs_app.o
+00:01:36   CC [M]  net/ipv4/netfilter/iptable_mangle.o
+00:01:36   CC      fs/ext4/xattr_user.o
+00:01:36   CC [M]  net/netfilter/ipset/ip_set_hash_mac.o
+00:01:36   CC      drivers/acpi/acpica/hwacpi.o
+00:01:36   CC [M]  sound/pci/emu10k1/emu10k1_synth.o
+00:01:36   CC [M]  sound/firewire/dice/dice-proc.o
+00:01:36   CC [M]  sound/pci/echoaudio/indigoiox.o
+00:01:36   CC      net/core/ptp_classifier.o
+00:01:36   CC [M]  sound/pci/emu10k1/emu10k1_callback.o
+00:01:36   CC      drivers/acpi/acpica/hwesleep.o
+00:01:36   CC [M]  sound/usb/mixer_us16x08.o
+00:01:37   CC      kernel/bpf/bpf_lsm.o
+00:01:37   CC [M]  net/ipv4/netfilter/iptable_nat.o
+00:01:37   CC      fs/ext4/fast_commit.o
+00:01:37   CC [M]  net/sched/sch_mqprio.o
+00:01:37   CC      drivers/acpi/acpica/hwgpe.o
+00:01:37   CC      fs/ext4/orphan.o
+00:01:37   CC [M]  sound/firewire/dice/dice-midi.o
+00:01:37   CC [M]  net/netfilter/ipvs/ip_vs_sync.o
+00:01:37   CC      net/xfrm/xfrm_state.o
+00:01:37   CC [M]  sound/pci/emu10k1/emu10k1_patch.o
+00:01:37   CC      net/core/netprio_cgroup.o
+00:01:37   CC      mm/khugepaged.o
+00:01:37   CC      drivers/acpi/acpica/hwregs.o
+00:01:37   CC [M]  sound/usb/mixer_s1810c.o
+00:01:37   CC [M]  sound/firewire/dice/dice-pcm.o
+00:01:37   CC [M]  sound/pci/hda/patch_realtek.o
+00:01:38   CC [M]  sound/pci/emu10k1/emu10k1x.o
+00:01:38   CC [M]  net/netfilter/ipset/ip_set_hash_net.o
+00:01:38   CC [M]  sound/pci/echoaudio/indigodjx.o
+00:01:38   CC      drivers/acpi/acpica/hwsleep.o
+00:01:38   CC [M]  net/ipv4/netfilter/iptable_raw.o
+00:01:38   CC      net/core/netclassid_cgroup.o
+00:01:38   AR      kernel/bpf/built-in.a
+00:01:38   CC [M]  net/sched/sch_choke.o
+00:01:38   CC      kernel/capability.o
+00:01:38   CC [M]  sound/usb/pcm.o
+00:01:38   CC      drivers/acpi/acpica/hwvalid.o
+00:01:38   CC [M]  sound/pci/ice1712/ice1712.o
+00:01:38   CC [M]  sound/firewire/dice/dice-hwdep.o
+00:01:38   CC      drivers/acpi/acpica/hwxface.o
+00:01:38   CC      fs/ext4/acl.o
+00:01:38   CC [M]  net/netfilter/ipvs/ip_vs_est.o
+00:01:38   CC      kernel/ptrace.o
+00:01:38   LD [M]  sound/pci/emu10k1/snd-emu10k1.o
+00:01:38   LD [M]  sound/pci/emu10k1/snd-emu10k1-synth.o
+00:01:39   LD [M]  sound/pci/emu10k1/snd-emu10k1x.o
+00:01:39   CC [M]  sound/pci/ice1712/delta.o
+00:01:39   CC [M]  net/ipv4/netfilter/iptable_security.o
+00:01:39   CC      net/core/lwtunnel.o
+00:01:39   CC [M]  sound/firewire/dice/dice.o
+00:01:39   CC      drivers/acpi/acpica/hwxfsleep.o
+00:01:39   CC [M]  sound/usb/power.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-darla20.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-gina20.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-layla20.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-darla24.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-gina24.o
+00:01:39   CC [M]  net/sched/sch_qfq.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-layla24.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-mona.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-mia.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-echo3g.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-indigo.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-indigoio.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-indigodj.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-indigoiox.o
+00:01:39   LD [M]  sound/pci/echoaudio/snd-indigodjx.o
+00:01:39   CC      net/netfilter/core.o
+00:01:39   CC      drivers/acpi/acpica/hwpci.o
+00:01:39   CC      fs/ext4/xattr_security.o
+00:01:39   CC      mm/page_counter.o
+00:01:39   CC [M]  sound/usb/proc.o
+00:01:39   AR      drivers/clk/actions/built-in.a
+00:01:39   CC [M]  sound/firewire/dice/dice-tcelectronic.o
+00:01:39   AR      drivers/clk/analogbits/built-in.a
+00:01:39   AR      drivers/clk/bcm/built-in.a
+00:01:39   AR      drivers/clk/imgtec/built-in.a
+00:01:39   CC [M]  sound/pci/ice1712/hoontech.o
+00:01:39   AR      drivers/clk/imx/built-in.a
+00:01:39   CC [M]  net/netfilter/ipvs/ip_vs_proto.o
+00:01:39   CC      net/xfrm/xfrm_hash.o
+00:01:39   AR      drivers/clk/ingenic/built-in.a
+00:01:39   CC      drivers/acpi/acpica/nsaccess.o
+00:01:40   CC      mm/memcontrol.o
+00:01:40   CC      kernel/user.o
+00:01:40   AR      drivers/clk/mediatek/built-in.a
+00:01:40   AR      drivers/clk/mstar/built-in.a
+00:01:40   CC [M]  net/ipv4/netfilter/ipt_ah.o
+00:01:40   AR      drivers/clk/mvebu/built-in.a
+00:01:40   AR      drivers/clk/ralink/built-in.a
+00:01:40   AR      drivers/clk/renesas/built-in.a
+00:01:40   AR      drivers/clk/socfpga/built-in.a
+00:01:40   CC      net/core/lwt_bpf.o
+00:01:40   CC [M]  sound/pci/hda/patch_cmedia.o
+00:01:40   AR      drivers/clk/sprd/built-in.a
+00:01:40   AR      drivers/clk/ti/built-in.a
+00:01:40   AR      drivers/clk/versatile/built-in.a
+00:01:40   CC      drivers/clk/x86/clk-pmc-atom.o
+00:01:40   CC      fs/ext4/verity.o
+00:01:40   CC [M]  sound/usb/quirks.o
+00:01:40   CC [M]  sound/firewire/dice/dice-alesis.o
+00:01:40   CC      kernel/signal.o
+00:01:40   CC      drivers/acpi/acpica/nsalloc.o
+00:01:40   CC      net/xfrm/xfrm_input.o
+00:01:40   CC [M]  sound/pci/ice1712/ews.o
+00:01:40   CC [M]  net/netfilter/ipset/ip_set_hash_netport.o
+00:01:40   CC [M]  net/sched/sch_codel.o
+00:01:40   CC [M]  sound/pci/hda/patch_analog.o
+00:01:40   CC [M]  net/ipv4/netfilter/ipt_rpfilter.o
+00:01:40   CC      drivers/clk/x86/clk-fch.o
+00:01:40   CC [M]  fs/ext4/inode-test.o
+00:01:40   CC      drivers/acpi/acpica/nsarguments.o
+00:01:40   CC [M]  sound/firewire/dice/dice-extension.o
+00:01:41   CC [M]  sound/firewire/oxfw/oxfw-command.o
+00:01:41   CC [M]  net/netfilter/ipvs/ip_vs_pe.o
+00:01:41   CC      drivers/clk/x86/clk-lpss-atom.o
+00:01:41   CC      drivers/acpi/acpica/nsconvert.o
+00:01:41   CC [M]  sound/usb/stream.o
+00:01:41   CC      net/core/dst_cache.o
+00:01:41   CC [M]  sound/pci/ice1712/ak4xxx.o
+00:01:41   CC [M]  sound/pci/hda/patch_sigmatel.o
+00:01:41   AR      fs/ext4/built-in.a
+00:01:41   LD [M]  fs/ext4/ext4-inode-test.o
+00:01:41   AR      drivers/clk/x86/built-in.a
+00:01:41   CC [M]  sound/firewire/dice/dice-mytek.o
+00:01:41   CC      fs/hugetlbfs/inode.o
+00:01:41   AR      drivers/clk/xilinx/built-in.a
+00:01:41   CC [M]  drivers/clk/xilinx/xlnx_vcu.o
+00:01:41   CC      drivers/acpi/acpica/nsdump.o
+00:01:41   CC [M]  sound/firewire/oxfw/oxfw-stream.o
+00:01:41   CC [M]  net/ipv4/netfilter/ipt_ECN.o
+00:01:41   CC [M]  net/sched/sch_cake.o
+00:01:41   CC      drivers/acpi/acpica/nseval.o
+00:01:41   CC      net/xfrm/xfrm_output.o
+00:01:41   CC [M]  sound/pci/ice1712/ice1724.o
+00:01:42   CC [M]  sound/firewire/dice/dice-presonus.o
+00:01:42   CC      drivers/clk/clk-devres.o
+00:01:42   CC [M]  net/netfilter/ipvs/ip_vs_proto_tcp.o
+00:01:42   CC [M]  sound/usb/validate.o
+00:01:42   CC      drivers/acpi/acpica/nsinit.o
+00:01:42   CC      net/core/devlink.o
+00:01:42   CC [M]  sound/firewire/oxfw/oxfw-pcm.o
+00:01:42   CC      drivers/clk/clk-bulk.o
+00:01:42   CC [M]  sound/pci/hda/patch_si3054.o
+00:01:42   CC [M]  sound/firewire/dice/dice-harman.o
+00:01:42   CC [M]  sound/usb/media.o
+00:01:42   CC      drivers/acpi/acpica/nsload.o
+00:01:42   AR      fs/hugetlbfs/built-in.a
+00:01:42   CC      fs/exportfs/expfs.o
+00:01:42   CC [M]  net/ipv4/netfilter/ipt_REJECT.o
+00:01:42   CC      drivers/clk/clkdev.o
+00:01:42   CC      kernel/sys.o
+00:01:42   CC      drivers/acpi/acpica/nsnames.o
+00:01:43   CC [M]  sound/pci/hda/patch_cirrus.o
+00:01:43   LD [M]  sound/firewire/dice/snd-dice.o
+00:01:43   CC      drivers/clk/clk.o
+00:01:43   CC [M]  sound/firewire/oxfw/oxfw-proc.o
+00:01:43   CC [M]  net/netfilter/ipset/ip_set_hash_netiface.o
+00:01:43   CC [M]  sound/usb/midi.o
+00:01:43   AR      fs/exportfs/built-in.a
+00:01:43   CC      net/xfrm/xfrm_sysctl.o
+00:01:43   CC      fs/nls/nls_base.o
+00:01:43   CC [M]  sound/pci/ice1712/amp.o
+00:01:43   CC [M]  net/netfilter/ipvs/ip_vs_proto_udp.o
+00:01:43   CC [M]  sound/pci/hda/patch_cs8409.o
+00:01:43   CC      drivers/acpi/acpica/nsobject.o
+00:01:43   CC [M]  sound/firewire/oxfw/oxfw-midi.o
+00:01:43   CC      fs/nls/nls_cp437.o
+00:01:43   CC      mm/vmpressure.o
+00:01:43   CC [M]  net/ipv4/netfilter/ipt_SYNPROXY.o
+00:01:43   CC      drivers/acpi/acpica/nsparse.o
+00:01:43   CC [M]  sound/pci/ice1712/revo.o
+00:01:43   CC [M]  net/netfilter/ipvs/ip_vs_proto_ah_esp.o
+00:01:44   CC      fs/nls/nls_ascii.o
+00:01:44   CC [M]  net/sched/sch_fq.o
+00:01:44   CC      drivers/acpi/acpica/nspredef.o
+00:01:44   CC      net/xfrm/xfrm_replay.o
+00:01:44   CC [M]  sound/firewire/oxfw/oxfw-hwdep.o
+00:01:44   CC [M]  fs/nls/nls_cp737.o
+00:01:44   CC [M]  sound/pci/hda/patch_cs8409-tables.o
+00:01:44   CC [M]  sound/pci/ice1712/aureon.o
+00:01:44   CC      mm/swap_cgroup.o
+00:01:44   CC      kernel/umh.o
+00:01:44   CC      drivers/acpi/acpica/nsprepkg.o
+00:01:44   LD [M]  sound/usb/snd-usb-audio.o
+00:01:44   LD [M]  sound/usb/snd-usbmidi-lib.o
+00:01:44   CC [M]  sound/firewire/oxfw/oxfw-spkr.o
+00:01:44   CC [M]  fs/nls/nls_cp775.o
+00:01:44   CC [M]  net/ipv4/netfilter/arp_tables.o
+00:01:44   CC [M]  net/netfilter/ipvs/ip_vs_proto_sctp.o
+00:01:44   CC [M]  sound/pci/hda/patch_ca0110.o
+00:01:44   CC [M]  sound/pci/hda/patch_ca0132.o
+00:01:44   CC      drivers/acpi/acpica/nsrepair.o
+00:01:44   CC [M]  fs/nls/nls_cp850.o
+00:01:45   SHIPPED fs/unicode/utf8data.h
+00:01:45   CC      fs/unicode/utf8-core.o
+00:01:45   CC      mm/hugetlb_cgroup.o
+00:01:45   CC [M]  sound/firewire/oxfw/oxfw-scs1x.o
+00:01:45   CC [M]  fs/nls/nls_cp852.o
+00:01:45   CC      drivers/acpi/acpica/nsrepair2.o
+00:01:45   CC      kernel/workqueue.o
+00:01:45   CC      fs/unicode/utf8-norm.o
+00:01:45   CC [M]  net/sched/sch_hhf.o
+00:01:45   CC [M]  sound/firewire/fireworks/fireworks_transaction.o
+00:01:45   CC      net/xfrm/xfrm_device.o
+00:01:45   CC [M]  sound/pci/ice1712/vt1720_mobo.o
+00:01:45   CC      drivers/clk/clk-divider.o
+00:01:45   CC [M]  fs/nls/nls_cp855.o
+00:01:45   CC      drivers/acpi/acpica/nssearch.o
+00:01:45   CC [M]  net/netfilter/ipset/ip_set_hash_netnet.o
+00:01:45   CC [M]  fs/nls/nls_cp857.o
+00:01:45   CC [M]  sound/firewire/oxfw/oxfw.o
+00:01:45   AR      fs/unicode/built-in.a
+00:01:45   CC [M]  sound/pci/hda/patch_conexant.o
+00:01:46   CC [M]  net/netfilter/ipvs/ip_vs_nfct.o
+00:01:46   CC [M]  sound/pci/ice1712/pontis.o
+00:01:46   CC      mm/memory-failure.o
+00:01:46   CC [M]  sound/firewire/fireworks/fireworks_command.o
+00:01:46   CC      drivers/acpi/acpica/nsutils.o
+00:01:46   CC [M]  fs/nls/nls_cp860.o
+00:01:46   CC [M]  net/ipv4/netfilter/arpt_mangle.o
+00:01:46   CC      drivers/clk/clk-fixed-factor.o
+00:01:46   CC [M]  fs/nls/nls_cp861.o
+00:01:46   LD [M]  sound/firewire/oxfw/snd-oxfw.o
+00:01:46   CC [M]  net/sched/sch_pie.o
+00:01:46   CC      drivers/acpi/acpica/nswalk.o
+00:01:46   CC      drivers/dma/dw/core.o
+00:01:46   CC      net/xfrm/xfrm_proc.o
+00:01:46   CC      drivers/clk/clk-fixed-rate.o
+00:01:46   CC [M]  sound/firewire/fireworks/fireworks_stream.o
+00:01:46   CC [M]  sound/pci/ice1712/prodigy192.o
+00:01:46   CC      net/xfrm/xfrm_algo.o
+00:01:46   CC [M]  fs/nls/nls_cp862.o
+00:01:46   CC      drivers/acpi/acpica/nsxfeval.o
+00:01:47   CC      drivers/clk/clk-gate.o
+00:01:47   CC [M]  net/netfilter/ipvs/ip_vs_rr.o
+00:01:47   CC [M]  fs/nls/nls_cp863.o
+00:01:47   CC [M]  net/ipv4/netfilter/arptable_filter.o
+00:01:47   CC [M]  sound/firewire/fireworks/fireworks_proc.o
+00:01:47   CC      drivers/acpi/acpica/nsxfname.o
+00:01:47   CC      drivers/clk/clk-multiplier.o
+00:01:47   CC [M]  fs/nls/nls_cp864.o
+00:01:47   CC [M]  sound/pci/ice1712/prodigy_hifi.o
+00:01:47   CC      drivers/dma/dw/dw.o
+00:01:47   CC      drivers/clk/clk-mux.o
+00:01:47   CC      mm/page_owner.o
+00:01:47   CC [M]  net/sched/sch_fq_pie.o
+00:01:47   CC      net/core/gro_cells.o
+00:01:47   CC [M]  fs/nls/nls_cp865.o
+00:01:47   CC [M]  sound/pci/hda/patch_via.o
+00:01:47   CC      mm/page_isolation.o
+00:01:47   CC      kernel/pid.o
+00:01:47   CC      drivers/acpi/acpica/nsxfobj.o
+00:01:47   CC [M]  net/ipv4/netfilter/nf_dup_ipv4.o
+00:01:47   CC      net/xfrm/xfrm_user.o
+00:01:47   CC [M]  sound/firewire/fireworks/fireworks_midi.o
+00:01:48   CC [M]  fs/nls/nls_cp866.o
+00:01:48   CC      drivers/clk/clk-composite.o
+00:01:48   CC [M]  net/netfilter/ipvs/ip_vs_wrr.o
+00:01:48   CC      drivers/dma/dw/idma32.o
+00:01:48   CC      drivers/acpi/acpica/psargs.o
+00:01:48   CC [M]  sound/pci/ice1712/juli.o
+00:01:48   CC [M]  fs/nls/nls_cp869.o
+00:01:48   CC [M]  net/sched/sch_cbs.o
+00:01:48   CC      net/core/skmsg.o
+00:01:48   CC [M]  net/netfilter/ipset/ip_set_hash_netportnet.o
+00:01:48   CC [M]  sound/firewire/fireworks/fireworks_pcm.o
+00:01:48   CC      mm/zpool.o
+00:01:48   CC [M]  sound/pci/hda/patch_hdmi.o
+00:01:48   CC      drivers/clk/clk-fractional-divider.o
+00:01:48   CC      drivers/acpi/acpica/psloop.o
+00:01:48   CC [M]  fs/nls/nls_cp874.o
+00:01:48   CC      drivers/dma/dw/acpi.o
+00:01:48   CC [M]  net/ipv4/netfilter/nf_nat_snmp_basic.asn1.o
+00:01:48   CC [M]  sound/pci/ice1712/phase.o
+00:01:48   CC      net/netfilter/nf_log.o
+00:01:48   CC [M]  net/ipv4/netfilter/nf_nat_snmp_basic_main.o
+00:01:48   CC [M]  fs/nls/nls_cp932.o
+00:01:49   CC      drivers/clk/clk-gpio.o
+00:01:49   CC      kernel/task_work.o
+00:01:49   CC      drivers/acpi/acpica/psobject.o
+00:01:49   CC      mm/zbud.o
+00:01:49   CC [M]  net/netfilter/ipvs/ip_vs_lc.o
+00:01:49   CC [M]  sound/firewire/fireworks/fireworks_hwdep.o
+00:01:49   CC      drivers/dma/dw/pci.o
+00:01:49   CC [M]  net/sched/sch_etf.o
+00:01:49   CC [M]  fs/nls/nls_euc-jp.o
+00:01:49   CC [M]  drivers/clk/clk-si544.o
+00:01:49   CC      drivers/acpi/acpica/psopcode.o
+00:01:49   CC [M]  sound/pci/ice1712/wtm.o
+00:01:49   CC      mm/zsmalloc.o
+00:01:49   CC      kernel/extable.o
+00:01:49   CC [M]  fs/nls/nls_cp936.o
+00:01:49   CC      drivers/acpi/acpica/psopinfo.o
+00:01:49   CC [M]  sound/firewire/fireworks/fireworks.o
+00:01:49   CC [M]  drivers/dma/dw/platform.o
+00:01:49   LD [M]  net/ipv4/netfilter/nf_nat_snmp_basic.o
+00:01:50   CC      net/xfrm/espintcp.o
+00:01:50   CC      mm/early_ioremap.o
+00:01:50   CC      net/ipv4/inetpeer.o
+00:01:50   CC      net/core/sock_map.o
+00:01:50   CC      drivers/acpi/acpica/psparse.o
+00:01:50   CC [M]  net/netfilter/ipvs/ip_vs_wlc.o
+00:01:50   CC [M]  fs/nls/nls_cp949.o
+00:01:50   AR      drivers/clk/built-in.a
+00:01:50   CC [M]  sound/pci/hda/hda_eld.o
+00:01:50   CC [M]  sound/pci/ice1712/se.o
+00:01:50   AR      drivers/soc/aspeed/built-in.a
+00:01:50   AR      drivers/soc/bcm/bcm63xx/built-in.a
+00:01:50   AR      drivers/soc/bcm/built-in.a
+00:01:50   CC [M]  net/sched/sch_taprio.o
+00:01:50   AR      drivers/dma/dw/built-in.a
+00:01:50   AR      drivers/soc/fsl/built-in.a
+00:01:50   LD [M]  drivers/dma/dw/dw_dmac.o
+00:01:50   LD [M]  sound/firewire/fireworks/snd-fireworks.o
+00:01:50   AR      drivers/soc/imx/built-in.a
+00:01:50   CC      drivers/dma/hsu/hsu.o
+00:01:50   AR      drivers/soc/ixp4xx/built-in.a
+00:01:50   CC      kernel/params.o
+00:01:50   CC [M]  sound/firewire/bebob/bebob_command.o
+00:01:50   AR      drivers/soc/mediatek/built-in.a
+00:01:50   AR      drivers/soc/amlogic/built-in.a
+00:01:50   CC      drivers/acpi/acpica/psscope.o
+00:01:50   CC [M]  sound/pci/hda/hda_intel.o
+00:01:50   AR      drivers/soc/qcom/built-in.a
+00:01:50   CC [M]  drivers/soc/qcom/qmi_encdec.o
+00:01:50   CC [M]  fs/nls/nls_cp950.o
+00:01:50   CC [M]  sound/pci/ice1712/maya44.o
+00:01:50   CC      drivers/acpi/acpica/pstree.o
+00:01:50   CC      mm/cma.o
+00:01:51   CC [M]  fs/nls/nls_cp1250.o
+00:01:51   AR      drivers/dma/idxd/built-in.a
+00:01:51   CC [M]  drivers/dma/idxd/bus.o
+00:01:51   CC [M]  net/netfilter/ipvs/ip_vs_fo.o
+00:01:51   CC [M]  sound/firewire/bebob/bebob_stream.o
+00:01:51   CC [M]  drivers/soc/qcom/qmi_interface.o
+00:01:51   CC      net/ipv4/protocol.o
+00:01:51   CC [M]  net/netfilter/ipset/ip_set_list_set.o
+00:01:51   AR      drivers/dma/hsu/built-in.a
+00:01:51   CC      kernel/kthread.o
+00:01:51   CC [M]  net/xfrm/xfrm_ipcomp.o
+00:01:51   CC      drivers/acpi/acpica/psutils.o
+00:01:51   CC [M]  sound/pci/ice1712/quartet.o
+00:01:51   CC [M]  fs/nls/nls_cp1251.o
+00:01:51   CC      fs/autofs/init.o
+00:01:51   CC      drivers/acpi/acpica/pswalk.o
+00:01:51   CC [M]  fs/nls/nls_iso8859-1.o
+00:01:51   CC [M]  drivers/dma/idxd/init.o
+00:01:51   CC      net/core/bpf_sk_storage.o
+00:01:51   CC      mm/balloon_compaction.o
+00:01:51   CC [M]  sound/firewire/bebob/bebob_proc.o
+00:01:51   CC      drivers/acpi/acpica/psxface.o
+00:01:52   CC [M]  fs/nls/nls_iso8859-2.o
+00:01:52   CC      fs/autofs/inode.o
+00:01:52   CC [M]  sound/pci/ice1712/psc724.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec.o
+00:01:52   CC      net/ipv4/ip_input.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-generic.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-realtek.o
+00:01:52   CC [M]  net/sched/cls_u32.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-cmedia.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-analog.o
+00:01:52   CC [M]  net/netfilter/ipvs/ip_vs_ovf.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-idt.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-si3054.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-cirrus.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-cs8409.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-ca0110.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-ca0132.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-conexant.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-via.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-codec-hdmi.o
+00:01:52   LD [M]  sound/pci/hda/snd-hda-intel.o
+00:01:52   LD [M]  drivers/soc/qcom/qmi_helpers.o
+00:01:52   AR      drivers/soc/renesas/built-in.a
+00:01:52   CC [M]  fs/nls/nls_iso8859-3.o
+00:01:52   CC [M]  fs/nls/nls_iso8859-4.o
+00:01:52   AR      drivers/soc/sunxi/built-in.a
+00:01:52   CC      kernel/sys_ni.o
+00:01:52   CC      drivers/acpi/acpica/rsaddr.o
+00:01:52   AR      drivers/soc/ti/built-in.a
+00:01:52   CC [M]  net/xfrm/xfrm_interface_core.o
+00:01:52   AR      drivers/soc/xilinx/built-in.a
+00:01:52   AR      drivers/soc/built-in.a
+00:01:52   LD [M]  net/netfilter/ipset/ip_set.o
+00:01:52   CC [M]  sound/firewire/digi00x/amdtp-dot.o
+00:01:52   CC      mm/page_ext.o
+00:01:52   CC [M]  sound/firewire/bebob/bebob_midi.o
+00:01:52   CC      net/unix/af_unix.o
+00:01:52   CC      net/unix/garbage.o
+00:01:52   CC      fs/autofs/root.o
+00:01:52   CC [M]  fs/nls/nls_iso8859-5.o
+00:01:52   CC [M]  drivers/dma/idxd/irq.o
+00:01:52   CC [M]  sound/pci/ice1712/wm8766.o
+00:01:52   CC      drivers/acpi/acpica/rscalc.o
+00:01:52   CC      kernel/nsproxy.o
+00:01:52   CC [M]  fs/nls/nls_iso8859-6.o
+00:01:52   CC [M]  net/core/pktgen.o
+00:01:53   CC      mm/secretmem.o
+00:01:53   CC      drivers/acpi/acpica/rscreate.o
+00:01:53   CC [M]  sound/firewire/bebob/bebob_pcm.o
+00:01:53   CC [M]  sound/firewire/digi00x/digi00x-stream.o
+00:01:53   CC [M]  net/netfilter/ipvs/ip_vs_lblc.o
+00:01:53   CC [M]  sound/pci/ice1712/wm8776.o
+00:01:53   CC [M]  fs/nls/nls_iso8859-7.o
+00:01:53   CC      fs/autofs/symlink.o
+00:01:53   CC [M]  drivers/dma/idxd/device.o
+00:01:53   CC      net/ipv4/ip_fragment.o
+00:01:53   CC [M]  net/sched/cls_route.o
+00:01:53   CC      drivers/acpi/acpica/rsdumpinfo.o
+00:01:53   CC [M]  fs/nls/nls_cp1255.o
+00:01:53   AR      net/ipv6/netfilter/built-in.a
+00:01:53   LD [M]  sound/pci/ice1712/snd-ice17xx-ak4xxx.o
+00:01:53   CC      fs/autofs/waitq.o
+00:01:53   CC [M]  net/ipv6/netfilter/ip6_tables.o
+00:01:53   LD [M]  sound/pci/ice1712/snd-ice1712.o
+00:01:53   LD [M]  sound/pci/ice1712/snd-ice1724.o
+00:01:53   CC [M]  sound/firewire/bebob/bebob_hwdep.o
+00:01:53   CC [M]  sound/pci/korg1212/korg1212.o
+00:01:53   CC      kernel/notifier.o
+00:01:53   AR      net/xfrm/built-in.a
+00:01:53   CC [M]  sound/firewire/digi00x/digi00x-proc.o
+00:01:53   LD [M]  net/xfrm/xfrm_interface.o
+00:01:53   CC      fs/autofs/expire.o
+00:01:53   CC      drivers/acpi/acpica/rsinfo.o
+00:01:53   CC [M]  fs/nls/nls_iso8859-9.o
+00:01:53   CC      mm/cma_sysfs.o
+00:01:54   CC      drivers/acpi/acpica/rsio.o
+00:01:54   CC [M]  fs/nls/nls_iso8859-13.o
+00:01:54   AR      drivers/dma/mediatek/built-in.a
+00:01:54   CC      fs/debugfs/inode.o
+00:01:54   CC [M]  net/netfilter/ipvs/ip_vs_lblcr.o
+00:01:54   CC [M]  sound/firewire/digi00x/digi00x-pcm.o
+00:01:54   CC      mm/userfaultfd.o
+00:01:54   CC [M]  sound/firewire/bebob/bebob_terratec.o
+00:01:54   CC      fs/autofs/dev-ioctl.o
+00:01:54   CC      kernel/ksysfs.o
+00:01:54   CC      drivers/acpi/acpica/rsirq.o
+00:01:54   CC [M]  fs/nls/nls_iso8859-14.o
+00:01:54   CC [M]  drivers/dma/idxd/sysfs.o
+00:01:54   CC      net/ipv4/ip_forward.o
+00:01:54   CC [M]  net/sched/cls_fw.o
+00:01:54   CC      net/unix/sysctl_net_unix.o
+00:01:54   LD [M]  sound/pci/korg1212/snd-korg1212.o
+00:01:54   CC [M]  sound/pci/mixart/mixart.o
+00:01:54   CC [M]  fs/nls/nls_iso8859-15.o
+00:01:54   CC      drivers/acpi/acpica/rslist.o
+00:01:54   CC [M]  sound/firewire/bebob/bebob_yamaha_terratec.o
+00:01:54   CC [M]  sound/firewire/digi00x/digi00x-hwdep.o
+00:01:54   CC      kernel/cred.o
+00:01:54   AR      fs/autofs/built-in.a
+00:01:54   CC      net/unix/unix_bpf.o
+00:01:55   CC      fs/debugfs/file.o
+00:01:55   CC [M]  fs/nls/nls_koi8-r.o
+00:01:55   CC      drivers/acpi/acpica/rsmemory.o
+00:01:55   CC [M]  net/ipv6/netfilter/ip6table_filter.o
+00:01:55   CC [M]  net/core/failover.o
+00:01:55   CC [M]  fs/nls/nls_koi8-u.o
+00:01:55   CC [M]  sound/firewire/bebob/bebob_focusrite.o
+00:01:55   CC      drivers/acpi/acpica/rsmisc.o
+00:01:55   CC [M]  net/netfilter/ipvs/ip_vs_dh.o
+00:01:55   CC      mm/page_idle.o
+00:01:55   CC [M]  sound/firewire/digi00x/digi00x-transaction.o
+00:01:55   CC [M]  drivers/dma/idxd/submit.o
+00:01:55   CC      net/ipv4/ip_options.o
+00:01:55   CC [M]  net/sched/cls_basic.o
+00:01:55   CC      kernel/reboot.o
+00:01:55   CC [M]  sound/pci/mixart/mixart_core.o
+00:01:55   CC [M]  fs/nls/nls_koi8-ru.o
+00:01:55   CC      drivers/virtio/virtio.o
+00:01:55   AR      fs/debugfs/built-in.a
+00:01:55   CC [M]  fs/nls/nls_utf8.o
+00:01:55   CC      drivers/acpi/acpica/rsserial.o
+00:01:56   CC [M]  sound/firewire/bebob/bebob_maudio.o
+00:01:56   CC [M]  net/netfilter/ipvs/ip_vs_sh.o
+00:01:56   CC      net/unix/diag.o
+00:01:56   CC [M]  sound/firewire/digi00x/digi00x-midi.o
+00:01:56   AR      net/core/built-in.a
+00:01:56   CC [M]  sound/firewire/tascam/tascam-proc.o
+00:01:56   CC [M]  fs/nls/mac-celtic.o
+00:01:56   CC [M]  net/ipv6/netfilter/ip6table_mangle.o
+00:01:56   CC [M]  drivers/dma/idxd/dma.o
+00:01:56   CC      mm/usercopy.o
+00:01:56   CC      drivers/acpi/acpica/rsutils.o
+00:01:56   CC      drivers/virtio/virtio_ring.o
+00:01:56   CC [M]  sound/pci/mixart/mixart_hwdep.o
+00:01:56   CC [M]  sound/firewire/tascam/amdtp-tascam.o
+00:01:56   CC [M]  net/sched/cls_flow.o
+00:01:56   CC [M]  fs/nls/mac-centeuro.o
+00:01:56   CC      kernel/async.o
+00:01:56   CC [M]  sound/firewire/bebob/bebob.o
+00:01:56   CC [M]  sound/firewire/digi00x/digi00x.o
+00:01:56   CC      drivers/acpi/acpica/rsxface.o
+00:01:56   CC [M]  net/ipv6/ila/ila_main.o
+00:01:56   CC      mm/memremap.o
+00:01:56   CC [M]  fs/nls/mac-croatian.o
+00:01:56   CC      net/ipv4/ip_output.o
+00:01:57   CC [M]  drivers/dma/idxd/cdev.o
+00:01:57   CC      kernel/range.o
+00:01:57   CC      net/unix/scm.o
+00:01:57   CC [M]  sound/pci/mixart/mixart_mixer.o
+00:01:57   CC      drivers/acpi/acpica/tbdata.o
+00:01:57   CC [M]  net/netfilter/ipvs/ip_vs_mh.o
+00:01:57   CC [M]  sound/firewire/tascam/tascam-stream.o
+00:01:57   CC      kernel/smpboot.o
+00:01:57   CC [M]  fs/nls/mac-cyrillic.o
+00:01:57   LD [M]  sound/firewire/digi00x/snd-firewire-digi00x.o
+00:01:57   CC [M]  net/ipv6/netfilter/ip6table_raw.o
+00:01:57   CC      drivers/acpi/apei/apei-base.o
+00:01:57   LD [M]  sound/firewire/bebob/snd-bebob.o
+00:01:57   AR      drivers/dma/qcom/built-in.a
+00:01:57   CC [M]  sound/pci/nm256/nm256.o
+00:01:57   CC [M]  fs/nls/mac-gaelic.o
+00:01:57   CC      drivers/acpi/acpica/tbfadt.o
+00:01:57   CC      mm/hmm.o
+00:01:57   CC      kernel/ucount.o
+00:01:57   CC      drivers/virtio/virtio_pci_modern_dev.o
+00:01:57   CC [M]  drivers/dma/idxd/perfmon.o
+00:01:57   CC [M]  net/ipv6/ila/ila_common.o
+00:01:57   CC [M]  fs/nls/mac-greek.o
+00:01:57   LD [M]  sound/pci/mixart/snd-mixart.o
+00:01:57   CC [M]  sound/firewire/tascam/tascam-pcm.o
+00:01:57   CC      drivers/xen/events/events_base.o
+00:01:57   CC [M]  net/sched/cls_bpf.o
+00:01:58   AR      net/unix/built-in.a
+00:01:58   CC      drivers/xen/events/events_2l.o
+00:01:58   CC      drivers/acpi/apei/hest.o
+00:01:58   CC      drivers/acpi/acpica/tbfind.o
+00:01:58   CC [M]  fs/nls/mac-iceland.o
+00:01:58   CC      kernel/regset.o
+00:01:58   CC [M]  net/ipv6/netfilter/ip6table_security.o
+00:01:58   LD [M]  sound/pci/nm256/snd-nm256.o
+00:01:58   CC [M]  net/netfilter/ipvs/ip_vs_sed.o
+00:01:58   CC [M]  sound/pci/oxygen/oxygen_io.o
+00:01:58   CC [M]  sound/firewire/tascam/tascam-hwdep.o
+00:01:58   CC      drivers/virtio/virtio_pci_modern.o
+00:01:58   CC [M]  fs/nls/mac-inuit.o
+00:01:58   CC      drivers/acpi/acpica/tbinstal.o
+00:01:58   CC      kernel/usermode_driver.o
+00:01:58   LD [M]  drivers/dma/idxd/idxd_bus.o
+00:01:58   LD [M]  drivers/dma/idxd/idxd.o
+00:01:58   CC      mm/memfd.o
+00:01:58   AR      drivers/dma/ti/built-in.a
+00:01:58   CC      drivers/acpi/apei/erst.o
+00:01:58   AR      drivers/dma/xilinx/built-in.a
+00:01:58   CC [M]  drivers/dma/ptdma/ptdma-dev.o
+00:01:58   CC [M]  fs/nls/mac-romanian.o
+00:01:58   CC [M]  net/ipv6/ila/ila_lwt.o
+00:01:58   CC [M]  drivers/dma/ptdma/ptdma-dmaengine.o
+00:01:58   CC      drivers/acpi/acpica/tbprint.o
+00:01:58   CC [M]  sound/pci/oxygen/oxygen_lib.o
+00:01:58   CC      net/ipv4/ip_sockglue.o
+00:01:59   CC [M]  fs/nls/mac-roman.o
+00:01:59   CC [M]  sound/firewire/tascam/tascam-transaction.o
+00:01:59   CC      drivers/virtio/virtio_pci_common.o
+00:01:59   CC [M]  net/sched/cls_flower.o
+00:01:59   CC      drivers/acpi/acpica/tbutils.o
+00:01:59   CC      kernel/kmod.o
+00:01:59   CC [M]  net/netfilter/ipvs/ip_vs_nq.o
+00:01:59   CC      fs/tracefs/inode.o
+00:01:59   CC [M]  net/ipv6/netfilter/ip6table_nat.o
+00:01:59   CC [M]  fs/nls/mac-turkish.o
+00:01:59   CC [M]  drivers/dma/ptdma/ptdma-debugfs.o
+00:01:59   CC      drivers/acpi/apei/bert.o
+00:01:59   CC      mm/mapping_dirty_helpers.o
+00:01:59   CC      drivers/acpi/acpica/tbxface.o
+00:01:59   CC [M]  sound/pci/oxygen/oxygen_mixer.o
+00:01:59   AR      fs/nls/built-in.a
+00:01:59   CC      drivers/xen/events/events_fifo.o
+00:01:59   CC [M]  sound/firewire/tascam/tascam-midi.o
+00:01:59   CC [M]  net/ipv6/ila/ila_xlat.o
+00:01:59   CC      drivers/virtio/virtio_pci_legacy.o
+00:01:59   CC      net/ipv6/af_inet6.o
+00:01:59   CC      drivers/acpi/acpica/tbxfload.o
+00:01:59   CC [M]  drivers/dma/ptdma/ptdma-pci.o
+00:01:59   CC      drivers/acpi/apei/ghes.o
+00:02:00   AR      fs/tracefs/built-in.a
+00:02:00   CC      kernel/groups.o
+00:02:00   CC      fs/btrfs/super.o
+00:02:00   CC      mm/ptdump.o
+00:02:00   CC [M]  sound/firewire/tascam/tascam.o
+00:02:00   CC [M]  sound/pci/oxygen/oxygen_pcm.o
+00:02:00   CC [M]  net/netfilter/ipvs/ip_vs_twos.o
+00:02:00   CC      drivers/acpi/acpica/tbxfroot.o
+00:02:00   CC [M]  drivers/virtio/virtio_mmio.o
+00:02:00   CC [M]  net/ipv6/netfilter/nf_defrag_ipv6_hooks.o
+00:02:00   AR      drivers/xen/events/built-in.a
+00:02:00   CC      drivers/xen/xenbus/xenbus_client.o
+00:02:00   LD [M]  drivers/dma/ptdma/ptdma.o
+00:02:00   CC      net/ipv4/inet_hashtables.o
+00:02:00   CC [M]  drivers/dma/dw-edma/dw-edma-core.o
+00:02:00   CC      mm/page_reporting.o
+00:02:00   CC      kernel/kcmp.o
+00:02:00   CC      drivers/acpi/acpica/utaddress.o
+00:02:00   LD [M]  sound/firewire/tascam/snd-firewire-tascam.o
+00:02:00   CC [M]  sound/firewire/motu/motu.o
+00:02:01   CC [M]  drivers/acpi/apei/einj.o
+00:02:01   CC      drivers/acpi/acpica/utalloc.o
+00:02:01   CC [M]  sound/pci/oxygen/oxygen.o
+00:02:01   CC [M]  drivers/virtio/virtio_balloon.o
+00:02:01   LD [M]  net/ipv6/ila/ila.o
+00:02:01   CC      kernel/freezer.o
+00:02:01   CC      mm/bootmem_info.o
+00:02:01   CC      drivers/acpi/pmic/intel_pmic.o
+00:02:01   CC [M]  net/netfilter/ipvs/ip_vs_ftp.o
+00:02:01   CC [M]  sound/firewire/motu/amdtp-motu.o
+00:02:01   CC      drivers/xen/xenbus/xenbus_comms.o
+00:02:01   CC      drivers/acpi/acpica/utascii.o
+00:02:01   CC [M]  net/ipv6/netfilter/nf_conntrack_reasm.o
+00:02:01   CC [M]  net/sched/cls_matchall.o
+00:02:01   CC [M]  drivers/dma/dw-edma/dw-edma-v0-core.o
+00:02:01   CC      drivers/regulator/core.o
+00:02:01   AR      drivers/acpi/apei/built-in.a
+00:02:01   CC      net/packet/af_packet.o
+00:02:01   CC [M]  mm/hwpoison-inject.o
+00:02:01   CC      drivers/acpi/acpica/utbuffer.o
+00:02:01   CC      drivers/acpi/pmic/intel_pmic_bytcrc.o
+00:02:01   CC [M]  sound/pci/oxygen/xonar_dg_mixer.o
+00:02:01   CC      kernel/profile.o
+00:02:02   CC      net/ipv4/inet_timewait_sock.o
+00:02:02   CC      drivers/xen/xenbus/xenbus_xs.o
+00:02:02   CC      drivers/acpi/acpica/utcopy.o
+00:02:02   CC [M]  drivers/virtio/virtio_input.o
+00:02:02   CC [M]  drivers/dma/dw-edma/dw-edma-v0-debugfs.o
+00:02:02   CC      drivers/acpi/pmic/intel_pmic_chtcrc.o
+00:02:02   CC [M]  sound/firewire/motu/motu-transaction.o
+00:02:02   CC [M]  net/sched/em_cmp.o
+00:02:02   CC [M]  sound/pci/oxygen/xonar_dg.o
+00:02:02   AR      mm/built-in.a
+00:02:02   CC      net/strparser/strparser.o
+00:02:02   CC [M]  net/netfilter/ipvs/ip_vs_pe_sip.o
+00:02:02   CC      drivers/acpi/acpica/utexcep.o
+00:02:02   CC      drivers/acpi/pmic/intel_pmic_xpower.o
+00:02:02   CC      kernel/stacktrace.o
+00:02:02   CC [M]  net/ipv6/netfilter/nf_socket_ipv6.o
+00:02:02   CC [M]  sound/firewire/motu/motu-stream.o
+00:02:02   CC [M]  drivers/dma/dw-edma/dw-edma-pcie.o
+00:02:02   CC [M]  drivers/virtio/virtio_vdpa.o
+00:02:02   CC      drivers/xen/xenbus/xenbus_probe.o
+00:02:02   CC      drivers/acpi/acpica/utdebug.o
+00:02:03   CC [M]  sound/pci/oxygen/virtuoso.o
+00:02:03   CC      drivers/acpi/pmic/intel_pmic_bxtwc.o
+00:02:03   CC [M]  net/sched/em_nbyte.o
+00:02:03   CC      net/ipv4/inet_connection_sock.o
+00:02:03   CC      kernel/dma.o
+00:02:03   CC      drivers/acpi/acpica/utdecode.o
+00:02:03   CC [M]  drivers/virtio/virtio_mem.o
+00:02:03   CC [M]  sound/firewire/motu/motu-proc.o
+00:02:03   CC      drivers/acpi/pmic/intel_pmic_chtwc.o
+00:02:03   CC      kernel/smp.o
+00:02:03   CC [M]  sound/pci/oxygen/xonar_lib.o
+00:02:03   LD [M]  net/netfilter/ipvs/ip_vs.o
+00:02:03   AR      net/strparser/built-in.a
+00:02:03   LD [M]  drivers/dma/dw-edma/dw-edma.o
+00:02:03   CC      kernel/uid16.o
+00:02:03   CC      drivers/acpi/acpica/utdelete.o
+00:02:03   CC [M]  drivers/dma/ioat/init.o
+00:02:03   CC      net/netfilter/nf_queue.o
+00:02:03   CC [M]  net/ipv6/netfilter/nf_tproxy_ipv6.o
+00:02:03   CC      drivers/xen/xenbus/xenbus_probe_backend.o
+00:02:03   CC [M]  net/sched/em_u32.o
+00:02:03   CC      drivers/acpi/pmic/intel_pmic_chtdc_ti.o
+00:02:04   CC [M]  sound/firewire/motu/motu-pcm.o
+00:02:04   CC      drivers/acpi/acpica/uterror.o
+00:02:04   CC [M]  sound/pci/oxygen/xonar_pcm179x.o
+00:02:04   CC      fs/btrfs/ctree.o
+00:02:04   CC      net/packet/diag.o
+00:02:04   CC      drivers/regulator/dummy.o
+00:02:04   CC      drivers/xen/xenbus/xenbus_dev_frontend.o
+00:02:04   AR      drivers/acpi/pmic/built-in.a
+00:02:04   CC      fs/btrfs/extent-tree.o
+00:02:04   CC      drivers/acpi/acpica/uteval.o
+00:02:04   CC      kernel/module.o
+00:02:04   CC [M]  sound/firewire/fireface/ff.o
+00:02:04   CC [M]  net/sched/em_meta.o
+00:02:04   CC [M]  sound/firewire/motu/motu-midi.o
+00:02:04   CC [M]  drivers/dma/ioat/dma.o
+00:02:04   CC      net/ipv4/tcp.o
+00:02:04   CC      drivers/acpi/acpica/utglobal.o
+00:02:04   CC [M]  drivers/virtio/virtio_dma_buf.o
+00:02:04   CC      net/netfilter/nf_sockopt.o
+00:02:04   CC [M]  net/ipv6/netfilter/nf_reject_ipv6.o
+00:02:05   CC [M]  sound/pci/oxygen/xonar_cs43xx.o
+00:02:05   CC      drivers/regulator/fixed-helper.o
+00:02:05   CC [M]  sound/firewire/fireface/ff-transaction.o
+00:02:05   CC      drivers/xen/xenbus/xenbus_dev_backend.o
+00:02:05   CC      drivers/acpi/acpica/uthex.o
+00:02:05   CC [M]  sound/firewire/motu/motu-hwdep.o
+00:02:05   AR      drivers/virtio/built-in.a
+00:02:05   AR      net/packet/built-in.a
+00:02:05   CC      drivers/xen/xenbus/xenbus_probe_frontend.o
+00:02:05   CC [M]  drivers/xen/xenfs/super.o
+00:02:05   CC      drivers/acpi/acpica/utids.o
+00:02:05   CC [M]  sound/pci/oxygen/xonar_wm87x6.o
+00:02:05   CC [M]  sound/firewire/fireface/ff-midi.o
+00:02:05   CC [M]  drivers/dma/ioat/prep.o
+00:02:05   CC      drivers/regulator/helpers.o
+00:02:05   CC [M]  sound/pci/pcxhr/pcxhr.o
+00:02:05   CC      net/netfilter/utils.o
+00:02:05   CC [M]  sound/firewire/motu/motu-protocol-v2.o
+00:02:05   CC [M]  net/sched/em_text.o
+00:02:05   CC      drivers/acpi/acpica/utinit.o
+00:02:05   CC [M]  drivers/xen/xenfs/xenstored.o
+00:02:06   CC [M]  net/ipv6/netfilter/nf_dup_ipv6.o
+00:02:06   AR      drivers/xen/xenbus/built-in.a
+00:02:06   CC      drivers/dma/dmaengine.o
+00:02:06   CC [M]  sound/firewire/fireface/ff-proc.o
+00:02:06   CC      drivers/acpi/acpica/utlock.o
+00:02:06   CC [M]  sound/firewire/motu/motu-protocol-v3.o
+00:02:06   CC [M]  drivers/xen/xenfs/xensyms.o
+00:02:06   CC [M]  sound/pci/oxygen/xonar_hdmi.o
+00:02:06   CC [M]  net/sched/em_canid.o
+00:02:06   CC      drivers/acpi/acpica/utmath.o
+00:02:06   CC      drivers/regulator/devres.o
+00:02:06   CC [M]  drivers/dma/ioat/dca.o
+00:02:06   CC      kernel/module_signing.o
+00:02:06   CC [M]  sound/firewire/fireface/amdtp-ff.o
+00:02:06   CC [M]  sound/pci/pcxhr/pcxhr_hwdep.o
+00:02:06   CC      net/netfilter/x_tables.o
+00:02:06   CC      drivers/acpi/acpica/utmisc.o
+00:02:07   LD [M]  drivers/xen/xenfs/xenfs.o
+00:02:07   CC [M]  sound/firewire/motu/motu-protocol-v1.o
+00:02:07   CC [M]  drivers/xen/xen-pciback/pci_stub.o
+00:02:07   CC      kernel/module_signature.o
+00:02:07   CC [M]  net/ipv6/netfilter/nft_reject_ipv6.o
+00:02:07   LD [M]  sound/pci/oxygen/snd-oxygen-lib.o
+00:02:07   LD [M]  sound/pci/oxygen/snd-oxygen.o
+00:02:07   CC      kernel/kallsyms.o
+00:02:07   LD [M]  sound/pci/oxygen/snd-virtuoso.o
+00:02:07   CC      drivers/acpi/dptf/int340x_thermal.o
+00:02:07   CC [M]  drivers/dma/ioat/sysfs.o
+00:02:07   CC [M]  drivers/xen/xen-pciback/pciback_ops.o
+00:02:07   CC      fs/pstore/inode.o
+00:02:07   CC      drivers/acpi/acpica/utmutex.o
+00:02:07   CC [M]  sound/firewire/fireface/ff-stream.o
+00:02:07   CC      drivers/regulator/irq_helpers.o
+00:02:07   CC [M]  net/sched/em_ipset.o
+00:02:07   CC [M]  sound/pci/pcxhr/pcxhr_mixer.o
+00:02:07   CC      fs/btrfs/print-tree.o
+00:02:07   CC [M]  drivers/acpi/dptf/dptf_power.o
+00:02:07   LD [M]  sound/firewire/motu/snd-firewire-motu.o
+00:02:07   CC [M]  sound/pci/pcxhr/pcxhr_core.o
+00:02:07   CC      drivers/acpi/acpica/utnonansi.o
+00:02:07   CC      net/ipv4/tcp_input.o
+00:02:07   LD [M]  drivers/dma/ioat/ioatdma.o
+00:02:07   CC      drivers/dma/virt-dma.o
+00:02:07   CC      fs/pstore/platform.o
+00:02:07   CC [M]  sound/firewire/fireface/ff-pcm.o
+00:02:08   CC [M]  net/ipv6/netfilter/nft_dup_ipv6.o
+00:02:08   CC      drivers/acpi/acpica/utobject.o
+00:02:08   CC      kernel/acct.o
+00:02:08   CC [M]  drivers/acpi/dptf/dptf_pch_fivr.o
+00:02:08   CC [M]  sound/soc/codecs/ac97.o
+00:02:08   CC [M]  drivers/regulator/fixed.o
+00:02:08   CC [M]  drivers/xen/xen-pciback/xenbus.o
+00:02:08   CC [M]  sound/soc/generic/simple-card-utils.o
+00:02:08   CC [M]  net/sched/em_ipt.o
+00:02:08   CC      drivers/dma/acpi-dma.o
+00:02:08   CC [M]  fs/pstore/ram.o
+00:02:08   CC      drivers/acpi/acpica/utosi.o
+00:02:08   CC      net/netfilter/xt_tcpudp.o
+00:02:08   AR      drivers/acpi/dptf/built-in.a
+00:02:08   CC [M]  sound/pci/pcxhr/pcxhr_mix22.o
+00:02:08   CC      drivers/xen/cpu_hotplug.o
+00:02:08   CC [M]  sound/firewire/fireface/ff-hwdep.o
+00:02:08   CC [M]  sound/soc/codecs/adau-utils.o
+00:02:08   CC      fs/btrfs/root-tree.o
+00:02:08   CC [M]  drivers/regulator/arizona-ldo1.o
+00:02:08   CC      drivers/acpi/acpica/utownerid.o
+00:02:08   CC      kernel/crash_core.o
+00:02:08   CC [M]  sound/soc/codecs/adau17x1.o
+00:02:08   CC [M]  net/ipv6/netfilter/nft_fib_ipv6.o
+00:02:09   CC [M]  drivers/xen/xen-pciback/conf_space.o
+00:02:09   CC      kernel/kexec_core.o
+00:02:09   CC [M]  drivers/dma/altera-msgdma.o
+00:02:09   CC [M]  sound/soc/generic/simple-card.o
+00:02:09   CC [M]  fs/pstore/ram_core.o
+00:02:09   CC [M]  sound/firewire/fireface/ff-protocol-former.o
+00:02:09   CC      drivers/acpi/acpica/utpredef.o
+00:02:09   LD [M]  sound/pci/pcxhr/snd-pcxhr.o
+00:02:09   CC [M]  sound/pci/riptide/riptide.o
+00:02:09   AR      net/sched/built-in.a
+00:02:09   CC      fs/btrfs/dir-item.o
+00:02:09   CC      drivers/acpi/acpica/utresdecode.o
+00:02:09   CC      net/netfilter/nf_hooks_lwtunnel.o
+00:02:09   CC [M]  drivers/regulator/arizona-micsupp.o
+00:02:09   LD [M]  sound/soc/generic/snd-soc-simple-card-utils.o
+00:02:09   LD [M]  sound/soc/generic/snd-soc-simple-card.o
+00:02:09   CC      net/ipv6/anycast.o
+00:02:09   CC [M]  drivers/xen/xen-pciback/conf_space_header.o
+00:02:09   AR      fs/pstore/built-in.a
+00:02:09   LD [M]  fs/pstore/ramoops.o
+00:02:09   CC [M]  drivers/dma/idma64.o
+00:02:09   CC      drivers/acpi/acpica/utresrc.o
+00:02:09   CC [M]  sound/firewire/lib.o
+00:02:09   CC [M]  sound/firewire/fireface/ff-protocol-latter.o
+00:02:09   AR      drivers/reset/hisilicon/built-in.a
+00:02:10   CC      drivers/xen/grant-table.o
+00:02:10   CC [M]  sound/soc/codecs/adau1761.o
+00:02:10   CC      drivers/reset/core.o
+00:02:10   CC [M]  net/ipv6/netfilter/ip6t_ah.o
+00:02:10   CC      kernel/kexec.o
+00:02:10   CC      drivers/acpi/acpica/utstate.o
+00:02:10   CC [M]  sound/pci/rme9652/rme9652.o
+00:02:10   CC [M]  drivers/regulator/max8893.o
+00:02:10   LD [M]  sound/pci/riptide/snd-riptide.o
+00:02:10   CC [M]  drivers/xen/xen-pciback/conf_space_capability.o
+00:02:10   CC      net/ipv4/tcp_output.o
+00:02:10   LD [M]  sound/firewire/fireface/snd-fireface.o
+00:02:10   CC [M]  net/netfilter/nfnetlink.o
+00:02:10   CC [M]  sound/firewire/iso-resources.o
+00:02:10   CC      drivers/acpi/acpica/utstring.o
+00:02:10   AR      drivers/dma/built-in.a
+00:02:10   CC      net/ipv6/ip6_output.o
+00:02:10   AR      drivers/reset/built-in.a
+00:02:10   CC      fs/btrfs/file-item.o
+00:02:10   CC [M]  sound/soc/adi/axi-i2s.o
+00:02:10   CC [M]  sound/soc/codecs/adau1761-i2c.o
+00:02:10   CC      kernel/kexec_file.o
+00:02:10   CC [M]  sound/soc/adi/axi-spdif.o
+00:02:10   CC      drivers/acpi/acpica/utstrsuppt.o
+00:02:11   CC [M]  sound/firewire/packets-buffer.o
+00:02:11   CC [M]  drivers/regulator/rt4801-regulator.o
+00:02:11   CC [M]  net/ipv6/netfilter/ip6t_eui64.o
+00:02:11   CC      net/8021q/vlan_core.o
+00:02:11   CC [M]  drivers/xen/xen-pciback/conf_space_quirks.o
+00:02:11   CC      drivers/acpi/acpica/utstrtoul64.o
+00:02:11   CC      net/ipv6/ip6_input.o
+00:02:11   CC      fs/efivarfs/inode.o
+00:02:11   LD [M]  sound/soc/adi/snd-soc-adi-axi-i2s.o
+00:02:11   LD [M]  sound/soc/adi/snd-soc-adi-axi-spdif.o
+00:02:11   CC [M]  drivers/acpi/nfit/core.o
+00:02:11   CC [M]  sound/firewire/fcp.o
+00:02:11   CC [M]  sound/soc/codecs/adau1761-spi.o
+00:02:11   CC [M]  sound/pci/rme9652/hdsp.o
+00:02:11   CC      drivers/acpi/acpica/utxface.o
+00:02:11   CC [M]  net/netfilter/nfnetlink_acct.o
+00:02:11   CC [M]  drivers/xen/xen-pciback/vpci.o
+00:02:11   CC      kernel/compat.o
+00:02:11   CC [M]  drivers/regulator/rt4831-regulator.o
+00:02:12   CC      fs/efivarfs/file.o
+00:02:12   CC      drivers/acpi/acpica/utxfinit.o
+00:02:12   CC [M]  net/8021q/vlan.o
+00:02:12   CC [M]  net/ipv6/netfilter/ip6t_frag.o
+00:02:12   CC [M]  sound/firewire/cmp.o
+00:02:12   CC [M]  sound/soc/codecs/adau7002.o
+00:02:12   CC      fs/btrfs/inode-item.o
+00:02:12   CC      drivers/acpi/acpica/utxferror.o
+00:02:12   CC      fs/efivarfs/super.o
+00:02:12   CC [M]  drivers/xen/xen-pciback/passthrough.o
+00:02:12   CC      kernel/utsname.o
+00:02:12   CC [M]  drivers/regulator/rt6160-regulator.o
+00:02:12   CC      drivers/acpi/acpica/utxfmutex.o
+00:02:12   CC [M]  sound/firewire/amdtp-stream.o
+00:02:12   CC [M]  sound/pci/trident/trident.o
+00:02:12   CC [M]  net/netfilter/nfnetlink_queue.o
+00:02:12   CC [M]  sound/soc/codecs/adau7118.o
+00:02:12   CC      kernel/user_namespace.o
+00:02:13   AR      fs/efivarfs/built-in.a
+00:02:13   CC [M]  net/8021q/vlan_dev.o
+00:02:13   CC [M]  net/8021q/vlan_netlink.o
+00:02:13   CC [M]  sound/hda/ext/hdac_ext_bus.o
+00:02:13   AR      drivers/acpi/acpica/built-in.a
+00:02:13   LD [M]  drivers/xen/xen-pciback/xen-pciback.o
+00:02:13   CC      net/ipv6/addrconf.o
+00:02:13   CC      drivers/xen/features.o
+00:02:13   CC [M]  net/ipv6/netfilter/ip6t_ipv6header.o
+00:02:13   CC      net/ipv4/tcp_timer.o
+00:02:13   CC [M]  drivers/regulator/rt6245-regulator.o
+00:02:13   CC [M]  sound/pci/trident/trident_main.o
+00:02:13   CC      fs/btrfs/disk-io.o
+00:02:13   CC [M]  drivers/acpi/nfit/intel.o
+00:02:13   CC [M]  sound/hda/ext/hdac_ext_controller.o
+00:02:13   CC      kernel/pid_namespace.o
+00:02:13   CC      drivers/xen/balloon.o
+00:02:13   CC [M]  sound/pci/rme9652/hdspm.o
+00:02:13   CC [M]  sound/soc/codecs/adau7118-i2c.o
+00:02:13   CC      drivers/tty/vt/vt_ioctl.o
+00:02:14   CC [M]  net/8021q/vlan_gvrp.o
+00:02:14   CC [M]  sound/firewire/amdtp-am824.o
+00:02:14   CC [M]  drivers/regulator/rtmv20-regulator.o
+00:02:14   CC [M]  sound/hda/ext/hdac_ext_stream.o
+00:02:14   CC [M]  drivers/acpi/nfit/mce.o
+00:02:14   CC [M]  net/ipv6/netfilter/ip6t_mh.o
+00:02:14   CC      kernel/stop_machine.o
+00:02:14   CC [M]  net/netfilter/nfnetlink_log.o
+00:02:14   CC [M]  sound/soc/codecs/adau7118-hw.o
+00:02:14   CC      drivers/xen/manage.o
+00:02:14   CC      net/ipv4/tcp_ipv4.o
+00:02:14   CC [M]  net/8021q/vlan_mvrp.o
+00:02:14   CC [M]  sound/firewire/isight.o
+00:02:14   CC [M]  sound/soc/codecs/ak5558.o
+00:02:14   CC [M]  sound/pci/trident/trident_memory.o
+00:02:14   CC      drivers/tty/vt/vc_screen.o
+00:02:14   LD [M]  sound/hda/ext/snd-hda-ext-core.o
+00:02:14   CC [M]  sound/hda/hda_bus_type.o
+00:02:14   LD [M]  drivers/acpi/nfit/nfit.o
+00:02:14   CC      drivers/acpi/tables.o
+00:02:15   CC [M]  drivers/regulator/rtq2134-regulator.o
+00:02:15   CC      kernel/audit.o
+00:02:15   CC [M]  net/ipv6/netfilter/ip6t_hbh.o
+00:02:15   CC      drivers/xen/time.o
+00:02:15   CC [M]  sound/hda/hdac_bus.o
+00:02:15   LD [M]  sound/pci/trident/snd-trident.o
+00:02:15   CC [M]  net/8021q/vlanproc.o
+00:02:15   CC [M]  sound/soc/codecs/arizona.o
+00:02:15   LD [M]  sound/firewire/snd-firewire-lib.o
+00:02:15   LD [M]  sound/firewire/snd-isight.o
+00:02:15   CC      net/ipv4/tcp_minisocks.o
+00:02:15   CC      drivers/tty/vt/selection.o
+00:02:15   CC [M]  sound/soc/amd/raven/pci-acp3x.o
+00:02:15   LD [M]  sound/pci/rme9652/snd-rme9652.o
+00:02:15   CC      drivers/acpi/blacklist.o
+00:02:15   LD [M]  sound/pci/rme9652/snd-hdsp.o
+00:02:15   LD [M]  sound/pci/rme9652/snd-hdspm.o
+00:02:15   CC [M]  sound/pci/ymfpci/ymfpci.o
+00:02:15   CC [M]  drivers/regulator/rtq6752-regulator.o
+00:02:15   CC [M]  net/netfilter/nfnetlink_osf.o
+00:02:16   CC [M]  sound/hda/hdac_device.o
+00:02:16   CC      drivers/xen/mem-reservation.o
+00:02:16   CC      fs/btrfs/transaction.o
+00:02:16   CC      drivers/acpi/osi.o
+00:02:16   AR      net/8021q/built-in.a
+00:02:16   LD [M]  net/8021q/8021q.o
+00:02:16   CC [M]  sound/soc/amd/raven/acp3x-pcm-dma.o
+00:02:16   CC      drivers/tty/vt/keyboard.o
+00:02:16   CC      kernel/auditfilter.o
+00:02:16   CC [M]  net/ipv6/netfilter/ip6t_rpfilter.o
+00:02:16   CC [M]  sound/pci/ymfpci/ymfpci_main.o
+00:02:16   AR      drivers/regulator/built-in.a
+00:02:16   CC      drivers/acpi/osl.o
+00:02:16   CC      net/ipv6/addrlabel.o
+00:02:16   CC      drivers/xen/pci.o
+00:02:16   CC      drivers/acpi/utils.o
+00:02:16   CC      drivers/char/hw_random/core.o
+00:02:16   CC [M]  net/netfilter/nfnetlink_hook.o
+00:02:16   CC [M]  sound/soc/amd/raven/acp3x-i2s.o
+00:02:16   CC [M]  sound/soc/codecs/arizona-jack.o
+00:02:16   CC [M]  sound/hda/hdac_sysfs.o
+00:02:17   CC      drivers/tty/hvc/hvc_console.o
+00:02:17   CC      net/ipv4/tcp_cong.o
+00:02:17   CC [M]  net/ipv6/netfilter/ip6t_rt.o
+00:02:17   CC      drivers/tty/hvc/hvc_irq.o
+00:02:17   CC      drivers/char/hw_random/virtio-rng.o
+00:02:17   CC      drivers/xen/dbgp.o
+00:02:17   CC      drivers/tty/vt/consolemap.o
+00:02:17   LD [M]  sound/soc/amd/raven/snd-pci-acp3x.o
+00:02:17   LD [M]  sound/soc/amd/raven/snd-acp3x-pcm-dma.o
+00:02:17   LD [M]  sound/soc/amd/raven/snd-acp3x-i2s.o
+00:02:17   CC      drivers/acpi/reboot.o
+00:02:17   CC [M]  sound/soc/amd/renoir/rn-pci-acp3x.o
+00:02:17   CC [M]  sound/hda/hdac_regmap.o
+00:02:17   LD [M]  sound/pci/ymfpci/snd-ymfpci.o
+00:02:17   CC [M]  sound/soc/amd/renoir/acp3x-pdm-dma.o
+00:02:17   CC      kernel/auditsc.o
+00:02:17   CC [M]  sound/pci/vx222/vx222.o
+00:02:17   CC      drivers/tty/hvc/hvc_xen.o
+00:02:17   CC [M]  sound/pci/vx222/vx222_ops.o
+00:02:17   CC      fs/btrfs/inode.o
+00:02:17   CC [M]  net/netfilter/nf_conntrack_core.o
+00:02:17   CC [M]  drivers/char/hw_random/timeriomem-rng.o
+00:02:18   CC      drivers/xen/acpi.o
+00:02:18   CC      drivers/acpi/nvs.o
+00:02:18   CC [M]  sound/soc/codecs/bd28623.o
+00:02:18   CC [M]  fs/dlm/ast.o
+00:02:18   CC [M]  sound/hda/hdac_controller.o
+00:02:18   HOSTCC  drivers/tty/vt/conmakehash
+00:02:18   CC [M]  drivers/char/hw_random/intel-rng.o
+00:02:18   CC      drivers/char/agp/backend.o
+00:02:18   CC [M]  sound/soc/amd/renoir/acp3x-rn.o
+00:02:18   CC      net/ipv4/tcp_metrics.o
+00:02:18   CC [M]  net/ipv6/netfilter/ip6t_srh.o
+00:02:18   CC      drivers/tty/vt/vt.o
+00:02:18   LD [M]  sound/pci/vx222/snd-vx222.o
+00:02:18   CC [M]  sound/pci/ad1889.o
+00:02:18   CC      drivers/xen/xen-acpi-pad.o
+00:02:18   AR      drivers/tty/hvc/built-in.a
+00:02:18   CC      drivers/acpi/wakeup.o
+00:02:18   CC      drivers/iommu/amd/iommu.o
+00:02:18   CC [M]  fs/dlm/config.o
+00:02:18   CC [M]  sound/soc/codecs/bt-sco.o
+00:02:18   CC [M]  drivers/char/hw_random/amd-rng.o
+00:02:18   LD [M]  sound/soc/amd/renoir/snd-rn-pci-acp3x.o
+00:02:19   LD [M]  sound/soc/amd/renoir/snd-acp3x-pdm-dma.o
+00:02:19   CC [M]  sound/hda/hdac_stream.o
+00:02:19   LD [M]  sound/soc/amd/renoir/snd-acp3x-rn.o
+00:02:19   CC      drivers/char/agp/generic.o
+00:02:19   CC [M]  sound/soc/amd/vangogh/pci-acp5x.o
+00:02:19   CC      drivers/acpi/sleep.o
+00:02:19   CC      drivers/xen/pcpu.o
+00:02:19   CC [M]  sound/pci/als300.o
+00:02:19   CC      kernel/audit_watch.o
+00:02:19   CC [M]  sound/soc/codecs/cros_ec_codec.o
+00:02:19   CC [M]  drivers/char/hw_random/via-rng.o
+00:02:19   CC [M]  net/ipv6/netfilter/ip6t_NPT.o
+00:02:19   CC [M]  sound/soc/amd/vangogh/acp5x-i2s.o
+00:02:19   CC [M]  sound/hda/array.o
+00:02:19   CC      net/ipv4/tcp_fastopen.o
+00:02:19   CC [M]  drivers/char/hw_random/xiphera-trng.o
+00:02:19   CC      drivers/xen/biomerge.o
+00:02:20   CC      drivers/char/agp/isoch.o
+00:02:20   CC [M]  fs/dlm/dir.o
+00:02:20   CC [M]  sound/pci/als4000.o
+00:02:20   CC      kernel/audit_fsnotify.o
+00:02:20   CC      drivers/acpi/device_sysfs.o
+00:02:20   CC [M]  net/netfilter/nf_conntrack_standalone.o
+00:02:20   CC [M]  sound/hda/hdmi_chmap.o
+00:02:20   CC [M]  sound/soc/amd/vangogh/acp5x-pcm-dma.o
+00:02:20   AR      drivers/char/hw_random/built-in.a
+00:02:20   CC [M]  net/ipv6/netfilter/ip6t_REJECT.o
+00:02:20   CC [M]  sound/soc/codecs/cs35l34.o
+00:02:20   CC      drivers/xen/xen-balloon.o
+00:02:20   CC [M]  fs/dlm/lock.o
+00:02:20   CC      drivers/iommu/amd/init.o
+00:02:20   CC      drivers/char/agp/compat_ioctl.o
+00:02:20   CC [M]  sound/x86/intel_hdmi_audio.o
+00:02:20   SHIPPED drivers/tty/vt/defkeymap.c
+00:02:20   CONMK   drivers/tty/vt/consolemap_deftbl.c
+00:02:20   CC      drivers/acpi/device_pm.o
+00:02:20   CC      drivers/tty/vt/defkeymap.o
+00:02:20   CC      kernel/audit_tree.o
+00:02:20   CC [M]  sound/pci/atiixp.o
+00:02:20   CC      drivers/tty/vt/consolemap_deftbl.o
+00:02:20   LD [M]  sound/soc/amd/vangogh/snd-pci-acp5x.o
+00:02:20   LD [M]  sound/soc/amd/vangogh/snd-acp5x-i2s.o
+00:02:21   LD [M]  sound/soc/amd/vangogh/snd-acp5x-pcm-dma.o
+00:02:21   AR      drivers/tty/vt/built-in.a
+00:02:21   CC      drivers/xen/sys-hypervisor.o
+00:02:21   CC [M]  sound/soc/amd/acp-pcm-dma.o
+00:02:21   CC      drivers/tty/serial/8250/8250_core.o
+00:02:21   CC      net/ipv4/tcp_rate.o
+00:02:21   CC [M]  sound/hda/trace.o
+00:02:21   CC      drivers/char/agp/frontend.o
+00:02:21   CC [M]  net/ipv6/netfilter/ip6t_SYNPROXY.o
+00:02:21   CC [M]  sound/soc/codecs/cs35l35.o
+00:02:21   CC [M]  net/netfilter/nf_conntrack_expect.o
+00:02:21   CC      drivers/xen/platform-pci.o
+00:02:21   CC [M]  sound/pci/atiixp_modem.o
+00:02:21   LD [M]  sound/x86/snd-hdmi-lpe-audio.o
+00:02:21   CC      drivers/acpi/proc.o
+00:02:21   CC      drivers/tty/serdev/core.o
+00:02:21   CC      kernel/kprobes.o
+00:02:21   CC [M]  sound/hda/hdac_component.o
+00:02:21   CC [M]  sound/soc/amd/acp-da7219-max98357a.o
+00:02:22   CC      drivers/tty/serial/8250/8250_pnp.o
+00:02:22   CC      drivers/char/agp/amd64-agp.o
+00:02:22   CC      drivers/iommu/amd/quirks.o
+00:02:22   CC      net/ipv4/tcp_recovery.o
+00:02:22   CC      drivers/xen/swiotlb-xen.o
+00:02:22   CC      drivers/tty/serdev/serdev-ttyport.o
+00:02:22   LD [M]  net/ipv6/netfilter/nf_defrag_ipv6.o
+00:02:22   CC [M]  sound/soc/codecs/cs35l36.o
+00:02:22   CC [M]  sound/hda/hdac_i915.o
+00:02:22   CC [M]  sound/pci/azt3328.o
+00:02:22   CC      drivers/acpi/bus.o
+00:02:22   CC      net/ipv6/route.o
+00:02:22   CC      drivers/iommu/amd/io_pgtable.o
+00:02:22   CC      drivers/tty/serial/8250/8250_port.o
+00:02:22   CC [M]  net/netfilter/nf_conntrack_helper.o
+00:02:22   CC      drivers/char/agp/intel-agp.o
+00:02:22   CC [M]  sound/soc/amd/acp-rt5645.o
+00:02:22   CC      fs/btrfs/file.o
+00:02:22   AR      drivers/tty/serdev/built-in.a
+00:02:22   CC      net/wireless/wext-core.o
+00:02:23   CC [M]  sound/hda/intel-dsp-config.o
+00:02:23   CC [M]  fs/dlm/lockspace.o
+00:02:23   CC      net/ipv4/tcp_ulp.o
+00:02:23   CC      kernel/watchdog.o
+00:02:23   CC      drivers/xen/efi.o
+00:02:23   CC [M]  drivers/iommu/amd/iommu_v2.o
+00:02:23   CC      drivers/char/agp/intel-gtt.o
+00:02:23   CC [M]  sound/pci/bt87x.o
+00:02:23   CC [M]  sound/soc/amd/acp3x-rt5682-max9836.o
+00:02:23   CC [M]  sound/soc/codecs/cs42l42.o
+00:02:23   CC      drivers/acpi/glue.o
+00:02:23   CC [M]  sound/hda/intel-nhlt.o
+00:02:23   CC [M]  fs/dlm/main.o
+00:02:23   CC [M]  net/netfilter/nf_conntrack_proto.o
+00:02:23   CC      net/wireless/wext-proc.o
+00:02:23   CC      kernel/watchdog_hld.o
+00:02:23   CC      drivers/xen/xlate_mmu.o
+00:02:24   CC [M]  sound/hda/intel-sdw-acpi.o
+00:02:24   CC [M]  fs/dlm/member.o
+00:02:24   AR      drivers/iommu/amd/built-in.a
+00:02:24   CC      drivers/iommu/intel/dmar.o
+00:02:24   CC      net/ipv4/tcp_offload.o
+00:02:24   CC      drivers/acpi/scan.o
+00:02:24   CC      drivers/tty/serial/8250/8250_dma.o
+00:02:24   CC [M]  sound/pci/cmipci.o
+00:02:24   CC      drivers/char/agp/sis-agp.o
+00:02:24   LD [M]  sound/soc/amd/acp_audio_dma.o
+00:02:24   LD [M]  sound/soc/amd/snd-soc-acp-da7219mx98357-mach.o
+00:02:24   LD [M]  sound/soc/amd/snd-soc-acp-rt5645-mach.o
+00:02:24   LD [M]  sound/soc/amd/snd-soc-acp-rt5682-mach.o
+00:02:24   CC [M]  fs/squashfs/block.o
+00:02:24   LD [M]  sound/hda/snd-hda-core.o
+00:02:24   LD [M]  sound/hda/snd-intel-dspcfg.o
+00:02:24   LD [M]  sound/hda/snd-intel-sdw-acpi.o
+00:02:24   CC      drivers/iommu/intel/iommu.o
+00:02:24   CC      kernel/seccomp.o
+00:02:24   CC [M]  net/wireless/core.o
+00:02:24   CC [M]  sound/soc/codecs/cs4234.o
+00:02:24   CC      drivers/xen/unpopulated-alloc.o
+00:02:24   CC [M]  fs/dlm/memory.o
+00:02:24   CC      drivers/tty/serial/8250/8250_dwlib.o
+00:02:24   CC      drivers/char/agp/via-agp.o
+00:02:25   CC [M]  net/netfilter/nf_conntrack_proto_generic.o
+00:02:25   CC [M]  fs/dlm/midcomms.o
+00:02:25   CC [M]  fs/squashfs/cache.o
+00:02:25   CC [M]  drivers/xen/evtchn.o
+00:02:25   CC      fs/btrfs/tree-defrag.o
+00:02:25   CC      net/ipv4/datagram.o
+00:02:25   CC      drivers/tty/serial/8250/8250_pci.o
+00:02:25   CC      drivers/acpi/resource.o
+00:02:25   AR      drivers/char/agp/built-in.a
+00:02:25   AR      drivers/char/pcmcia/built-in.a
+00:02:25   CC [M]  sound/soc/codecs/cs43130.o
+00:02:25   CC      fs/btrfs/extent_map.o
+00:02:25   CC      drivers/char/tpm/tpm-chip.o
+00:02:25   CC [M]  sound/pci/cs4281.o
+00:02:25   CC [M]  fs/squashfs/dir.o
+00:02:26   CC [M]  drivers/xen/gntdev.o
+00:02:26   CC      kernel/relay.o
+00:02:26   CC [M]  net/netfilter/nf_conntrack_proto_tcp.o
+00:02:26   CC      drivers/acpi/acpi_processor.o
+00:02:26   CC      net/ipv6/ip6_fib.o
+00:02:26   CC      drivers/char/tpm/tpm-dev-common.o
+00:02:26   CC [M]  fs/squashfs/export.o
+00:02:26   CC      kernel/utsname_sysctl.o
+00:02:26   CC [M]  net/wireless/sysfs.o
+00:02:26   CC      net/ipv4/raw.o
+00:02:26   CC [M]  drivers/tty/serial/jsm/jsm_driver.o
+00:02:26   CC [M]  fs/dlm/netlink.o
+00:02:26   CC      drivers/tty/serial/8250/8250_early.o
+00:02:26   CC [M]  sound/pci/ens1370.o
+00:02:26   CC [M]  fs/squashfs/file.o
+00:02:26   CC      fs/btrfs/sysfs.o
+00:02:26   CC      drivers/char/tpm/tpm-dev.o
+00:02:26   CC [M]  sound/soc/codecs/cx2072x.o
+00:02:26   CC      kernel/delayacct.o
+00:02:26   CC      drivers/acpi/processor_core.o
+00:02:27   CC [M]  drivers/xen/gntalloc.o
+00:02:27   CC      drivers/tty/serial/8250/8250_dw.o
+00:02:27   CC [M]  drivers/tty/serial/jsm/jsm_neo.o
+00:02:27   CC [M]  fs/dlm/lowcomms.o
+00:02:27   CC      drivers/iommu/intel/pasid.o
+00:02:27   CC      kernel/taskstats.o
+00:02:27   CC [M]  fs/squashfs/fragment.o
+00:02:27   CC      drivers/char/tpm/tpm-interface.o
+00:02:27   CC      drivers/acpi/processor_pdc.o
+00:02:27   CC [M]  net/wireless/radiotap.o
+00:02:27   CC [M]  sound/pci/ak4531_codec.o
+00:02:27   CC [M]  net/netfilter/nf_conntrack_proto_udp.o
+00:02:27   CC [M]  fs/squashfs/id.o
+00:02:27   CC [M]  drivers/xen/privcmd.o
+00:02:27   CC      drivers/tty/serial/8250/8250_mid.o
+00:02:27   CC      net/ipv4/udp.o
+00:02:27   CC      drivers/acpi/ec.o
+00:02:28   CC [M]  sound/soc/codecs/da7213.o
+00:02:28   CC      drivers/iommu/intel/trace.o
+00:02:28   CC      net/ipv6/ipv6_sockglue.o
+00:02:28   CC [M]  drivers/tty/serial/jsm/jsm_tty.o
+00:02:28   CC [M]  fs/squashfs/inode.o
+00:02:28   CC [M]  sound/pci/ens1371.o
+00:02:28   CC      kernel/tsacct.o
+00:02:28   CC [M]  net/wireless/util.o
+00:02:28   CC      drivers/char/tpm/tpm1-cmd.o
+00:02:28   CC      fs/btrfs/struct-funcs.o
+00:02:28   CC [M]  drivers/tty/serial/8250/8250_exar.o
+00:02:28   CC [M]  net/netfilter/nf_conntrack_proto_icmp.o
+00:02:28   CC [M]  fs/squashfs/namei.o
+00:02:28   CC      kernel/tracepoint.o
+00:02:28   CC [M]  drivers/xen/privcmd-buf.o
+00:02:28   CC      drivers/iommu/intel/cap_audit.o
+00:02:28   CC [M]  drivers/tty/serial/jsm/jsm_cls.o
+00:02:29   CC [M]  fs/dlm/plock.o
+00:02:29   CC [M]  sound/soc/codecs/da7219.o
+00:02:29   CC      drivers/char/tpm/tpm2-cmd.o
+00:02:29   CC      drivers/acpi/dock.o
+00:02:29   CC [M]  sound/pci/es1938.o
+00:02:29   CC [M]  drivers/tty/serial/8250/serial_cs.o
+00:02:29   CC [M]  fs/squashfs/super.o
+00:02:29   CC      kernel/latencytop.o
+00:02:29   CC [M]  drivers/xen/xen-acpi-processor.o
+00:02:29   CC [M]  fs/dlm/rcom.o
+00:02:29   LD [M]  drivers/tty/serial/jsm/jsm.o
+00:02:29   CC      fs/btrfs/xattr.o
+00:02:29   AR      drivers/tty/ipwireless/built-in.a
+00:02:29   CC [M]  drivers/tty/ipwireless/hardware.o
+00:02:29   CC      net/ipv6/ndisc.o
+00:02:29   CC      drivers/iommu/intel/svm.o
+00:02:29   CC      drivers/acpi/pci_root.o
+00:02:29   CC [M]  net/netfilter/nf_conntrack_extend.o
+00:02:29   CC      drivers/char/tpm/tpmrm-dev.o
+00:02:29   CC      kernel/irq_work.o
+00:02:30   CC [M]  drivers/tty/serial/8250/8250_lpss.o
+00:02:30   CC [M]  fs/squashfs/symlink.o
+00:02:30   CC [M]  fs/dlm/recover.o
+00:02:30   CC [M]  sound/soc/codecs/da7219-aad.o
+00:02:30   CC [M]  drivers/xen/xen-scsiback.o
+00:02:30   CC [M]  sound/pci/es1968.o
+00:02:30   CC      kernel/static_call.o
+00:02:30   CC      drivers/char/tpm/tpm2-space.o
+00:02:30   CC      net/ipv4/udplite.o
+00:02:30   CC [M]  fs/squashfs/decompressor.o
+00:02:30   CC [M]  net/wireless/reg.o
+00:02:30   CC      drivers/acpi/pci_link.o
+00:02:30   AR      drivers/tty/serial/8250/built-in.a
+00:02:30   CC [M]  drivers/tty/ipwireless/main.o
+00:02:30   CC      drivers/tty/serial/serial_core.o
+00:02:30   CC      kernel/static_call_inline.o
+00:02:30   CC      drivers/iommu/intel/irq_remapping.o
+00:02:30   CC [M]  fs/dlm/recoverd.o
+00:02:30   CC [M]  net/netfilter/nf_conntrack_acct.o
+00:02:30   CC      fs/btrfs/ordered-data.o
+00:02:31   CC [M]  sound/soc/codecs/dmic.o
+00:02:31   CC [M]  fs/squashfs/file_direct.o
+00:02:31   CC      drivers/char/tpm/tpm-sysfs.o
+00:02:31   CC      kernel/user-return-notifier.o
+00:02:31   CC [M]  drivers/tty/ipwireless/network.o
+00:02:31   CC [M]  fs/dlm/requestqueue.o
+00:02:31   CC      drivers/acpi/pci_irq.o
+00:02:31   CC      kernel/padata.o
+00:02:31   CC      net/ipv4/udp_offload.o
+00:02:31   CC [M]  drivers/xen/xen-front-pgdir-shbuf.o
+00:02:31   CC      net/ipv6/udp.o
+00:02:31   CC [M]  fs/squashfs/page_actor.o
+00:02:31   CC [M]  sound/soc/codecs/es7134.o
+00:02:31   CC [M]  fs/dlm/user.o
+00:02:31   AR      drivers/iommu/intel/built-in.a
+00:02:31   CC [M]  net/netfilter/nf_conntrack_seqadj.o
+00:02:31   AR      drivers/iommu/arm/arm-smmu/built-in.a
+00:02:31   CC      drivers/char/tpm/eventlog/common.o
+00:02:31   AR      drivers/iommu/arm/arm-smmu-v3/built-in.a
+00:02:31   AR      drivers/iommu/arm/built-in.a
+00:02:31   CC      drivers/iommu/iommu.o
+00:02:32   CC [M]  sound/pci/fm801.o
+00:02:32   CC      drivers/acpi/acpi_lpss.o
+00:02:32   CC [M]  drivers/tty/ipwireless/tty.o
+00:02:32   LD [M]  drivers/xen/xen-evtchn.o
+00:02:32   LD [M]  drivers/xen/xen-gntdev.o
+00:02:32   LD [M]  drivers/xen/xen-gntalloc.o
+00:02:32   CC      kernel/crash_dump.o
+00:02:32   LD [M]  drivers/xen/xen-privcmd.o
+00:02:32   AR      drivers/xen/built-in.a
+00:02:32   CC [M]  fs/squashfs/decompressor_multi_percpu.o
+00:02:32   CC      drivers/tty/serial/earlycon.o
+00:02:32   CC      drivers/iommu/iommu-traces.o
+00:02:32   CC [M]  sound/soc/codecs/es8316.o
+00:02:32   CC      fs/btrfs/extent_io.o
+00:02:32   CC [M]  fs/dlm/util.o
+00:02:32   CC      drivers/char/tpm/eventlog/tpm1.o
+00:02:32   CC      kernel/jump_label.o
+00:02:32   CC      net/ipv4/arp.o
+00:02:32   CC [M]  fs/dlm/debug_fs.o
+00:02:32   CC      drivers/tty/serial/serial_mctrl_gpio.o
+00:02:32   LD [M]  drivers/tty/ipwireless/ipwireless.o
+00:02:32   CC [M]  sound/pci/intel8x0.o
+00:02:32   CC [M]  fs/squashfs/xattr.o
+00:02:32   CC [M]  net/netfilter/nf_conntrack_proto_icmpv6.o
+00:02:33   CC [M]  net/wireless/scan.o
+00:02:33   CC      drivers/char/tpm/eventlog/tpm2.o
+00:02:33   CC      drivers/acpi/acpi_apd.o
+00:02:33   CC [M]  fs/coda/psdev.o
+00:02:33   CC [M]  sound/soc/codecs/es8328.o
+00:02:33   CC [M]  fs/coda/cache.o
+00:02:33   CC      kernel/context_tracking.o
+00:02:33   CC      drivers/tty/serial/kgdboc.o
+00:02:33   CC [M]  fs/squashfs/xattr_id.o
+00:02:33   CC      drivers/iommu/iommu-sysfs.o
+00:02:33   LD [M]  fs/dlm/dlm.o
+00:02:33   CC      net/ipv6/udplite.o
+00:02:33   CC      drivers/acpi/acpi_platform.o
+00:02:33   CC [M]  sound/soc/codecs/es8328-i2c.o
+00:02:33   CC      drivers/char/tpm/tpm_ppi.o
+00:02:33   CC [M]  fs/squashfs/lz4_wrapper.o
+00:02:33   CC      drivers/iommu/dma-iommu.o
+00:02:33   CC [M]  drivers/char/mwave/mwavedd.o
+00:02:34   CC [M]  fs/coda/cnode.o
+00:02:34   CC [M]  drivers/tty/serial/sc16is7xx.o
+00:02:34   CC      kernel/iomem.o
+00:02:34   CC      net/netlabel/netlabel_user.o
+00:02:34   CC [M]  net/netfilter/nf_conntrack_timestamp.o
+00:02:34   CC [M]  sound/pci/intel8x0m.o
+00:02:34   CC      drivers/acpi/acpi_pnp.o
+00:02:34   CC      drivers/char/tpm/eventlog/acpi.o
+00:02:34   CC      net/ipv4/icmp.o
+00:02:34   CC [M]  sound/soc/codecs/es8328-spi.o
+00:02:34   CC [M]  fs/squashfs/lzo_wrapper.o
+00:02:34   CC [M]  drivers/char/mwave/smapi.o
+00:02:34   CC      kernel/rseq.o
+00:02:34   CC      net/ipv6/raw.o
+00:02:34   CC      drivers/acpi/power.o
+00:02:34   CC [M]  fs/coda/inode.o
+00:02:34   CC      drivers/char/tpm/eventlog/efi.o
+00:02:34   CC      net/netlabel/netlabel_kapi.o
+00:02:35   CC [M]  sound/pci/maestro3.o
+00:02:35   CC      drivers/iommu/io-pgtable.o
+00:02:35   CC [M]  sound/soc/codecs/hdac_hdmi.o
+00:02:35   CC [M]  fs/squashfs/xz_wrapper.o
+00:02:35   CC [M]  net/netfilter/nf_conntrack_ecache.o
+00:02:35   CC [M]  drivers/char/mwave/tp3780i.o
+00:02:35   CC [M]  drivers/tty/serial/arc_uart.o
+00:02:35   CC      drivers/acpi/event.o
+00:02:35   CC      kernel/watch_queue.o
+00:02:35   CC [M]  net/wireless/nl80211.o
+00:02:35   CC [M]  fs/coda/dir.o
+00:02:35   CC      drivers/char/tpm/tpm_tis_core.o
+00:02:35   CC      drivers/iommu/ioasid.o
+00:02:35   CC [M]  fs/squashfs/zlib_wrapper.o
+00:02:35   AR      drivers/tty/serial/built-in.a
+00:02:35   CC      drivers/tty/tty_io.o
+00:02:35   CC [M]  drivers/char/mwave/3780i.o
+00:02:35   CC      net/ipv4/devinet.o
+00:02:35   CC      drivers/iommu/iova.o
+00:02:36   CC [M]  sound/pci/rme32.o
+00:02:36   CC      drivers/acpi/evged.o
+00:02:36   CC      fs/btrfs/volumes.o
+00:02:36   CHK     kernel/kheaders_data.tar.xz
+00:02:36   CC [M]  net/netfilter/nf_conntrack_labels.o
+00:02:36   CC      net/ipv6/icmp.o
+00:02:36   CC      net/netlabel/netlabel_domainhash.o
+00:02:36   GEN     kernel/kheaders_data.tar.xz
+00:02:36   CC [M]  fs/squashfs/zstd_wrapper.o
+00:02:36   CC [M]  fs/coda/file.o
+00:02:36   CC [M]  sound/soc/codecs/hdac_hda.o
+00:02:36   LD [M]  drivers/char/mwave/mwave.o
+00:02:36   CC [M]  sound/pci/rme96.o
+00:02:36   CC      drivers/char/tpm/tpm_tis.o
+00:02:36   CC      drivers/acpi/sysfs.o
+00:02:36   CC      drivers/iommu/irq_remapping.o
+00:02:36   LD [M]  fs/squashfs/squashfs.o
+00:02:36   CC      drivers/acpi/property.o
+00:02:37   CC [M]  sound/soc/codecs/max9759.o
+00:02:37   CC      drivers/char/tpm/tpm_crb.o
+00:02:37   CC [M]  fs/coda/upcall.o
+00:02:37   CC [M]  fs/minix/bitmap.o
+00:02:37   CC [M]  net/netfilter/nf_conntrack_proto_sctp.o
+00:02:37   AR      drivers/gpu/drm/arm/built-in.a
+00:02:37   CC      drivers/tty/n_tty.o
+00:02:37   AR      drivers/gpu/drm/rcar-du/built-in.a
+00:02:37   AR      drivers/gpu/drm/omapdrm/built-in.a
+00:02:37   CC      drivers/iommu/hyperv-iommu.o
+00:02:37   AR      drivers/gpu/drm/tilcdc/built-in.a
+00:02:37   AR      drivers/gpu/drm/imx/built-in.a
+00:02:37   CC      net/netlabel/netlabel_addrlist.o
+00:02:37   AR      drivers/gpu/drm/i2c/built-in.a
+00:02:37   CC [M]  drivers/gpu/drm/i2c/ch7006_drv.o
+00:02:37   CC [M]  sound/soc/codecs/max98088.o
+00:02:37   CC [M]  sound/pci/sonicvibes.o
+00:02:37   CC [M]  fs/minix/itree_v1.o
+00:02:37   CC      net/ipv6/mcast.o
+00:02:37   CC      drivers/acpi/acpi_cmos_rtc.o
+00:02:37   CC [M]  drivers/char/tpm/tpm_tis_spi_main.o
+00:02:37   CC      net/ipv4/af_inet.o
+00:02:38   CC      drivers/iommu/virtio-iommu.o
+00:02:38   CC [M]  fs/coda/coda_linux.o
+00:02:38   CC [M]  fs/minix/itree_v2.o
+00:02:38   CC [M]  drivers/gpu/drm/i2c/ch7006_mode.o
+00:02:38   CC      drivers/tty/tty_ioctl.o
+00:02:38   CC [M]  drivers/char/tpm/tpm_tis_spi_cr50.o
+00:02:38   CC      drivers/acpi/x86/apple.o
+00:02:38   CC      net/netlabel/netlabel_mgmt.o
+00:02:38   CC [M]  net/netfilter/nf_conntrack_proto_gre.o
+00:02:38   CC [M]  sound/pci/via82xx.o
+00:02:38   CC [M]  sound/soc/codecs/max98090.o
+00:02:38   CC [M]  fs/coda/symlink.o
+00:02:39   CC      drivers/acpi/x86/utils.o
+00:02:39   CC [M]  drivers/char/tpm/tpm_tis_i2c_cr50.o
+00:02:39   CC      drivers/iommu/iommu-sva-lib.o
+00:02:39   CC [M]  fs/minix/namei.o
+00:02:39   CC      drivers/tty/tty_ldisc.o
+00:02:39   CC [M]  drivers/gpu/drm/i2c/sil164_drv.o
+00:02:39   CC      drivers/acpi/x86/s2idle.o
+00:02:39   CC      drivers/iommu/io-pgfault.o
+00:02:39   CC [M]  fs/coda/pioctl.o
+00:02:39   CC      net/ipv4/igmp.o
+00:02:39   CC [M]  net/netfilter/nf_conntrack_netlink.o
+00:02:39   CC      net/netlabel/netlabel_unlabeled.o
+00:02:39   CC [M]  fs/minix/inode.o
+00:02:40   CC      fs/btrfs/async-thread.o
+00:02:40   CC      drivers/tty/tty_buffer.o
+00:02:40   CC [M]  sound/soc/codecs/max98357a.o
+00:02:40   CC [M]  sound/pci/via82xx_modem.o
+00:02:40   CC [M]  drivers/char/tpm/tpm_i2c_atmel.o
+00:02:40   CC      net/ipv6/reassembly.o
+00:02:40   AR      drivers/iommu/built-in.a
+00:02:40   CC      net/ipv6/tcp_ipv6.o
+00:02:40   CC [M]  fs/coda/sysctl.o
+00:02:40   LD [M]  drivers/gpu/drm/i2c/ch7006.o
+00:02:40   LD [M]  drivers/gpu/drm/i2c/sil164.o
+00:02:40   CC      drivers/acpi/debugfs.o
+00:02:40   AR      drivers/gpu/drm/panel/built-in.a
+00:02:40   CC [M]  drivers/gpu/drm/panel/panel-widechips-ws2401.o
+00:02:40   CC      drivers/tty/tty_port.o
+00:02:40   CC [M]  sound/soc/codecs/max9867.o
+00:02:40   LD [M]  fs/coda/coda.o
+00:02:40   CC [M]  drivers/char/tpm/tpm_i2c_infineon.o
+00:02:40   CC [M]  fs/minix/file.o
+00:02:41   CC      fs/btrfs/ioctl.o
+00:02:41   LD [M]  sound/pci/snd-ad1889.o
+00:02:41   LD [M]  sound/pci/snd-als300.o
+00:02:41   LD [M]  sound/pci/snd-als4000.o
+00:02:41   LD [M]  sound/pci/snd-atiixp.o
+00:02:41   CC      drivers/acpi/acpi_lpat.o
+00:02:41   LD [M]  sound/pci/snd-atiixp-modem.o
+00:02:41   LD [M]  sound/pci/snd-azt3328.o
+00:02:41   LD [M]  sound/pci/snd-bt87x.o
+00:02:41   LD [M]  sound/pci/snd-cmipci.o
+00:02:41   LD [M]  sound/pci/snd-cs4281.o
+00:02:41   LD [M]  sound/pci/snd-ens1370.o
+00:02:41   LD [M]  sound/pci/snd-ens1371.o
+00:02:41   CC [M]  sound/xen/xen_snd_front.o
+00:02:41   LD [M]  sound/pci/snd-es1938.o
+00:02:41   LD [M]  sound/pci/snd-es1968.o
+00:02:41   CC      net/netlabel/netlabel_cipso_v4.o
+00:02:41   LD [M]  sound/pci/snd-fm801.o
+00:02:41   LD [M]  sound/pci/snd-intel8x0.o
+00:02:41   LD [M]  sound/pci/snd-intel8x0m.o
+00:02:41   LD [M]  sound/pci/snd-maestro3.o
+00:02:41   LD [M]  sound/pci/snd-rme32.o
+00:02:41   LD [M]  sound/pci/snd-rme96.o
+00:02:41   LD [M]  sound/pci/snd-sonicvibes.o
+00:02:41   LD [M]  sound/pci/snd-via82xx.o
+00:02:41   LD [M]  sound/pci/snd-via82xx-modem.o
+00:02:41   CC      drivers/tty/tty_mutex.o
+00:02:41   CC [M]  fs/minix/dir.o
+00:02:41   CC      net/ipv6/ping.o
+00:02:41   CC      drivers/acpi/acpi_fpdt.o
+00:02:41   AR      drivers/gpu/drm/bridge/analogix/built-in.a
+00:02:41   CC [M]  drivers/gpu/drm/bridge/analogix/analogix-anx78xx.o
+00:02:41   CC [M]  sound/soc/codecs/max98927.o
+00:02:41   CC      net/dcb/dcbnl.o
+00:02:41   CC [M]  drivers/char/tpm/tpm_i2c_nuvoton.o
+00:02:41   CC [M]  sound/xen/xen_snd_front_cfg.o
+00:02:42   CC      drivers/tty/tty_ldsem.o
+00:02:42   CC      net/ipv4/fib_frontend.o
+00:02:42   CC [M]  net/netfilter/nf_conntrack_amanda.o
+00:02:42   CC      drivers/acpi/acpi_lpit.o
+00:02:42   CC      net/netlabel/netlabel_calipso.o
+00:02:42   LD [M]  fs/minix/minix.o
+00:02:42   CC      net/ipv6/exthdrs.o
+00:02:42   CC [M]  drivers/char/tpm/tpm_nsc.o
+00:02:42   CC [M]  sound/xen/xen_snd_front_evtchnl.o
+00:02:42   CC      drivers/tty/tty_baudrate.o
+00:02:42   CC [M]  sound/soc/codecs/max98373.o
+00:02:42   CC      drivers/acpi/acpi_watchdog.o
+00:02:42   CC      net/dcb/dcbevent.o
+00:02:42   CC [M]  drivers/gpu/drm/bridge/analogix/analogix_dp_core.o
+00:02:42   CC [M]  sound/virtio/virtio_card.o
+00:02:43   CC      drivers/tty/tty_jobctrl.o
+00:02:43   CC [M]  drivers/char/tpm/tpm_atmel.o
+00:02:43   CC [M]  net/netfilter/nf_conntrack_ftp.o
+00:02:43   CC      drivers/acpi/prmt.o
+00:02:43   CC [M]  net/netfilter/nf_conntrack_h323_main.o
+00:02:43   CC [M]  sound/xen/xen_snd_front_alsa.o
+00:02:43   AR      net/netlabel/built-in.a
+00:02:43   AR      net/dcb/built-in.a
+00:02:43   CC [M]  sound/virtio/virtio_chmap.o
+00:02:43   CC [M]  fs/fat/cache.o
+00:02:43   CC [M]  sound/soc/codecs/max98373-i2c.o
+00:02:43   CC [M]  drivers/char/xillybus/xillybus_class.o
+00:02:43   CC      drivers/tty/n_null.o
+00:02:43   CC      net/ipv4/fib_semantics.o
+00:02:43   CC [M]  drivers/char/tpm/tpm_infineon.o
+00:02:44   CC [M]  net/wireless/mlme.o
+00:02:44   CC      fs/btrfs/locking.o
+00:02:44   CC [M]  drivers/gpu/drm/bridge/analogix/analogix_dp_reg.o
+00:02:44   CC [M]  sound/virtio/virtio_ctl_msg.o
+00:02:44   CC [M]  fs/fat/dir.o
+00:02:44   CC      net/ipv6/datagram.o
+00:02:44   CC [M]  drivers/char/xillybus/xillybus_core.o
+00:02:44   CC      drivers/acpi/acpi_adxl.o
+00:02:44   CC      drivers/tty/pty.o
+00:02:44   LD [M]  sound/xen/snd_xen_front.o
+00:02:44   CC      fs/btrfs/orphan.o
+00:02:44   CC [M]  sound/soc/codecs/max98373-sdw.o
+00:02:44   CC [M]  drivers/char/tpm/tpm_vtpm_proxy.o
+00:02:44   CC      drivers/acpi/ac.o
+00:02:44   CC [M]  fs/exfat/inode.o
+00:02:44   CC [M]  sound/virtio/virtio_jack.o
+00:02:45   CC      drivers/tty/tty_audit.o
+00:02:45   CC [M]  fs/exfat/namei.o
+00:02:45   CC [M]  net/netfilter/nf_conntrack_h323_asn1.o
+00:02:45   CC      drivers/acpi/button.o
+00:02:45   CC [M]  drivers/gpu/drm/bridge/analogix/analogix-i2c-dptx.o
+00:02:45   CC [M]  drivers/char/xillybus/xillybus_pcie.o
+00:02:45   LD [M]  drivers/char/tpm/tpm_tis_spi.o
+00:02:45   AR      drivers/char/tpm/built-in.a
+00:02:45   CC [M]  sound/soc/codecs/max98390.o
+00:02:45   CC [M]  sound/virtio/virtio_pcm.o
+00:02:45   CC [M]  fs/fat/fatent.o
+00:02:45   CC      fs/btrfs/export.o
+00:02:45   CC      drivers/char/mem.o
+00:02:45   CC [M]  net/wireless/ibss.o
+00:02:45   CC      net/ipv6/ip6_flowlabel.o
+00:02:45   CC      drivers/tty/sysrq.o
+00:02:45   CC [M]  net/netfilter/nf_conntrack_irc.o
+00:02:45   CC [M]  drivers/char/xillybus/xillyusb.o
+00:02:45   CC      drivers/acpi/fan.o
+00:02:46   CC      net/ipv4/fib_trie.o
+00:02:46   CC [M]  fs/isofs/namei.o
+00:02:46   LD [M]  drivers/gpu/drm/bridge/analogix/analogix_dp.o
+00:02:46   AR      drivers/gpu/drm/bridge/cadence/built-in.a
+00:02:46   CC [M]  fs/exfat/dir.o
+00:02:46   AR      drivers/gpu/drm/bridge/synopsys/built-in.a
+00:02:46   CC [M]  sound/virtio/virtio_pcm_msg.o
+00:02:46   AR      drivers/gpu/drm/bridge/built-in.a
+00:02:46   AR      drivers/gpu/drm/hisilicon/built-in.a
+00:02:46   CC      drivers/gpu/drm/tiny/simpledrm.o
+00:02:46   CC      drivers/acpi/pci_slot.o
+00:02:46   CC [M]  fs/hfsplus/super.o
+00:02:46   CC [M]  sound/soc/codecs/nau8315.o
+00:02:46   CC [M]  fs/fat/file.o
+00:02:46   CC [M]  fs/isofs/inode.o
+00:02:46   CC      fs/btrfs/tree-log.o
+00:02:46   CC [M]  drivers/tty/n_hdlc.o
+00:02:47   CC [M]  sound/virtio/virtio_pcm_ops.o
+00:02:47   CC      net/ipv6/inet6_connection_sock.o
+00:02:47   CC [M]  net/netfilter/nf_conntrack_broadcast.o
+00:02:47   CC [M]  net/wireless/sme.o
+00:02:47   CC      drivers/char/random.o
+00:02:47   CC      drivers/acpi/processor_driver.o
+00:02:47   CC [M]  fs/exfat/super.o
+00:02:47   CC [M]  sound/soc/codecs/nau8540.o
+00:02:47   CC [M]  drivers/gpu/drm/tiny/bochs.o
+00:02:47   CC [M]  fs/hfsplus/options.o
+00:02:47   CC [M]  drivers/tty/nozomi.o
+00:02:47   LD [M]  sound/virtio/virtio_snd.o
+00:02:47   CC [M]  drivers/tty/ttynull.o
+00:02:47   CC [M]  fs/fat/inode.o
+00:02:47   CC      drivers/acpi/processor_idle.o
+00:02:48   CC [M]  fs/isofs/dir.o
+00:02:48   CC [M]  net/netfilter/nf_conntrack_netbios_ns.o
+00:02:48   CC      net/ipv6/udp_offload.o
+00:02:48   CC      net/ipv4/fib_notifier.o
+00:02:48   CC      drivers/char/misc.o
+00:02:48   CC      drivers/acpi/processor_throttling.o
+00:02:48   CC [M]  fs/hfsplus/inode.o
+00:02:48   CC [M]  sound/soc/codecs/nau8824.o
+00:02:48   CC [M]  fs/exfat/fatent.o
+00:02:48   CC [M]  drivers/gpu/drm/tiny/cirrus.o
+00:02:48   CC [M]  fs/isofs/util.o
+00:02:48   AR      drivers/tty/built-in.a
+00:02:48   CC      drivers/char/hpet.o
+00:02:48   CC [M]  fs/hfsplus/ioctl.o
+00:02:48   CC      net/ipv6/seg6.o
+00:02:48   CC [M]  net/wireless/chan.o
+00:02:49   CC [M]  fs/exfat/cache.o
+00:02:49   CC [M]  fs/fat/misc.o
+00:02:49   CC      drivers/acpi/processor_thermal.o
+00:02:49   CC [M]  net/netfilter/nf_conntrack_snmp.o
+00:02:49   CC [M]  fs/isofs/rock.o
+00:02:49   CC      net/ipv4/inet_fragment.o
+00:02:49   CC      drivers/acpi/processor_perflib.o
+00:02:49   CC      drivers/acpi/container.o
+00:02:49   CC [M]  fs/hfsplus/extents.o
+00:02:49   CC [M]  sound/soc/codecs/pcm1789-i2c.o
+00:02:49   CC      drivers/char/nvram.o
+00:02:49   CC [M]  drivers/gpu/drm/tiny/gm12u320.o
+00:02:49   CC [M]  fs/exfat/nls.o
+00:02:49   CC      net/ipv4/ping.o
+00:02:49   CC      net/ipv4/ip_tunnel_core.o
+00:02:49   CC [M]  fs/fat/nfs.o
+00:02:49   CC      fs/btrfs/free-space-cache.o
+00:02:49   CC [M]  fs/isofs/export.o
+00:02:49   CC      drivers/acpi/thermal.o
+00:02:49   CC      net/ipv6/fib6_notifier.o
+00:02:50   CC [M]  net/netfilter/nf_conntrack_pptp.o
+00:02:50   CC [M]  fs/hfsplus/catalog.o
+00:02:50   CC [M]  drivers/char/virtio_console.o
+00:02:50   CC [M]  fs/exfat/misc.o
+00:02:50   CC [M]  sound/soc/codecs/pcm1789.o
+00:02:50   CC [M]  net/wireless/ethtool.o
+00:02:50   CC [M]  fs/fat/namei_vfat.o
+00:02:50   CC [M]  fs/isofs/joliet.o
+00:02:50   CC      drivers/gpu/vga/vgaarb.o
+00:02:50   CC [M]  drivers/gpu/drm/tiny/ili9486.o
+00:02:50   CC      drivers/acpi/acpi_memhotplug.o
+00:02:50   CC [M]  fs/exfat/file.o
+00:02:50   CC      net/ipv6/rpl.o
+00:02:50   CC [M]  sound/soc/codecs/pcm186x.o
+00:02:50   CC [M]  fs/isofs/compress.o
+00:02:51   CC [M]  fs/hfsplus/dir.o
+00:02:51   AR      sound/built-in.a
+00:02:51   CC      drivers/connector/cn_queue.o
+00:02:51   CC      net/ipv4/gre_offload.o
+00:02:51   CC      drivers/acpi/ioapic.o
+00:02:51   CC [M]  net/netfilter/nf_conntrack_sane.o
+00:02:51   CC [M]  fs/fat/namei_msdos.o
+00:02:51   CC [M]  net/wireless/mesh.o
+00:02:51   AR      drivers/gpu/drm/tiny/built-in.a
+00:02:51   CC [M]  drivers/char/uv_mmtimer.o
+00:02:51   CC      drivers/gpu/vga/vga_switcheroo.o
+00:02:51   AR      drivers/gpu/drm/xlnx/built-in.a
+00:02:51   AR      drivers/gpu/drm/gud/built-in.a
+00:02:51   CC [M]  drivers/gpu/drm/gud/gud_drv.o
+00:02:51   CC [M]  fs/exfat/balloc.o
+00:02:51   LD [M]  fs/isofs/isofs.o
+00:02:51   CC [M]  kernel/torture.o
+00:02:51   CC [M]  sound/soc/codecs/pcm186x-i2c.o
+00:02:51   CC [M]  fs/hfsplus/btree.o
+00:02:51   CC      drivers/acpi/battery.o
+00:02:51   CC      net/ipv6/ioam6.o
+00:02:52   CC [M]  fs/fat/fat_test.o
+00:02:52   CC [M]  drivers/char/lp.o
+00:02:52   CC      fs/btrfs/zlib.o
+00:02:52   CC      drivers/connector/connector.o
+00:02:52   CC      net/ipv4/metrics.o
+00:02:52   CC [M]  net/netfilter/nf_conntrack_sip.o
+00:02:52   LD [M]  fs/exfat/exfat.o
+00:02:52   CC      drivers/base/power/sysfs.o
+00:02:52   CC      drivers/base/power/generic_ops.o
+00:02:52   CC [M]  sound/soc/codecs/pcm186x-spi.o
+00:02:52   AR      drivers/gpu/vga/built-in.a
+00:02:52   CC [M]  sound/sound_core.o
+00:02:52   CC [M]  drivers/gpu/drm/gud/gud_pipe.o
+00:02:52   LD [M]  fs/fat/fat.o
+00:02:52   CC [M]  fs/hfsplus/bnode.o
+00:02:52   LD [M]  fs/fat/vfat.o
+00:02:52   LD [M]  fs/fat/msdos.o
+00:02:52   CC [M]  net/wireless/ap.o
+00:02:52   CC      drivers/connector/cn_proc.o
+00:02:52   CC      fs/btrfs/lzo.o
+00:02:52   CC      drivers/acpi/hed.o
+00:02:52   AR      net/mpls/built-in.a
+00:02:52   CC [M]  net/mpls/mpls_gso.o
+00:02:52   CC      drivers/base/power/common.o
+00:02:52   CC [M]  drivers/char/ppdev.o
+00:02:53   CC [M]  sound/soc/codecs/pcm3060.o
+00:02:53   CC [M]  net/mpls/af_mpls.o
+00:02:53   CC [M]  drivers/gpu/drm/ttm/ttm_tt.o
+00:02:53   CC      net/ipv4/netlink.o
+00:02:53   CC      drivers/acpi/bgrt.o
+00:02:53   CC      net/ipv6/sysctl_net_ipv6.o
+00:02:53   CC      drivers/base/power/qos.o
+00:02:53   CC [M]  drivers/gpu/drm/gud/gud_connector.o
+00:02:53   CC [M]  drivers/char/tlclk.o
+00:02:53   CC [M]  fs/hfs/bitmap.o
+00:02:53   CC [M]  fs/hfsplus/brec.o
+00:02:53   AR      drivers/connector/built-in.a
+00:02:53   CC [M]  drivers/gpu/drm/ttm/ttm_bo.o
+00:02:53   CC [M]  sound/soc/codecs/pcm3060-i2c.o
+00:02:53   CC      drivers/acpi/cppc_acpi.o
+00:02:53   CC [M]  net/wireless/trace.o
+00:02:53   CC      net/switchdev/switchdev.o
+00:02:54   CC      fs/btrfs/zstd.o
+00:02:54   CC [M]  net/netfilter/nf_conntrack_tftp.o
+00:02:54   CC [M]  fs/hfs/bfind.o
+00:02:54   CC      net/ipv4/nexthop.o
+00:02:54   CC      drivers/base/power/runtime.o
+00:02:54   CC      net/ipv6/ip6mr.o
+00:02:54   CC [M]  drivers/char/hangcheck-timer.o
+00:02:54   CC [M]  fs/hfsplus/bfind.o
+00:02:54   CC [M]  sound/soc/codecs/pcm3060-spi.o
+00:02:54   LD [M]  drivers/gpu/drm/gud/gud.o
+00:02:54   CC      drivers/acpi/spcr.o
+00:02:54   CC [M]  drivers/gpu/drm/ttm/ttm_bo_util.o
+00:02:54   CC      fs/btrfs/compression.o
+00:02:54   CC [M]  fs/hfs/bnode.o
+00:02:54   AR      drivers/char/built-in.a
+00:02:54   CC [M]  fs/ecryptfs/dentry.o
+00:02:55   CC [M]  net/netfilter/nf_log_syslog.o
+00:02:55   CC [M]  net/mpls/mpls_iptunnel.o
+00:02:55   CC [M]  fs/hfsplus/tables.o
+00:02:55   CC [M]  sound/soc/codecs/pcm512x.o
+00:02:55   AR      net/switchdev/built-in.a
+00:02:55   CC      drivers/acpi/viot.o
+00:02:55   CC [M]  kernel/resource_kunit.o
+00:02:55   CC      drivers/base/power/wakeirq.o
+00:02:55   CC      drivers/base/power/main.o
+00:02:55   CC [M]  drivers/gpu/drm/ttm/ttm_bo_vm.o
+00:02:55   CC [M]  net/wireless/ocb.o
+00:02:55   CC [M]  fs/ecryptfs/file.o
+00:02:55   CC [M]  fs/hfs/brec.o
+00:02:55   CC [M]  fs/hfsplus/unicode.o
+00:02:55   AR      drivers/base/firmware_loader/builtin/built-in.a
+00:02:55   CC      drivers/base/firmware_loader/main.o
+00:02:55   CC [M]  drivers/acpi/acpi_ipmi.o
+00:02:56   CC [M]  drivers/gpu/drm/ttm/ttm_module.o
+00:02:56   LD [M]  net/mpls/mpls_router.o
+00:02:56   CC      drivers/base/firmware_loader/fallback_platform.o
+00:02:56   CC      fs/btrfs/delayed-ref.o
+00:02:56   CC [M]  sound/soc/codecs/pcm512x-i2c.o
+00:02:56   CC [M]  fs/hfs/btree.o
+00:02:56   CC [M]  fs/ecryptfs/inode.o
+00:02:56   CC      net/ipv4/udp_tunnel_stub.o
+00:02:56   CC [M]  net/netfilter/nf_nat_core.o
+00:02:56   CC [M]  drivers/acpi/acpi_video.o
+00:02:56   CC      net/ipv6/xfrm6_policy.o
+00:02:56   CC [M]  drivers/gpu/drm/ttm/ttm_execbuf_util.o
+00:02:56   CC [M]  fs/hfsplus/wrapper.o
+00:02:56   CC [M]  sound/soc/codecs/rl6231.o
+00:02:56   CC [M]  drivers/gpu/drm/scheduler/sched_main.o
+00:02:56   CC      drivers/base/power/wakeup.o
+00:02:56   AR      drivers/base/firmware_loader/built-in.a
+00:02:56   CC [M]  drivers/gpu/drm/radeon/radeon_drv.o
+00:02:56   CC [M]  fs/hfs/catalog.o
+00:02:57   CC [M]  sound/soc/codecs/rl6347a.o
+00:02:57   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_drv.o
+00:02:57   CC [M]  drivers/gpu/drm/ttm/ttm_range_manager.o
+00:02:57   CC [M]  fs/hfsplus/bitmap.o
+00:02:57   CC [M]  fs/ecryptfs/main.o
+00:02:57   CC      net/ipv4/sysctl_net_ipv4.o
+00:02:57   CC      net/ipv6/xfrm6_state.o
+00:02:57   CC [M]  fs/hfs/dir.o
+00:02:57   CC      fs/btrfs/relocation.o
+00:02:57   CC [M]  drivers/gpu/drm/ttm/ttm_resource.o
+00:02:57   CC [M]  drivers/gpu/drm/scheduler/sched_fence.o
+00:02:57   CC [M]  drivers/acpi/video_detect.o
+00:02:57   CC [M]  sound/soc/codecs/rt1011.o
+00:02:57   CC [M]  drivers/gpu/drm/radeon/radeon_device.o
+00:02:57   CC      drivers/base/power/wakeup_stats.o
+00:02:57   CC [M]  net/netfilter/nf_nat_proto.o
+00:02:57   CC [M]  fs/hfsplus/part_tbl.o
+00:02:58   CC [M]  drivers/gpu/drm/scheduler/sched_entity.o
+00:02:58   CC [M]  fs/hfs/extent.o
+00:02:58   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_device.o
+00:02:58   CC [M]  fs/ecryptfs/super.o
+00:02:58   CC [M]  drivers/gpu/drm/ttm/ttm_pool.o
+00:02:58   CC      drivers/base/power/trace.o
+00:02:58   CC      net/ipv6/xfrm6_input.o
+00:02:58   CC [M]  drivers/acpi/acpi_tad.o
+00:02:58   CC      net/ipv4/proc.o
+00:02:58   CC [M]  fs/hfsplus/attributes.o
+00:02:58   LD [M]  drivers/gpu/drm/scheduler/gpu-sched.o
+00:02:58   AR      drivers/block/rnbd/built-in.a
+00:02:58   CC [M]  drivers/block/rnbd/rnbd-clt.o
+00:02:58   CC [M]  fs/hfs/inode.o
+00:02:58   CC [M]  sound/soc/codecs/rt1015.o
+00:02:58   CC [M]  fs/ecryptfs/mmap.o
+00:02:58   CC      drivers/base/power/domain.o
+00:02:59   CC [M]  drivers/gpu/drm/ttm/ttm_device.o
+00:02:59   CC [M]  drivers/gpu/drm/radeon/radeon_asic.o
+00:02:59   CC [M]  net/netfilter/nf_nat_helper.o
+00:02:59   CC [M]  fs/hfsplus/xattr.o
+00:02:59   CC [M]  drivers/acpi/platform_profile.o
+00:02:59   CC [M]  fs/hfs/attr.o
+00:02:59   CC      net/ipv6/xfrm6_output.o
+00:02:59   CC [M]  drivers/gpu/drm/ttm/ttm_sys_manager.o
+00:02:59   CC      net/ipv4/fib_rules.o
+00:02:59   CC [M]  fs/ecryptfs/read_write.o
+00:02:59   CC [M]  sound/soc/codecs/rt1015p.o
+00:02:59   CC [M]  drivers/acpi/sbshc.o
+00:03:00   CC [M]  drivers/gpu/drm/radeon/radeon_kms.o
+00:03:00   CC [M]  drivers/block/rnbd/rnbd-clt-sysfs.o
+00:03:00   CC [M]  drivers/gpu/drm/ttm/ttm_agp_backend.o
+00:03:00   CC [M]  fs/hfs/mdb.o
+00:03:00   CC [M]  fs/hfsplus/xattr_user.o
+00:03:00   CC      fs/btrfs/delayed-inode.o
+00:03:00   CC [M]  net/netfilter/nf_nat_redirect.o
+00:03:00   CC [M]  drivers/acpi/sbs.o
+00:03:00   CC      drivers/base/power/domain_governor.o
+00:03:00   CC [M]  sound/soc/codecs/rt1308.o
+00:03:00   CC [M]  fs/ecryptfs/crypto.o
+00:03:00   LD [M]  drivers/gpu/drm/ttm/ttm.o
+00:03:00   CC [M]  fs/nfs/filelayout/filelayout.o
+00:03:00   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_kms.o
+00:03:00   CC      net/ipv6/xfrm6_protocol.o
+00:03:00   CC [M]  fs/hfs/part_tbl.o
+00:03:00   CC      drivers/base/power/clock_ops.o
+00:03:00   CC [M]  fs/hfsplus/xattr_security.o
+00:03:00   CC      net/ipv4/ipmr.o
+00:03:01   CC [M]  drivers/acpi/acpi_pad.o
+00:03:01   CC [M]  drivers/gpu/drm/radeon/radeon_atombios.o
+00:03:01   CC [M]  drivers/block/rnbd/rnbd-common.o
+00:03:01   CC [M]  fs/hfs/string.o
+00:03:01   AR      drivers/base/power/built-in.a
+00:03:01   CC [M]  sound/soc/codecs/rt1308-sdw.o
+00:03:01   CC      drivers/base/regmap/regmap.o
+00:03:01   CC [M]  net/netfilter/nf_nat_masquerade.o
+00:03:01   CC [M]  fs/hfsplus/xattr_trusted.o
+00:03:01   CC [M]  kernel/sysctl-test.o
+00:03:01   CC [M]  drivers/acpi/acpi_extlog.o
+00:03:01   CC [M]  fs/ecryptfs/keystore.o
+00:03:01   CC [M]  fs/hfs/super.o
+00:03:01   CC      net/ipv6/netfilter.o
+00:03:01   CC [M]  drivers/block/rnbd/rnbd-srv.o
+00:03:02   CC [M]  kernel/kheaders.o
+00:03:02   CC      fs/btrfs/scrub.o
+00:03:02   LD [M]  fs/hfsplus/hfsplus.o
+00:03:02   CC [M]  sound/soc/codecs/rt1316-sdw.o
+00:03:02   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_atombios.o
+00:03:02   CC [M]  fs/nfs/filelayout/filelayoutdev.o
+00:03:02   CC      drivers/base/regmap/regcache.o
+00:03:02   LD [M]  drivers/acpi/video.o
+00:03:02   AR      drivers/acpi/built-in.a
+00:03:02   AR      kernel/built-in.a
+00:03:02   CC      net/l3mdev/l3mdev.o
+00:03:02   CC [M]  net/netfilter/nf_nat_amanda.o
+00:03:02   CC [M]  fs/hfs/sysdep.o
+00:03:02   CC [M]  drivers/gpu/drm/i915/i915_drv.o
+00:03:02   CC [M]  sound/soc/codecs/rt286.o
+00:03:02   CC [M]  drivers/block/rnbd/rnbd-srv-dev.o
+00:03:02   CC [M]  net/wireless/pmsr.o
+00:03:03   CC [M]  drivers/block/xen-blkback/blkback.o
+00:03:03   CC      net/ipv6/fib6_rules.o
+00:03:03   CC [M]  fs/ecryptfs/kthread.o
+00:03:03   CC [M]  fs/hfs/trans.o
+00:03:03   AR      net/l3mdev/built-in.a
+00:03:03   CC [M]  drivers/block/xen-blkback/xenbus.o
+00:03:03   CC      net/ipv4/ipmr_base.o
+00:03:03   LD [M]  fs/nfs/filelayout/nfs_layout_nfsv41_files.o
+00:03:03   CC [M]  fs/nfs/blocklayout/blocklayout.o
+00:03:03   CC [M]  drivers/gpu/drm/radeon/radeon_agp.o
+00:03:03   CC [M]  drivers/gpu/drm/amd/amdgpu/atombios_crtc.o
+00:03:03   CC      drivers/base/regmap/regcache-rbtree.o
+00:03:03   CC [M]  drivers/block/rnbd/rnbd-srv-sysfs.o
+00:03:03   CC [M]  net/netfilter/nf_nat_ftp.o
+00:03:03   LD [M]  fs/hfs/hfs.o
+00:03:03   AR      drivers/base/test/built-in.a
+00:03:03   CC [M]  sound/ac97_bus.o
+00:03:03   CC [M]  fs/ecryptfs/debug.o
+00:03:03   CC [M]  sound/soc/codecs/rt5640.o
+00:03:04   CC      drivers/base/regmap/regcache-flat.o
+00:03:04   CC [M]  drivers/gpu/drm/i915/i915_config.o
+00:03:04   CC [M]  drivers/gpu/drm/radeon/atombios_crtc.o
+00:03:04   CC      net/ipv6/proc.o
+00:03:04   LD [M]  drivers/block/rnbd/rnbd-client.o
+00:03:04   LD [M]  drivers/block/rnbd/rnbd-server.o
+00:03:04   CC [M]  drivers/gpu/drm/i915/i915_irq.o
+00:03:04   CC      drivers/base/component.o
+00:03:04   AR      drivers/misc/eeprom/built-in.a
+00:03:04   CC [M]  drivers/misc/eeprom/at24.o
+00:03:04   CC [M]  net/wireless/debugfs.o
+00:03:04   CC      net/ipv4/syncookies.o
+00:03:04   LD [M]  fs/ecryptfs/ecryptfs.o
+00:03:04   CC [M]  net/wireless/wext-compat.o
+00:03:04   LD [M]  drivers/block/xen-blkback/xen-blkback.o
+00:03:04   CC [M]  drivers/block/drbd/drbd_bitmap.o
+00:03:04   CC      drivers/base/regmap/regmap-debugfs.o
+00:03:04   CC      fs/btrfs/reada.o
+00:03:04   CC [M]  net/netfilter/nf_nat_irc.o
+00:03:04   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_connectors.o
+00:03:04   CC [M]  fs/nfs/blocklayout/dev.o
+00:03:04   LD [M]  sound/soundcore.o
+00:03:04   CC      net/ncsi/ncsi-cmd.o
+00:03:05   CC [M]  sound/soc/codecs/rt5645.o
+00:03:05   CC      net/xdp/xsk.o
+00:03:05   CC [M]  drivers/block/drbd/drbd_proc.o
+00:03:05   CC      drivers/base/regmap/regmap-i2c.o
+00:03:05   CC [M]  drivers/misc/eeprom/max6875.o
+00:03:05   CC      net/ipv6/syncookies.o
+00:03:05   CC      net/ipv4/netfilter.o
+00:03:05   CC [M]  net/netfilter/nf_nat_sip.o
+00:03:05   CC [M]  drivers/gpu/drm/radeon/radeon_combios.o
+00:03:05   CC [M]  fs/nfs/blocklayout/extent_tree.o
+00:03:05   CC      fs/btrfs/backref.o
+00:03:05   CC      net/ncsi/ncsi-rsp.o
+00:03:06   CC [M]  drivers/misc/eeprom/eeprom_93cx6.o
+00:03:06   CC [M]  drivers/gpu/drm/amd/amdgpu/atom.o
+00:03:06   CC      drivers/base/regmap/regmap-mmio.o
+00:03:06   CC [M]  net/wireless/wext-sme.o
+00:03:06   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_fence.o
+00:03:06   CC [M]  drivers/block/drbd/drbd_worker.o
+00:03:06   CC [M]  drivers/misc/eeprom/idt_89hpesx.o
+00:03:06   CC      net/ipv6/calipso.o
+00:03:06   CC [M]  sound/soc/codecs/rt5651.o
+00:03:06   CC      drivers/base/regmap/regmap-irq.o
+00:03:06   CC      net/ipv4/inet_diag.o
+00:03:06   CC      net/xdp/xdp_umem.o
+00:03:06   CC [M]  net/netfilter/nf_nat_tftp.o
+00:03:07   GEN     net/wireless/shipped-certs.c
+00:03:07   CC [M]  fs/nfs/blocklayout/rpc_pipefs.o
+00:03:07   AR      net/wireless/built-in.a
+00:03:07   CC [M]  net/wireless/shipped-certs.o
+00:03:07   CC [M]  drivers/gpu/drm/i915/i915_getparam.o
+00:03:07   CC      net/ncsi/ncsi-aen.o
+00:03:07   CC [M]  drivers/misc/eeprom/ee1004.o
+00:03:07   CC [M]  drivers/base/regmap/regmap-spi.o
+00:03:07   CC      net/xdp/xsk_queue.o
+00:03:07   CC [M]  sound/soc/codecs/rt5659.o
+00:03:07   CC [M]  drivers/gpu/drm/radeon/atom.o
+00:03:07   CC      drivers/base/core.o
+00:03:07   LD [M]  net/wireless/cfg80211.o
+00:03:07   CC      drivers/mfd/mfd-core.o
+00:03:07   CC [M]  net/netfilter/nf_synproxy_core.o
+00:03:07   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.o
+00:03:07   CC      net/ipv6/seg6_iptunnel.o
+00:03:08   CC      fs/btrfs/ulist.o
+00:03:08   LD [M]  fs/nfs/blocklayout/blocklayoutdriver.o
+00:03:08   CC [M]  drivers/base/regmap/regmap-sdw.o
+00:03:08   CC      net/ipv4/tcp_diag.o
+00:03:08   CC [M]  fs/nfs/flexfilelayout/flexfilelayout.o
+00:03:08   CC [M]  drivers/gpu/drm/i915/i915_mitigations.o
+00:03:08   CC      net/ncsi/ncsi-manage.o
+00:03:08   AR      drivers/misc/cb710/built-in.a
+00:03:08   CC [M]  drivers/misc/cb710/core.o
+00:03:08   CC      net/xdp/xskmap.o
+00:03:08   CC [M]  drivers/block/drbd/drbd_receiver.o
+00:03:08   CC [M]  drivers/base/regmap/regmap-sdw-mbq.o
+00:03:08   CC      drivers/mfd/axp20x.o
+00:03:08   CC [M]  sound/soc/codecs/rt5660.o
+00:03:09   CC [M]  drivers/base/regmap/regmap-sccb.o
+00:03:09   CC [M]  drivers/misc/cb710/sgbuf2.o
+00:03:09   CC      fs/btrfs/qgroup.o
+00:03:09   CC      net/ipv6/seg6_local.o
+00:03:09   CC [M]  drivers/gpu/drm/i915/i915_module.o
+00:03:09   CC      net/ipv4/udp_diag.o
+00:03:09   CC [M]  drivers/gpu/drm/radeon/radeon_fence.o
+00:03:09   CC      net/xdp/xsk_buff_pool.o
+00:03:09   CC [M]  net/netfilter/nf_conncount.o
+00:03:09   CC      drivers/mfd/axp20x-i2c.o
+00:03:09   LD [M]  drivers/misc/cb710/cb710.o
+00:03:09   AR      drivers/misc/ti-st/built-in.a
+00:03:09   AR      drivers/base/regmap/built-in.a
+00:03:09   CC [M]  drivers/gpu/drm/i915/i915_params.o
+00:03:09   AR      drivers/misc/lis3lv02d/built-in.a
+00:03:09   CC [M]  drivers/misc/lis3lv02d/lis3lv02d.o
+00:03:09   CC      drivers/base/bus.o
+00:03:09   CC      net/ncsi/ncsi-netlink.o
+00:03:09   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_object.o
+00:03:09   CC [M]  sound/soc/codecs/rt5670.o
+00:03:10   CC      drivers/mfd/intel-lpss.o
+00:03:10   CC [M]  fs/nfs/flexfilelayout/flexfilelayoutdev.o
+00:03:10   CC      net/ipv4/raw_diag.o
+00:03:10   CC [M]  drivers/misc/lis3lv02d/lis3lv02d_i2c.o
+00:03:10   CC      drivers/base/dd.o
+00:03:10   CC [M]  net/xdp/xsk_diag.o
+00:03:10   CC [M]  drivers/gpu/drm/radeon/radeon_ttm.o
+00:03:10   CC [M]  net/netfilter/nf_dup_netdev.o
+00:03:10   CC      drivers/mfd/intel-lpss-pci.o
+00:03:10   CC [M]  drivers/gpu/drm/i915/i915_pci.o
+00:03:10   CC [M]  drivers/block/mtip32xx/mtip32xx.o
+00:03:10   CC      net/ipv6/seg6_hmac.o
+00:03:11   AR      net/ncsi/built-in.a
+00:03:11   CC [M]  drivers/gpu/drm/mgag200/mgag200_drv.o
+00:03:11   AR      drivers/misc/cardreader/built-in.a
+00:03:11   CC [M]  sound/soc/codecs/rt5677.o
+00:03:11   CC [M]  drivers/misc/cardreader/alcor_pci.o
+00:03:11   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_gart.o
+00:03:11   CC      drivers/mfd/intel-lpss-acpi.o
+00:03:11   CC      drivers/base/syscore.o
+00:03:11   CC      net/ipv4/tcp_cubic.o
+00:03:11   AR      net/xdp/built-in.a
+00:03:11   LD [M]  fs/nfs/flexfilelayout/nfs_layout_flexfiles.o
+00:03:11   CC [M]  fs/nfs/client.o
+00:03:11   CC [M]  drivers/nfc/pn544/pn544.o
+00:03:11   CC      drivers/mfd/syscon.o
+00:03:11   CC      fs/btrfs/send.o
+00:03:11   CC [M]  net/netfilter/nf_tables_core.o
+00:03:11   CC [M]  drivers/gpu/drm/radeon/radeon_object.o
+00:03:11   CC [M]  drivers/misc/cardreader/rtsx_pcr.o
+00:03:11   CC [M]  drivers/gpu/drm/i915/i915_scatterlist.o
+00:03:12   CC [M]  drivers/gpu/drm/mgag200/mgag200_i2c.o
+00:03:12   CC [M]  drivers/block/drbd/drbd_req.o
+00:03:12   CC      drivers/mfd/intel_soc_pmic_core.o
+00:03:12   CC      net/ipv6/rpl_iptunnel.o
+00:03:12   CC      drivers/base/driver.o
+00:03:12   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_encoders.o
+00:03:12   CC [M]  drivers/nfc/pn544/i2c.o
+00:03:12   CC [M]  drivers/gpu/drm/i915/i915_suspend.o
+00:03:12   CC      net/ipv4/tcp_bpf.o
+00:03:12   CC      drivers/base/class.o
+00:03:12   CC [M]  net/netfilter/nf_tables_api.o
+00:03:12   CC [M]  sound/soc/codecs/rt5677-spi.o
+00:03:12   CC [M]  drivers/gpu/drm/radeon/radeon_gart.o
+00:03:12   CC      drivers/mfd/intel_soc_pmic_crc.o
+00:03:12   CC [M]  drivers/gpu/drm/mgag200/mgag200_mm.o
+00:03:12   CC [M]  fs/nfsd/trace.o
+00:03:13   CC [M]  fs/nfs/dir.o
+00:03:13   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_display.o
+00:03:13   CC      drivers/mfd/intel_soc_pmic_chtwc.o
+00:03:13   CC [M]  drivers/misc/cardreader/rts5209.o
+00:03:13   CC      drivers/base/platform.o
+00:03:13   CC      net/ipv6/ioam6_iptunnel.o
+00:03:13   CC [M]  drivers/nfc/pn544/mei.o
+00:03:13   CC [M]  drivers/gpu/drm/i915/i915_switcheroo.o
+00:03:13   CC [M]  drivers/gpu/drm/mgag200/mgag200_mode.o
+00:03:13   CC [M]  drivers/gpu/drm/radeon/radeon_legacy_crtc.o
+00:03:13   CC [M]  sound/soc/codecs/rt5682.o
+00:03:13   CC [M]  drivers/misc/cardreader/rts5229.o
+00:03:13   LD [M]  drivers/nfc/pn544/pn544_i2c.o
+00:03:13   LD [M]  drivers/nfc/pn544/pn544_mei.o
+00:03:13   CC [M]  drivers/nfc/microread/microread.o
+00:03:13   CC      net/ipv4/udp_bpf.o
+00:03:13   CC [M]  drivers/block/drbd/drbd_actlog.o
+00:03:13   CC      drivers/mfd/intel_soc_pmic_chtdc_ti.o
+00:03:14   CC      drivers/base/cpu.o
+00:03:14   CC      net/ipv6/mip6.o
+00:03:14   CC [M]  drivers/misc/cardreader/rtl8411.o
+00:03:14   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_i2c.o
+00:03:14   CC [M]  drivers/nfc/microread/i2c.o
+00:03:14   CC [M]  drivers/gpu/drm/i915/i915_sysfs.o
+00:03:14   CC [M]  drivers/mfd/sm501.o
+00:03:14   CC [M]  drivers/gpu/drm/mgag200/mgag200_pll.o
+00:03:14   CC      drivers/base/firmware.o
+00:03:14   CC [M]  drivers/gpu/drm/radeon/radeon_legacy_encoders.o
+00:03:14   CC [M]  drivers/misc/cardreader/rts5227.o
+00:03:15   CC      net/ipv4/cipso_ipv4.o
+00:03:15   CC [M]  sound/soc/codecs/rt5682-i2c.o
+00:03:15   CC      fs/btrfs/dev-replace.o
+00:03:15   CC      drivers/base/init.o
+00:03:15   CC [M]  fs/nfs/file.o
+00:03:15   CC      net/ipv6/addrconf_core.o
+00:03:15   CC [M]  drivers/nfc/microread/mei.o
+00:03:15   CC [M]  drivers/block/drbd/drbd_main.o
+00:03:15   CC [M]  drivers/misc/cardreader/rts5249.o
+00:03:15   CC [M]  drivers/mfd/bd9571mwv.o
+00:03:15   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_fb.o
+00:03:15   CC [M]  drivers/gpu/drm/i915/i915_utils.o
+00:03:15   CC      drivers/base/map.o
+00:03:15   LD [M]  drivers/gpu/drm/mgag200/mgag200.o
+00:03:16   CC [M]  sound/soc/codecs/rt5682-sdw.o
+00:03:16   CC      drivers/base/devres.o
+00:03:16   LD [M]  drivers/nfc/microread/microread_i2c.o
+00:03:16   LD [M]  drivers/nfc/microread/microread_mei.o
+00:03:16   CC [M]  drivers/nfc/pn533/pn533.o
+00:03:16   CC [M]  drivers/gpu/drm/radeon/radeon_connectors.o
+00:03:16   CC [M]  sound/soc/codecs/rt700.o
+00:03:16   CC [M]  drivers/misc/cardreader/rts5260.o
+00:03:16   CC [M]  drivers/mfd/cros_ec_dev.o
+00:03:16   CC      net/ipv6/exthdrs_core.o
+00:03:16   CC [M]  fs/nfsd/nfssvc.o
+00:03:16   CC      net/ipv4/xfrm4_policy.o
+00:03:16   CC      fs/btrfs/raid56.o
+00:03:16   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_gem.o
+00:03:16   CC      drivers/base/attribute_container.o
+00:03:16   CC [M]  fs/nfs/getroot.o
+00:03:16   CC [M]  drivers/gpu/drm/i915/intel_device_info.o
+00:03:16   CC [M]  drivers/mfd/arizona-core.o
+00:03:16   CC [M]  drivers/misc/cardreader/rts5261.o
+00:03:17   AR      drivers/misc/pvpanic/built-in.a
+00:03:17   CC [M]  drivers/misc/pvpanic/pvpanic.o
+00:03:17   CC [M]  sound/soc/codecs/rt700-sdw.o
+00:03:17   CC      drivers/base/transport_class.o
+00:03:17   CC      net/ipv6/ip6_checksum.o
+00:03:17   CC [M]  drivers/nfc/pn533/usb.o
+00:03:17   CC      drivers/base/topology.o
+00:03:17   CC [M]  drivers/misc/pvpanic/pvpanic-mmio.o
+00:03:17   CC      net/ipv4/xfrm4_state.o
+00:03:17   CC [M]  drivers/misc/cardreader/rts5228.o
+00:03:17   CC [M]  drivers/gpu/drm/radeon/radeon_encoders.o
+00:03:17   CC [M]  fs/nfs/inode.o
+00:03:17   CC [M]  sound/soc/codecs/rt711.o
+00:03:17   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ring.o
+00:03:17   CC [M]  drivers/mfd/arizona-irq.o
+00:03:18   CC [M]  fs/nfsd/nfsctl.o
+00:03:18   CC [M]  drivers/nfc/pn533/i2c.o
+00:03:18   CC      drivers/base/container.o
+00:03:18   CC [M]  drivers/gpu/drm/i915/intel_dram.o
+00:03:18   CC [M]  drivers/misc/cardreader/rtsx_usb.o
+00:03:18   CC [M]  drivers/block/drbd/drbd_strings.o
+00:03:18   CC [M]  drivers/gpu/drm/radeon/radeon_display.o
+00:03:18   CC [M]  net/netfilter/nft_chain_filter.o
+00:03:18   CC [M]  drivers/block/drbd/drbd_nl.o
+00:03:18   CC      drivers/base/property.o
+00:03:18   CC      net/ipv6/ip6_icmp.o
+00:03:18   CC      fs/btrfs/uuid-tree.o
+00:03:18   CC      net/ipv4/xfrm4_input.o
+00:03:18   CC [M]  drivers/mfd/wm5102-tables.o
+00:03:18   CC [M]  net/netfilter/nf_tables_trace.o
+00:03:18   CC [M]  sound/soc/codecs/rt711-sdw.o
+00:03:18   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_cs.o
+00:03:18   CC [M]  drivers/nfc/pn533/uart.o
+00:03:19   LD [M]  drivers/misc/cardreader/rtsx_pci.o
+00:03:19   CC [M]  drivers/misc/ibmasm/module.o
+00:03:19   CC [M]  drivers/gpu/drm/i915/intel_memory_region.o
+00:03:19   CC [M]  fs/nfsd/nfsfh.o
+00:03:19   CC [M]  sound/soc/codecs/rt711-sdca.o
+00:03:19   CC      net/ipv6/output_core.o
+00:03:19   CC [M]  drivers/mfd/arizona-spi.o
+00:03:19   CC [M]  drivers/nfc/nfcmrvl/main.o
+00:03:19   CC      drivers/base/cacheinfo.o
+00:03:19   CC      fs/btrfs/props.o
+00:03:19   CC      net/ipv4/xfrm4_output.o
+00:03:19   LD [M]  drivers/nfc/pn533/pn533_usb.o
+00:03:19   LD [M]  drivers/nfc/pn533/pn533_i2c.o
+00:03:19   LD [M]  drivers/nfc/pn533/pn532_uart.o
+00:03:19   CC [M]  net/netfilter/nft_immediate.o
+00:03:19   CC [M]  drivers/misc/ibmasm/ibmasmfs.o
+00:03:19   CC [M]  drivers/gpu/drm/radeon/radeon_cursor.o
+00:03:19   CC [M]  fs/nfs/super.o
+00:03:19   CC [M]  drivers/block/drbd/drbd_interval.o
+00:03:20   CC      drivers/base/swnode.o
+00:03:20   CC [M]  drivers/nfc/nfcmrvl/fw_dnld.o
+00:03:20   CC [M]  fs/lockd/clntlock.o
+00:03:20   CC [M]  drivers/mfd/lpc_sch.o
+00:03:20   CC [M]  drivers/gpu/drm/i915/intel_pch.o
+00:03:20   CC [M]  drivers/misc/ibmasm/event.o
+00:03:20   CC [M]  sound/soc/codecs/rt711-sdca-sdw.o
+00:03:20   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_bios.o
+00:03:20   CC      net/ipv6/protocol.o
+00:03:20   CC      net/ipv4/xfrm4_protocol.o
+00:03:20   CC [M]  drivers/gpu/drm/radeon/radeon_i2c.o
+00:03:20   CC [M]  net/netfilter/nft_cmp.o
+00:03:20   CC      fs/btrfs/free-space-tree.o
+00:03:20   CC [M]  fs/nfsd/vfs.o
+00:03:20   CC [M]  drivers/misc/ibmasm/command.o
+00:03:20   CC [M]  drivers/mfd/lpc_ich.o
+00:03:20   CC [M]  drivers/nfc/nfcmrvl/usb.o
+00:03:21   CC      drivers/base/auxiliary.o
+00:03:21   CC [M]  sound/soc/codecs/rt715.o
+00:03:21   CC [M]  fs/nfs/io.o
+00:03:21   CC [M]  fs/lockd/clntproc.o
+00:03:21   CC [M]  drivers/misc/ibmasm/remote.o
+00:03:21   CC      net/ipv6/ip6_offload.o
+00:03:21   CC      drivers/base/devtmpfs.o
+00:03:21   CC [M]  drivers/gpu/drm/i915/intel_pm.o
+00:03:21   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_benchmark.o
+00:03:21   CC [M]  drivers/mfd/vx855.o
+00:03:21   CC      net/ipv4/bpf_tcp_ca.o
+00:03:21   LD [M]  drivers/nfc/nfcmrvl/nfcmrvl.o
+00:03:21   LD [M]  drivers/nfc/nfcmrvl/nfcmrvl_usb.o
+00:03:21   CC [M]  drivers/nfc/st21nfca/core.o
+00:03:21   CC [M]  net/netfilter/nft_range.o
+00:03:21   CC [M]  drivers/gpu/drm/radeon/radeon_clocks.o
+00:03:21   CC [M]  drivers/block/drbd/drbd_state.o
+00:03:22   CC [M]  drivers/misc/ibmasm/heartbeat.o
+00:03:22   CC [M]  drivers/mfd/wl1273-core.o
+00:03:22   CC [M]  sound/soc/codecs/rt715-sdw.o
+00:03:22   CC      drivers/base/node.o
+00:03:22   CC [M]  fs/nfs/direct.o
+00:03:22   CC      fs/btrfs/tree-checker.o
+00:03:22   CC [M]  drivers/misc/ibmasm/r_heartbeat.o
+00:03:22   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_test.o
+00:03:22   CC [M]  drivers/nfc/st21nfca/dep.o
+00:03:22   CC      net/ipv6/tcpv6_offload.o
+00:03:22   CC [M]  fs/lockd/clntxdr.o
+00:03:22   CC [M]  net/ipv4/ip_tunnel.o
+00:03:22   CC [M]  net/netfilter/nft_bitwise.o
+00:03:22   CC [M]  fs/nfsd/export.o
+00:03:22   CC [M]  drivers/misc/ibmasm/dot_command.o
+00:03:22   CC [M]  drivers/gpu/drm/radeon/radeon_fb.o
+00:03:22   CC [M]  drivers/mfd/intel_pmc_bxt.o
+00:03:23   CC [M]  sound/soc/codecs/rt715-sdca.o
+00:03:23   CC      drivers/base/memory.o
+00:03:23   CC [M]  drivers/nfc/st21nfca/se.o
+00:03:23   CC [M]  drivers/misc/ibmasm/lowlevel.o
+00:03:23   CC [M]  drivers/mfd/dln2.o
+00:03:23   CC [M]  drivers/gpu/drm/amd/amdgpu/atombios_dp.o
+00:03:23   CC      net/ipv6/exthdrs_offload.o
+00:03:23   CC [M]  fs/lockd/host.o
+00:03:23   CC [M]  fs/nfs/pagelist.o
+00:03:23   CC [M]  net/netfilter/nft_byteorder.o
+00:03:23   CC [M]  drivers/misc/ibmasm/uart.o
+00:03:23   CC [M]  drivers/gpu/drm/radeon/radeon_gem.o
+00:03:23   CC [M]  sound/soc/codecs/rt715-sdca-sdw.o
+00:03:23   CC [M]  drivers/nfc/st21nfca/vendor_cmds.o
+00:03:23   CC      drivers/base/module.o
+00:03:24   CC      fs/btrfs/space-info.o
+00:03:24   CC [M]  drivers/block/drbd/drbd_nla.o
+00:03:24   LD [M]  drivers/misc/ibmasm/ibmasm.o
+00:03:24   CC [M]  drivers/misc/sgi-xp/xp_main.o
+00:03:24   CC      drivers/base/hypervisor.o
+00:03:24   CC [M]  drivers/mfd/rt4831.o
+00:03:24   CC [M]  net/ipv4/ipip.o
+00:03:24   CC [M]  fs/nfsd/auth.o
+00:03:24   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_afmt.o
+00:03:24   CC [M]  sound/soc/codecs/sigmadsp.o
+00:03:24   CC      net/ipv6/inet6_hashtables.o
+00:03:24   CC [M]  drivers/nfc/st21nfca/i2c.o
+00:03:24   CC      drivers/base/pinctrl.o
+00:03:24   CC [M]  drivers/block/drbd/drbd_debugfs.o
+00:03:24   CC [M]  net/netfilter/nft_payload.o
+00:03:24   CC [M]  drivers/misc/sgi-xp/xp_uv.o
+00:03:24   CC [M]  fs/lockd/svc.o
+00:03:24   CC [M]  drivers/gpu/drm/radeon/radeon_ring.o
+00:03:25   CC      drivers/base/devcoredump.o
+00:03:25   CC [M]  drivers/mfd/intel_soc_pmic_bxtwc.o
+00:03:25   CC [M]  fs/nfs/read.o
+00:03:25   CC [M]  drivers/misc/sgi-xp/xpc_main.o
+00:03:25   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_trace_points.o
+00:03:25   CC [M]  sound/soc/codecs/sigmadsp-regmap.o
+00:03:25   CC      fs/btrfs/block-rsv.o
+00:03:25   CC [M]  fs/nfsd/lockd.o
+00:03:25   LD [M]  drivers/nfc/st21nfca/st21nfca_hci.o
+00:03:25   LD [M]  drivers/nfc/st21nfca/st21nfca_i2c.o
+00:03:25   CC [M]  drivers/nfc/nxp-nci/core.o
+00:03:25   CC [M]  net/ipv4/fou.o
+00:03:25   CC [M]  drivers/mfd/intel_soc_pmic_mrfld.o
+00:03:25   CC      drivers/base/platform-msi.o
+00:03:25   CC      net/ipv6/mcast_snoop.o
+00:03:25   CC [M]  drivers/gpu/drm/radeon/radeon_irq_kms.o
+00:03:25   CC [M]  fs/lockd/svclock.o
+00:03:26   CC [M]  sound/soc/codecs/spdif_receiver.o
+00:03:26   CC [M]  net/netfilter/nft_lookup.o
+00:03:26   LD [M]  drivers/mfd/arizona.o
+00:03:26   AR      drivers/mfd/built-in.a
+00:03:26   CC [M]  drivers/gpu/drm/i915/intel_region_ttm.o
+00:03:26   CC      drivers/base/trace.o
+00:03:26   CC [M]  drivers/nfc/nxp-nci/firmware.o
+00:03:26   LD [M]  drivers/block/drbd/drbd.o
+00:03:26   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_execbuf.o
+00:03:26   CC [M]  drivers/block/zram/zcomp.o
+00:03:26   CC [M]  drivers/misc/sgi-xp/xpc_channel.o
+00:03:26   CC [M]  fs/nfsd/nfscache.o
+00:03:26   CC [M]  sound/soc/codecs/spdif_transmitter.o
+00:03:26   CC [M]  fs/nfs/symlink.o
+00:03:26   CC [M]  drivers/block/zram/zram_drv.o
+00:03:26   CC      fs/btrfs/delalloc-space.o
+00:03:26   CC [M]  net/ipv6/ah6.o
+00:03:26   AR      drivers/base/built-in.a
+00:03:26   CC [M]  sound/soc/codecs/ssm4567.o
+00:03:26   CC [M]  drivers/nfc/nxp-nci/i2c.o
+00:03:26   CC [M]  drivers/gpu/drm/radeon/radeon_cs.o
+00:03:27   CC [M]  drivers/misc/sgi-xp/xpc_partition.o
+00:03:27   CC [M]  net/netfilter/nft_dynset.o
+00:03:27   CC [M]  net/ipv4/gre_demux.o
+00:03:27   CC      fs/btrfs/block-group.o
+00:03:27   CC [M]  drivers/gpu/drm/i915/intel_runtime_pm.o
+00:03:27   CC [M]  drivers/gpu/drm/amd/amdgpu/atombios_encoders.o
+00:03:27   CC [M]  fs/lockd/svcshare.o
+00:03:27   CC [M]  fs/nfs/unlink.o
+00:03:27   CC [M]  drivers/misc/sgi-xp/xpc_uv.o
+00:03:27   CC [M]  sound/soc/codecs/tas2562.o
+00:03:27   LD [M]  drivers/nfc/nxp-nci/nxp-nci.o
+00:03:27   LD [M]  drivers/nfc/nxp-nci/nxp-nci_i2c.o
+00:03:27   AR      drivers/nfc/built-in.a
+00:03:27   CC [M]  drivers/nfc/mei_phy.o
+00:03:27   CC [M]  fs/nfsd/stats.o
+00:03:27   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_gmr.o
+00:03:27   CC [M]  drivers/gpu/drm/vgem/vgem_drv.o
+00:03:27   LD [M]  drivers/block/zram/zram.o
+00:03:27   CC [M]  drivers/block/null_blk/main.o
+00:03:28   CC [M]  net/ipv6/esp6.o
+00:03:28   CC [M]  drivers/gpu/drm/radeon/radeon_bios.o
+00:03:28   CC [M]  net/netfilter/nft_meta.o
+00:03:28   CC [M]  net/ipv4/ip_gre.o
+00:03:28   CC [M]  fs/lockd/svcproc.o
+00:03:28   CC [M]  drivers/gpu/drm/i915/intel_sideband.o
+00:03:28   CC [M]  drivers/nfc/nfcsim.o
+00:03:28   CC [M]  sound/soc/codecs/tas2764.o
+00:03:28   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_kms.o
+00:03:28   CC [M]  drivers/misc/sgi-xp/xpnet.o
+00:03:28   CC [M]  drivers/gpu/drm/vgem/vgem_fence.o
+00:03:28   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_sa.o
+00:03:28   CC [M]  fs/nfsd/filecache.o
+00:03:28   CC [M]  fs/nfs/write.o
+00:03:29   CC [M]  drivers/nfc/port100.o
+00:03:29   CC [M]  drivers/gpu/drm/radeon/radeon_benchmark.o
+00:03:29   LD [M]  drivers/gpu/drm/vgem/vgem.o
+00:03:29   CC [M]  fs/sysv/ialloc.o
+00:03:29   CC [M]  net/netfilter/nft_rt.o
+00:03:29   CC [M]  sound/soc/codecs/tas6424.o
+00:03:29   CC      fs/btrfs/discard.o
+00:03:29   CC [M]  fs/lockd/svcsubs.o
+00:03:29   CC [M]  drivers/block/null_blk/trace.o
+00:03:29   CC [M]  drivers/gpu/drm/i915/intel_step.o
+00:03:29   LD [M]  drivers/misc/sgi-xp/xp.o
+00:03:29   LD [M]  drivers/misc/sgi-xp/xpc.o
+00:03:29   CC [M]  net/ipv6/esp6_offload.o
+00:03:29   CC [M]  drivers/misc/sgi-gru/grufile.o
+00:03:29   CC [M]  drivers/gpu/drm/amd/amdgpu/atombios_i2c.o
+00:03:29   CC [M]  net/ipv4/udp_tunnel_core.o
+00:03:29   CC [M]  drivers/nfc/trf7970a.o
+00:03:30   HOSTCC  drivers/gpu/drm/radeon/mkregtable
+00:03:30   CC [M]  drivers/block/null_blk/zoned.o
+00:03:30   CC [M]  fs/sysv/balloc.o
+00:03:30   CC [M]  drivers/gpu/drm/radeon/rs400.o
+00:03:30   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_drv.o
+00:03:30   CC [M]  sound/soc/codecs/tda7419.o
+00:03:30   CC [M]  net/netfilter/nft_exthdr.o
+00:03:30   CC [M]  drivers/gpu/drm/i915/intel_uncore.o
+00:03:30   CC [M]  drivers/misc/sgi-gru/grumain.o
+00:03:30   CC [M]  fs/lockd/mon.o
+00:03:30   CC [M]  fs/nfsd/nfs3proc.o
+00:03:30   CC [M]  fs/sysv/inode.o
+00:03:30   CC      fs/btrfs/reflink.o
+00:03:30   CC [M]  net/ipv6/ipcomp6.o
+00:03:30   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_dma_buf.o
+00:03:30   CC [M]  fs/nfs/namespace.o
+00:03:31   CC [M]  net/ipv4/udp_tunnel_nic.o
+00:03:31   LD [M]  drivers/block/null_blk/null_blk.o
+00:03:31   MKREG   drivers/gpu/drm/radeon/rs600_reg_safe.h
+00:03:31   AR      drivers/block/built-in.a
+00:03:31   CC [M]  drivers/gpu/drm/radeon/rs690.o
+00:03:31   CC [M]  drivers/block/floppy.o
+00:03:31   CC [M]  sound/soc/codecs/tas2770.o
+00:03:31   CC [M]  drivers/misc/altera-stapl/altera-lpt.o
+00:03:31   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_ioctl.o
+00:03:31   CC [M]  fs/sysv/itree.o
+00:03:31   CC [M]  drivers/misc/altera-stapl/altera-jtag.o
+00:03:31   CC [M]  fs/lockd/xdr.o
+00:03:31   CC [M]  drivers/misc/sgi-gru/grufault.o
+00:03:31   CC [M]  net/netfilter/nft_last.o
+00:03:31   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vm.o
+00:03:31   CC [M]  net/ipv6/xfrm6_tunnel.o
+00:03:31   CC [M]  fs/nfsd/nfs3xdr.o
+00:03:32   CC [M]  fs/nfs/mount_clnt.o
+00:03:32   CC      fs/btrfs/subpage.o
+00:03:32   CC [M]  sound/soc/codecs/tlv320aic32x4.o
+00:03:32   CC [M]  drivers/misc/altera-stapl/altera-comp.o
+00:03:32   CC [M]  fs/sysv/file.o
+00:03:32   MKREG   drivers/gpu/drm/radeon/rv515_reg_safe.h
+00:03:32   CC [M]  drivers/gpu/drm/radeon/r520.o
+00:03:32   CC [M]  drivers/misc/altera-stapl/altera.o
+00:03:32   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_resource.o
+00:03:32   CC [M]  net/ipv4/ip_vti.o
+00:03:32   CC [M]  fs/sysv/dir.o
+00:03:32   CC [M]  net/netfilter/nft_chain_route.o
+00:03:32   CC [M]  drivers/misc/sgi-gru/grutlbpurge.o
+00:03:32   CC [M]  fs/lockd/clnt4xdr.o
+00:03:32   CC [M]  net/ipv6/tunnel6.o
+00:03:33   CC [M]  sound/soc/codecs/tlv320aic32x4-clk.o
+00:03:33   CC [M]  fs/nfs/nfstrace.o
+00:03:33   CC [M]  drivers/gpu/drm/radeon/r600.o
+00:03:33   CC [M]  drivers/gpu/drm/i915/intel_wakeref.o
+00:03:33   CC [M]  fs/nfsd/nfs3acl.o
+00:03:33   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_ttm_buffer.o
+00:03:33   CC      fs/btrfs/tree-mod-log.o
+00:03:33   CC [M]  fs/sysv/namei.o
+00:03:33   CC [M]  sound/soc/codecs/tlv320aic32x4-i2c.o
+00:03:33   CC [M]  drivers/misc/sgi-gru/gruprocfs.o
+00:03:33   CC [M]  net/ipv4/ah4.o
+00:03:33   LD [M]  drivers/misc/altera-stapl/altera-stapl.o
+00:03:33   CC [M]  net/ipv6/ip6_vti.o
+00:03:33   CC [M]  net/netfilter/nf_tables_offload.o
+00:03:33   CC [M]  drivers/gpu/drm/i915/vlv_suspend.o
+00:03:33   CC [M]  fs/lockd/xdr4.o
+00:03:33   CC [M]  drivers/block/brd.o
+00:03:34   CC      net/mptcp/protocol.o
+00:03:34   CC [M]  fs/sysv/super.o
+00:03:34   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ib.o
+00:03:34   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_cmd.o
+00:03:34   CC [M]  fs/nfsd/nfs4proc.o
+00:03:34   CC [M]  sound/soc/codecs/tlv320aic32x4-spi.o
+00:03:34   CC [M]  drivers/misc/sgi-gru/grukservices.o
+00:03:34   LD [M]  fs/sysv/sysv.o
+00:03:34   CC      fs/btrfs/acl.o
+00:03:34   CC      net/mctp/af_mctp.o
+00:03:34   CC [M]  drivers/block/loop.o
+00:03:34   CC [M]  net/ipv4/esp4.o
+00:03:34   CC [M]  net/netfilter/nft_set_hash.o
+00:03:34   CC [M]  sound/soc/codecs/tlv320adcx140.o
+00:03:34   CC [M]  fs/lockd/svc4proc.o
+00:03:35   CC [M]  drivers/gpu/drm/i915/dma_resv_utils.o
+00:03:35   CC [M]  net/ipv6/sit.o
+00:03:35   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_irq.o
+00:03:35   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_pll.o
+00:03:35   CC [M]  drivers/gpu/drm/i915/i915_memcpy.o
+00:03:35   CC [M]  drivers/misc/sgi-gru/gruhandles.o
+00:03:35   CC [M]  drivers/gpu/drm/radeon/rv770.o
+00:03:35   CC [M]  drivers/gpu/drm/i915/i915_mm.o
+00:03:35   CC [M]  fs/nfs/export.o
+00:03:35   CC      net/mctp/device.o
+00:03:35   CC      fs/btrfs/zoned.o
+00:03:35   CC [M]  sound/soc/codecs/tscs42xx.o
+00:03:36   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_ldu.o
+00:03:36   CC [M]  fs/lockd/procfs.o
+00:03:36   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ucode.o
+00:03:36   CC [M]  drivers/misc/sgi-gru/grukdump.o
+00:03:36   CC [M]  net/netfilter/nft_set_bitmap.o
+00:03:36   CC [M]  net/ipv4/esp4_offload.o
+00:03:36   CC [M]  fs/nfsd/nfs4xdr.o
+00:03:36   CC [M]  drivers/block/pktcdvd.o
+00:03:36   CC [M]  drivers/gpu/drm/i915/i915_sw_fence.o
+00:03:36   LD [M]  fs/lockd/lockd.o
+00:03:36   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_ttm_glue.o
+00:03:36   CC      net/mptcp/subflow.o
+00:03:36   CC [M]  sound/soc/codecs/ts3a227e.o
+00:03:36   CC      net/mctp/route.o
+00:03:36   CC [M]  drivers/gpu/drm/radeon/radeon_test.o
+00:03:36   CC [M]  fs/nfs/sysfs.o
+00:03:36   CC [M]  net/ipv4/ipcomp.o
+00:03:36   CC [M]  net/ipv6/ip6_tunnel.o
+00:03:37   LD [M]  drivers/misc/sgi-gru/gru.o
+00:03:37   CC [M]  drivers/misc/mei/hdcp/mei_hdcp.o
+00:03:37   CC [M]  drivers/gpu/drm/i915/i915_sw_fence_work.o
+00:03:37   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_bo_list.o
+00:03:37   CC [M]  net/netfilter/nft_set_rbtree.o
+00:03:37   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_overlay.o
+00:03:37   CC [M]  drivers/block/nbd.o
+00:03:37   CC      fs/btrfs/verity.o
+00:03:37   CC [M]  drivers/gpu/drm/i915/i915_syncmap.o
+00:03:37   CC [M]  sound/soc/codecs/wm5102.o
+00:03:37   CC [M]  drivers/misc/mei/init.o
+00:03:37   CC [M]  fs/nfs/fs_context.o
+00:03:37   MKREG   drivers/gpu/drm/radeon/r200_reg_safe.h
+00:03:37   CC [M]  drivers/gpu/drm/radeon/radeon_legacy_tv.o
+00:03:38   CC [M]  drivers/gpu/drm/i915/i915_user_extensions.o
+00:03:38   CC [M]  net/ipv4/xfrm4_tunnel.o
+00:03:38   CC [M]  sound/soc/codecs/wm8524.o
+00:03:38   CC      net/mctp/neigh.o
+00:03:38   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_gmrid_manager.o
+00:03:38   CC [M]  drivers/gpu/drm/i915/i915_ioc32.o
+00:03:38   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ctx.o
+00:03:38   CC [M]  drivers/misc/mei/hbm.o
+00:03:38   CC [M]  net/netfilter/nft_set_pipapo.o
+00:03:38   CC      net/mptcp/options.o
+00:03:38   AR      drivers/dax/pmem/built-in.a
+00:03:38   CC [M]  drivers/dax/pmem/pmem.o
+00:03:38   AR      fs/btrfs/built-in.a
+00:03:38   CC [M]  net/llc/llc_core.o
+00:03:38   MKREG   drivers/gpu/drm/radeon/r600_reg_safe.h
+00:03:38   CC [M]  sound/soc/codecs/wm8731.o
+00:03:38   CC [M]  net/ipv6/ip6_gre.o
+00:03:38   CC [M]  drivers/gpu/drm/radeon/r600_blit_shaders.o
+00:03:38   CC [M]  net/ipv4/tunnel4.o
+00:03:39   CC [M]  drivers/gpu/drm/radeon/radeon_pm.o
+00:03:39   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_fence.o
+00:03:39   CC [M]  drivers/dax/pmem/core.o
+00:03:39   AR      net/mctp/built-in.a
+00:03:39   CC [M]  drivers/misc/mei/interrupt.o
+00:03:39   CC [M]  sound/soc/intel/common/soc-acpi-intel-byt-match.o
+00:03:39   CC [M]  fs/nfs/sysctl.o
+00:03:39   CC [M]  drivers/gpu/drm/i915/i915_debugfs.o
+00:03:39   CC [M]  fs/nfsd/nfs4state.o
+00:03:39   CC [M]  drivers/block/virtio_blk.o
+00:03:39   CC [M]  net/llc/llc_input.o
+00:03:39   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_sync.o
+00:03:39   CC [M]  sound/soc/intel/common/soc-acpi-intel-cht-match.o
+00:03:39   CC [M]  drivers/dax/pmem/compat.o
+00:03:39   CC [M]  drivers/misc/mei/client.o
+00:03:39   CC [M]  sound/soc/codecs/wm8804.o
+00:03:40   CC [M]  net/ipv4/tcp_bbr.o
+00:03:40   CC [M]  sound/soc/intel/common/soc-acpi-intel-hsw-bdw-match.o
+00:03:40   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_bo.o
+00:03:40   CC      net/mptcp/token.o
+00:03:40   CC [M]  fs/nfs/fscache.o
+00:03:40   CC [M]  net/llc/llc_output.o
+00:03:40   LD [M]  drivers/dax/pmem/dax_pmem.o
+00:03:40   LD [M]  drivers/dax/pmem/dax_pmem_core.o
+00:03:40   LD [M]  drivers/dax/pmem/dax_pmem_compat.o
+00:03:40   CC [M]  net/netfilter/nft_set_pipapo_avx2.o
+00:03:40   CC      drivers/dax/hmem/device.o
+00:03:40   CC [M]  sound/soc/intel/common/soc-acpi-intel-skl-match.o
+00:03:40   CC [M]  drivers/gpu/drm/radeon/atombios_dp.o
+00:03:40   CC [M]  drivers/block/xen-blkfront.o
+00:03:40   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_gtt_mgr.o
+00:03:40   CC [M]  sound/soc/codecs/wm8804-i2c.o
+00:03:40   CC [M]  drivers/gpu/drm/i915/i915_debugfs_params.o
+00:03:40   CC [M]  drivers/dax/hmem/hmem.o
+00:03:40   LD [M]  net/llc/llc.o
+00:03:41   CC [M]  sound/soc/intel/common/soc-acpi-intel-kbl-match.o
+00:03:41   CC [M]  sound/soc/intel/atom/sst/sst.o
+00:03:41   CC [M]  net/ipv6/fou6.o
+00:03:41   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_scrn.o
+00:03:41   CC [M]  drivers/misc/mei/main.o
+00:03:41   CC [M]  net/ipv4/tcp_bic.o
+00:03:41   CC      net/mptcp/crypto.o
+00:03:41   AR      drivers/dax/hmem/built-in.a
+00:03:41   LD [M]  drivers/dax/hmem/dax_hmem.o
+00:03:41   CC      drivers/dax/super.o
+00:03:41   CC [M]  fs/nfs/fscache-index.o
+00:03:41   CC [M]  drivers/gpu/drm/radeon/r600_hdmi.o
+00:03:41   CC [M]  sound/soc/codecs/wm_adsp.o
+00:03:41   CC [M]  sound/soc/intel/common/soc-acpi-intel-bxt-match.o
+00:03:41   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_preempt_mgr.o
+00:03:41   CC [M]  net/netfilter/nft_compat.o
+00:03:41   CC [M]  sound/soc/intel/atom/sst/sst_ipc.o
+00:03:41   CC [M]  drivers/gpu/drm/i915/display/intel_display_debugfs.o
+00:03:41   CC [M]  sound/soc/intel/common/soc-acpi-intel-glk-match.o
+00:03:42   CC [M]  drivers/misc/mei/dma-ring.o
+00:03:42   CC [M]  net/ipv6/ip6_udp_tunnel.o
+00:03:42   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_context.o
+00:03:42   CC      drivers/dax/bus.o
+00:03:42   CC [M]  net/ipv4/tcp_cdg.o
+00:03:42   CC [M]  sound/soc/intel/common/soc-acpi-intel-cnl-match.o
+00:03:42   CC      net/mptcp/ctrl.o
+00:03:42   CC [M]  fs/nfs/nfs3super.o
+00:03:42   CC [M]  sound/soc/intel/atom/sst/sst_stream.o
+00:03:42   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vram_mgr.o
+00:03:42   CC [M]  drivers/gpu/drm/radeon/dce3_1_afmt.o
+00:03:42   CC [M]  drivers/misc/mei/bus.o
+00:03:42   CC [M]  drivers/block/rbd.o
+00:03:42   CC [M]  sound/soc/intel/common/soc-acpi-intel-cfl-match.o
+00:03:43   CC [M]  net/netfilter/nft_connlimit.o
+00:03:43   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_surface.o
+00:03:43   CC [M]  sound/soc/intel/atom/sst/sst_drv_interface.o
+00:03:43   AR      net/ipv6/built-in.a
+00:03:43   CC [M]  drivers/dax/device.o
+00:03:43   CC [M]  sound/soc/intel/atom/sst/sst_loader.o
+00:03:43   CC [M]  sound/soc/intel/common/soc-acpi-intel-cml-match.o
+00:03:43   CC [M]  drivers/misc/mei/bus-fixup.o
+00:03:43   CC      net/mptcp/pm.o
+00:03:43   CC [M]  fs/nfs/nfs3client.o
+00:03:43   CC [M]  net/ipv4/tcp_dctcp.o
+00:03:43   CC [M]  drivers/gpu/drm/radeon/evergreen.o
+00:03:43   CC [M]  sound/soc/intel/common/soc-acpi-intel-icl-match.o
+00:03:43   CC [M]  sound/soc/codecs/zl38060.o
+00:03:43   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_virt.o
+00:03:43   CC [M]  drivers/dax/kmem.o
+00:03:43   CC [M]  fs/nfsd/nfs4idmap.o
+00:03:43   CC [M]  drivers/misc/vmw_vmci/vmci_context.o
+00:03:43   CC [M]  drivers/gpu/drm/i915/display/intel_pipe_crc.o
+00:03:43   CC [M]  sound/soc/intel/atom/sst/sst_pvt.o
+00:03:44   CC [M]  drivers/misc/mei/debugfs.o
+00:03:44   CC [M]  net/netfilter/nft_numgen.o
+00:03:44   CC [M]  sound/soc/intel/common/soc-acpi-intel-tgl-match.o
+00:03:44   CC [M]  fs/nfs/nfs3proc.o
+00:03:44   LD [M]  drivers/dax/device_dax.o
+00:03:44   AR      drivers/dax/built-in.a
+00:03:44   CC [M]  drivers/gpu/drm/i915/i915_pmu.o
+00:03:44   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_prime.o
+00:03:44   CC [M]  drivers/misc/mei/mei-trace.o
+00:03:44   CC [M]  sound/soc/codecs/simple-amplifier.o
+00:03:44   CC      net/mptcp/diag.o
+00:03:44   CC [M]  net/ipv4/tcp_westwood.o
+00:03:44   CC [M]  sound/soc/intel/atom/sst/sst_acpi.o
+00:03:44   CC [M]  sound/soc/intel/common/soc-acpi-intel-ehl-match.o
+00:03:44   CC [M]  drivers/misc/vmw_vmci/vmci_datagram.o
+00:03:44   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_atomfirmware.o
+00:03:45   CC [M]  fs/nfsd/nfs4acl.o
+00:03:45   CC [M]  net/netfilter/nft_ct.o
+00:03:45   CC [M]  drivers/misc/vmw_vmci/vmci_doorbell.o
+00:03:45   CC [M]  fs/smbfs_common/cifs_arc4.o
+00:03:45   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_mob.o
+00:03:45   CC [M]  sound/soc/codecs/simple-mux.o
+00:03:45   CC [M]  sound/soc/intel/common/soc-acpi-intel-jsl-match.o
+00:03:45   CC [M]  drivers/misc/mei/pci-me.o
+00:03:45   LD [M]  sound/soc/intel/atom/sst/snd-intel-sst-core.o
+00:03:45   LD [M]  sound/soc/intel/atom/sst/snd-intel-sst-acpi.o
+00:03:45   CC [M]  sound/soc/intel/atom/sst-mfld-platform-pcm.o
+00:03:45   CC [M]  fs/smbfs_common/cifs_md4.o
+00:03:45   CC      net/mptcp/mib.o
+00:03:45   CC [M]  net/ipv4/tcp_highspeed.o
+00:03:45   CC [M]  sound/soc/intel/common/soc-acpi-intel-adl-match.o
+00:03:45   CC [M]  drivers/misc/vmw_vmci/vmci_driver.o
+00:03:45   CC [M]  fs/nfs/nfs3xdr.o
+00:03:45   CC [M]  drivers/gpu/drm/i915/gt/debugfs_engines.o
+00:03:45   CC [M]  drivers/misc/mei/hw-me.o
+00:03:45   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vf_error.o
+00:03:45   CC [M]  drivers/misc/mei/pci-txe.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-ac97.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau-utils.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau17x1.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau1761.o
+00:03:45   CC [M]  drivers/misc/vmw_vmci/vmci_event.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau1761-i2c.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau1761-spi.o
+00:03:45   LD [M]  sound/soc/codecs/snd-soc-adau7002.o
+00:03:45   CC [M]  sound/soc/intel/common/soc-acpi-intel-hda-match.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-adau7118.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-adau7118-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-adau7118-hw.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-ak5558.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-arizona.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-bd28623.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-bt-sco.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cros-ec-codec.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs35l34.o
+00:03:46   CC [M]  sound/soc/intel/atom/sst-mfld-platform-compress.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs35l35.o
+00:03:46   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_shader.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs35l36.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs42l42.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs4234.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cs43130.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-cx2072x.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-da7213.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-da7219.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-dmic.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-es7134.o
+00:03:46   CC [M]  fs/nfs/nfs3acl.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-es8316.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-es8328.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-es8328-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-es8328-spi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-hdac-hdmi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-hdac-hda.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max9759.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98088.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98090.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98357a.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max9867.o
+00:03:46   MKREG   drivers/gpu/drm/radeon/evergreen_reg_safe.h
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98927.o
+00:03:46   MKREG   drivers/gpu/drm/radeon/cayman_reg_safe.h
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98373.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98373-i2c.o
+00:03:46   CC [M]  drivers/gpu/drm/radeon/evergreen_blit_shaders.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98373-sdw.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-max98390.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-nau8315.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-nau8540.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-nau8824.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm1789-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm1789-codec.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm186x.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm186x-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm186x-spi.o
+00:03:46   CC [M]  fs/nfsd/nfs4callback.o
+00:03:46   CC [M]  drivers/gpu/drm/radeon/evergreen_hdmi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm3060.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm3060-i2c.o
+00:03:46   CC [M]  drivers/misc/vmw_vmci/vmci_guest.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm3060-spi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm512x.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-pcm512x-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rl6231.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rl6347a.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1011.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1015.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1015p.o
+00:03:46   CC [M]  net/netfilter/nft_flow_offload.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1308.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1308-sdw.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt1316-sdw.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt286.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5640.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5645.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5651.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5659.o
+00:03:46   CC      net/mptcp/pm_netlink.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5660.o
+00:03:46   CC [M]  sound/soc/intel/common/soc-acpi-intel-sdw-mockup-match.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5670.o
+00:03:46   CC [M]  drivers/misc/vmw_vmci/vmci_handle_array.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5677.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5677-spi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5682.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5682-i2c.o
+00:03:46   CC [M]  net/ipv4/tcp_hybla.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt5682-sdw.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt700.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt711.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt711-sdca.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt715.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-rt715-sdca.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-sigmadsp.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-sigmadsp-regmap.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-spdif-rx.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-spdif-tx.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-ssm4567.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tas2562.o
+00:03:46   CC [M]  sound/soc/intel/atom/sst-atom-controls.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tas2764.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tas6424.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tda7419.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tas2770.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tlv320aic32x4.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tlv320aic32x4-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tlv320aic32x4-spi.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tlv320adcx140.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-tscs42xx.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-ts3a227e.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm5102.o
+00:03:46   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_sched.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm8524.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm8731.o
+00:03:46   CC [M]  drivers/gpu/drm/i915/gt/debugfs_gt.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm8804.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm8804-i2c.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-wm-adsp.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-zl38060.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-simple-amplifier.o
+00:03:46   LD [M]  sound/soc/codecs/snd-soc-simple-mux.o
+00:03:46   CC      net/mptcp/sockopt.o
+00:03:46   CC [M]  drivers/misc/mei/hw-txe.o
+00:03:46   LD [M]  sound/soc/intel/common/snd-soc-acpi-intel-match.o
+00:03:46   CC      net/mptcp/syncookies.o
+00:03:47   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_cmdbuf_res.o
+00:03:47   CC [M]  drivers/misc/vmw_vmci/vmci_host.o
+00:03:47   CC [M]  drivers/gpu/drm/radeon/radeon_trace_points.o
+00:03:47   CC [M]  fs/cifs/trace.o
+00:03:47   CC [M]  fs/nfs/nfs4proc.o
+00:03:47   CC [M]  drivers/misc/echo/echo.o
+00:03:47   CC [M]  net/ipv4/tcp_htcp.o
+00:03:47   LD [M]  sound/soc/intel/atom/snd-soc-sst-atom-hifi2-platform.o
+00:03:47   CC [M]  net/netfilter/nft_limit.o
+00:03:47   LD [M]  drivers/misc/mei/mei.o
+00:03:47   CC [M]  sound/soc/intel/catpt/device.o
+00:03:47   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_debugfs.o
+00:03:47   LD [M]  drivers/misc/mei/mei-me.o
+00:03:47   LD [M]  drivers/misc/mei/mei-txe.o
+00:03:47   CC [M]  fs/cifs/cifsfs.o
+00:03:47   CC [M]  drivers/gpu/drm/i915/gt/debugfs_gt_pm.o
+00:03:47   CC [M]  drivers/misc/vmw_vmci/vmci_queue_pair.o
+00:03:47   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_cmdbuf.o
+00:03:47   CC [M]  fs/nfsd/nfs4recover.o
+00:03:47   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ids.o
+00:03:48   CC      drivers/dma-buf/heaps/system_heap.o
+00:03:48   CC [M]  net/tls/tls_main.o
+00:03:48   CC      net/mptcp/mptcp_diag.o
+00:03:48   CC [M]  drivers/gpu/drm/radeon/ni.o
+00:03:48   CC [M]  sound/soc/intel/catpt/dsp.o
+00:03:48   CC      drivers/dma-buf/heaps/cma_heap.o
+00:03:48   CC [M]  net/ipv4/tcp_vegas.o
+00:03:48   CC [M]  net/netfilter/nft_nat.o
+00:03:48   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_stdu.o
+00:03:49   CC [M]  drivers/gpu/drm/i915/gt/gen2_engine_cs.o
+00:03:49   CC [M]  drivers/gpu/drm/vkms/vkms_drv.o
+00:03:49   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_gmc.o
+00:03:49   CC [M]  drivers/misc/vmw_vmci/vmci_resource.o
+00:03:49   CC [M]  fs/ntfs3/attrib.o
+00:03:49   AR      drivers/dma-buf/heaps/built-in.a
+00:03:49   CC [M]  sound/soc/intel/catpt/loader.o
+00:03:49   CC      drivers/dma-buf/dma-buf.o
+00:03:49   CC [M]  drivers/misc/vmw_vmci/vmci_route.o
+00:03:49   CC [M]  fs/cifs/cifssmb.o
+00:03:49   CC [M]  net/mptcp/crypto_test.o
+00:03:49   CC [M]  fs/nfsd/nfs4layouts.o
+00:03:49   CC [M]  net/tls/tls_sw.o
+00:03:49   LD [M]  drivers/misc/vmw_vmci/vmw_vmci.o
+00:03:49   CC [M]  drivers/misc/bcm-vk/bcm_vk_dev.o
+00:03:49   CC [M]  net/ipv4/tcp_nv.o
+00:03:49   CC [M]  net/netfilter/nft_queue.o
+00:03:49   CC [M]  drivers/gpu/drm/vkms/vkms_plane.o
+00:03:50   CC [M]  drivers/gpu/drm/radeon/cayman_blit_shaders.o
+00:03:50   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_cotable.o
+00:03:50   CC [M]  sound/soc/intel/catpt/ipc.o
+00:03:50   CC [M]  drivers/gpu/drm/i915/gt/gen6_engine_cs.o
+00:03:50   CC [M]  drivers/gpu/drm/radeon/atombios_encoders.o
+00:03:50   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_mmhub.o
+00:03:50   CC      drivers/dma-buf/dma-fence.o
+00:03:50   CC [M]  net/mptcp/token_test.o
+00:03:50   CC [M]  sound/soc/intel/catpt/messages.o
+00:03:50   CC [M]  fs/ntfs3/attrlist.o
+00:03:50   CC [M]  drivers/misc/bcm-vk/bcm_vk_msg.o
+00:03:50   CC [M]  drivers/gpu/drm/vkms/vkms_output.o
+00:03:50   CC [M]  drivers/gpu/drm/i915/gt/gen6_ppgtt.o
+00:03:50   CC [M]  net/ipv4/tcp_veno.o
+00:03:50   CC [M]  net/netfilter/nft_quota.o
+00:03:50   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_so.o
+00:03:51   CC [M]  fs/nfsd/blocklayout.o
+00:03:51   CC      drivers/dma-buf/dma-fence-array.o
+00:03:51   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_xgmi.o
+00:03:51   CC [M]  sound/soc/intel/catpt/pcm.o
+00:03:51   CC [M]  fs/ntfs3/bitfunc.o
+00:03:51   CC [M]  net/tls/tls_proc.o
+00:03:51   CC [M]  drivers/gpu/drm/vkms/vkms_crtc.o
+00:03:51   CC      drivers/dma-buf/dma-fence-chain.o
+00:03:51   LD [M]  net/mptcp/mptcp_crypto_test.o
+00:03:51   LD [M]  net/mptcp/mptcp_token_test.o
+00:03:51   AR      net/mptcp/built-in.a
+00:03:51   CC [M]  fs/ntfs3/bitmap.o
+00:03:51   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_binding.o
+00:03:51   CC [M]  drivers/misc/bcm-vk/bcm_vk_sg.o
+00:03:51   CC [M]  drivers/gpu/drm/radeon/radeon_semaphore.o
+00:03:51   CC [M]  net/netfilter/nft_reject.o
+00:03:51   CC [M]  net/ipv4/tcp_scalable.o
+00:03:52   CC      drivers/dma-buf/dma-resv.o
+00:03:52   CC [M]  sound/soc/intel/catpt/sysfs.o
+00:03:52   CC [M]  fs/nfs/nfs4xdr.o
+00:03:52   CC [M]  fs/nfsd/blocklayoutxdr.o
+00:03:52   CC [M]  drivers/gpu/drm/vkms/vkms_composer.o
+00:03:52   CC [M]  drivers/gpu/drm/i915/gt/gen7_renderclear.o
+00:03:52   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_csa.o
+00:03:52   CC [M]  drivers/misc/bcm-vk/bcm_vk_tty.o
+00:03:52   CC [M]  fs/nfs/nfs4state.o
+00:03:52   CC [M]  net/tls/trace.o
+00:03:52   LD [M]  sound/soc/intel/catpt/snd-soc-catpt.o
+00:03:52   CC [M]  drivers/gpu/drm/radeon/radeon_sa.o
+00:03:52   CC [M]  sound/soc/intel/boards/sof_rt5682.o
+00:03:52   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_msg.o
+00:03:52   CC [M]  fs/ntfs3/dir.o
+00:03:52   CC [M]  net/netfilter/nft_reject_inet.o
+00:03:52   CC      drivers/dma-buf/seqno-fence.o
+00:03:52   CC [M]  net/ipv4/tcp_lp.o
+00:03:53   LD [M]  drivers/misc/bcm-vk/bcm_vk.o
+00:03:53   CC [M]  drivers/gpu/drm/vkms/vkms_writeback.o
+00:03:53   CC [M]  drivers/misc/uacce/uacce.o
+00:03:53   CC [M]  fs/cifs/cifs_debug.o
+00:03:53   CC [M]  fs/nfsd/flexfilelayout.o
+00:03:53   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ras.o
+00:03:53   CC [M]  drivers/gpu/drm/i915/gt/gen8_engine_cs.o
+00:03:53   CC      drivers/dma-buf/dma-heap.o
+00:03:53   CC [M]  net/tls/tls_device.o
+00:03:53   CC [M]  drivers/gpu/drm/radeon/atombios_i2c.o
+00:03:53   CC [M]  sound/soc/intel/boards/sof_realtek_common.o
+00:03:53   CC [M]  fs/ntfs3/fsntfs.o
+00:03:53   CC      drivers/misc/kgdbts.o
+00:03:53   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_simple_resource.o
+00:03:53   CC [M]  net/netfilter/nft_reject_netdev.o
+00:03:53   LD [M]  drivers/gpu/drm/vkms/vkms.o
+00:03:53   CC      drivers/macintosh/mac_hid.o
+00:03:53   CC [M]  net/ipv4/tcp_yeah.o
+00:03:54   CC      drivers/dma-buf/sync_file.o
+00:03:54   CC [M]  fs/nfsd/flexfilelayoutxdr.o
+00:03:54   CC [M]  sound/soc/intel/boards/sof_cs42l42.o
+00:03:54   AR      drivers/macintosh/built-in.a
+00:03:54   CC [M]  fs/ufs/balloc.o
+00:03:54   CC [M]  drivers/gpu/drm/radeon/si.o
+00:03:54   CC [M]  fs/cifs/connect.o
+00:03:54   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_va.o
+00:03:54   CC [M]  drivers/gpu/drm/i915/gt/gen8_ppgtt.o
+00:03:54   CC [M]  fs/ufs/cylinder.o
+00:03:54   CC [M]  drivers/misc/tifm_core.o
+00:03:54   CC      drivers/dma-buf/udmabuf.o
+00:03:54   CC [M]  net/netfilter/nft_tunnel.o
+00:03:54   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vm_cpu.o
+00:03:55   CC [M]  net/ipv4/tcp_illinois.o
+00:03:55   CC [M]  net/tls/tls_device_fallback.o
+00:03:55   CC [M]  fs/ntfs3/frecord.o
+00:03:55   LD [M]  fs/nfsd/nfsd.o
+00:03:55   CC [M]  sound/soc/intel/boards/haswell.o
+00:03:55   CC [M]  net/key/af_key.o
+00:03:55   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_blit.o
+00:03:55   CC [M]  drivers/misc/tifm_7xx1.o
+00:03:55   CC [M]  fs/cifs/dir.o
+00:03:55   AR      drivers/dma-buf/built-in.a
+00:03:55   CC [M]  drivers/gpu/drm/radeon/si_blit_shaders.o
+00:03:55   CC [M]  drivers/gpu/drm/i915/gt/intel_breadcrumbs.o
+00:03:55   CC [M]  fs/ufs/dir.o
+00:03:55   CC [M]  sound/soc/intel/boards/bxt_da7219_max98357a.o
+00:03:55   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vm_sdma.o
+00:03:55   CC [M]  drivers/misc/bh1770glc.o
+00:03:56   LD [M]  net/ipv4/gre.o
+00:03:56   LD [M]  net/ipv4/udp_tunnel.o
+00:03:56   AR      net/ipv4/built-in.a
+00:03:56   CC [M]  net/netfilter/nft_log.o
+00:03:56   CC [M]  fs/ntfs3/file.o
+00:03:56   CC [M]  fs/nfs/nfs4renewd.o
+00:03:56   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_validation.o
+00:03:56   CC [M]  drivers/gpu/drm/radeon/radeon_prime.o
+00:03:56   LD [M]  net/tls/tls.o
+00:03:56   CC [M]  fs/jffs2/compr.o
+00:03:56   CC [M]  sound/soc/intel/boards/sof_pcm512x.o
+00:03:56   CC [M]  sound/soc/intel/boards/sof_wm8804.o
+00:03:56   CC [M]  sound/soc/intel/boards/glk_rt5682_max98357a.o
+00:03:56   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_discovery.o
+00:03:56   CC [M]  fs/ufs/file.o
+00:03:56   CC [M]  fs/jffs2/dir.o
+00:03:56   CC [M]  drivers/misc/apds990x.o
+00:03:57   CC [M]  drivers/gpu/drm/i915/gt/intel_context.o
+00:03:57   CC [M]  net/netfilter/nft_masq.o
+00:03:57   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_page_dirty.o
+00:03:57   CC [M]  fs/nfs/nfs4super.o
+00:03:57   CC [M]  drivers/gpu/drm/nouveau/nvif/object.o
+00:03:57   CC [M]  fs/ufs/ialloc.o
+00:03:57   CC [M]  fs/ntfs3/fslog.o
+00:03:57   CC [M]  drivers/gpu/drm/nouveau/nvif/client.o
+00:03:57   CC [M]  fs/ubifs/shrinker.o
+00:03:57   CC [M]  fs/cifs/file.o
+00:03:57   CC [M]  fs/jffs2/file.o
+00:03:57   CC [M]  sound/soc/intel/boards/broadwell.o
+00:03:57   AR      drivers/scsi/pcmcia/built-in.a
+00:03:57   AR      drivers/scsi/device_handler/built-in.a
+00:03:57   CC [M]  drivers/scsi/device_handler/scsi_dh_rdac.o
+00:03:57   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ras_eeprom.o
+00:03:57   CC [M]  fs/ufs/inode.o
+00:03:57   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_streamoutput.o
+00:03:57   CC [M]  drivers/misc/enclosure.o
+00:03:58   CC [M]  drivers/gpu/drm/i915/gt/intel_context_sseu.o
+00:03:58   CC [M]  net/netfilter/nft_redir.o
+00:03:58   CC [M]  drivers/gpu/drm/nouveau/nvif/device.o
+00:03:58   CC [M]  fs/jffs2/ioctl.o
+00:03:58   CC [M]  fs/nfs/nfs4file.o
+00:03:58   CC [M]  fs/ubifs/journal.o
+00:03:58   CC [M]  sound/soc/intel/boards/bdw-rt5650.o
+00:03:58   AR      drivers/scsi/megaraid/built-in.a
+00:03:58   CC [M]  drivers/scsi/megaraid/megaraid_mm.o
+00:03:58   CC [M]  drivers/misc/hpilo.o
+00:03:58   CC [M]  drivers/scsi/device_handler/scsi_dh_hp_sw.o
+00:03:58   CC [M]  fs/jffs2/nodelist.o
+00:03:58   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_devcaps.o
+00:03:58   CC [M]  drivers/gpu/drm/radeon/cik.o
+00:03:58   CC [M]  drivers/gpu/drm/nouveau/nvif/disp.o
+00:03:58   CC [M]  sound/soc/intel/boards/bdw-rt5677.o
+00:03:59   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_nbio.o
+00:03:59   CC [M]  drivers/scsi/megaraid/megaraid_mbox.o
+00:03:59   CC [M]  net/netfilter/nft_hash.o
+00:03:59   CC [M]  drivers/misc/apds9802als.o
+00:03:59   CC [M]  drivers/scsi/device_handler/scsi_dh_emc.o
+00:03:59   CC [M]  drivers/gpu/drm/i915/gt/intel_engine_cs.o
+00:03:59   CC [M]  fs/ufs/namei.o
+00:03:59   CC [M]  fs/jffs2/malloc.o
+00:03:59   CC [M]  fs/nfs/delegation.o
+00:03:59   CC [M]  drivers/gpu/drm/vmwgfx/ttm_object.o
+00:03:59   CC [M]  sound/soc/intel/boards/bytcr_rt5640.o
+00:03:59   CC [M]  fs/ubifs/file.o
+00:03:59   CC [M]  drivers/gpu/drm/nouveau/nvif/driver.o
+00:03:59   CC [M]  fs/ufs/super.o
+00:03:59   CC [M]  fs/jffs2/read.o
+00:03:59   CC [M]  fs/ntfs3/inode.o
+00:03:59   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_umc.o
+00:04:00   CC [M]  drivers/scsi/device_handler/scsi_dh_alua.o
+00:04:00   CC [M]  drivers/misc/isl29003.o
+00:04:00   CC [M]  net/netfilter/nft_fib.o
+00:04:00   CC [M]  drivers/gpu/drm/vmwgfx/ttm_memory.o
+00:04:00   CC [M]  drivers/gpu/drm/nouveau/nvif/fifo.o
+00:04:00   CC [M]  fs/jffs2/nodemgmt.o
+00:04:00   CC [M]  drivers/scsi/megaraid/megaraid_sas_base.o
+00:04:00   CC [M]  sound/soc/intel/boards/bytcr_rt5651.o
+00:04:00   CC [M]  fs/ubifs/dir.o
+00:04:00   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_system_manager.o
+00:04:00   CC [M]  drivers/misc/isl29020.o
+00:04:00   CC [M]  drivers/gpu/drm/amd/amdgpu/smu_v11_0_i2c.o
+00:04:01   CC [M]  drivers/gpu/drm/gma500/backlight.o
+00:04:01   CC [M]  fs/ufs/util.o
+00:04:01   CC [M]  net/netfilter/nft_fib_inet.o
+00:04:01   CC [M]  fs/nfs/nfs4idmap.o
+00:04:01   CC [M]  drivers/gpu/drm/i915/gt/intel_engine_heartbeat.o
+00:04:01   CC [M]  fs/jffs2/readinode.o
+00:04:01   CC [M]  drivers/gpu/drm/nouveau/nvif/mem.o
+00:04:01   CC [M]  fs/ntfs3/index.o
+00:04:01   CC [M]  fs/cifs/inode.o
+00:04:01   CC [M]  drivers/gpu/drm/vmwgfx/vmwgfx_fb.o
+00:04:01   CC [M]  sound/soc/intel/boards/bytcr_wm5102.o
+00:04:01   CC [M]  drivers/misc/tsl2550.o
+00:04:01   LD [M]  fs/ufs/ufs.o
+00:04:01   CC [M]  net/bridge/netfilter/nft_meta_bridge.o
+00:04:01   CC [M]  drivers/gpu/drm/gma500/cdv_device.o
+00:04:02   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_fru_eeprom.o
+00:04:02   CC [M]  drivers/gpu/drm/nouveau/nvif/mmu.o
+00:04:02   CC [M]  fs/ubifs/super.o
+00:04:02   CC [M]  net/netfilter/nft_fib_netdev.o
+00:04:02   CC [M]  fs/jffs2/write.o
+00:04:02   CC [M]  drivers/gpu/drm/radeon/cik_blit_shaders.o
+00:04:02   CC [M]  drivers/gpu/drm/radeon/r600_dpm.o
+00:04:02   CC [M]  drivers/misc/vmw_balloon.o
+00:04:02   CC [M]  drivers/gpu/drm/i915/gt/intel_engine_pm.o
+00:04:02   CC [M]  sound/soc/intel/boards/cht_bsw_rt5672.o
+00:04:02   CC [M]  fs/nfs/callback.o
+00:04:02   LD [M]  drivers/gpu/drm/vmwgfx/vmwgfx.o
+00:04:02   CC [M]  drivers/gpu/drm/i915/gt/intel_engine_user.o
+00:04:02   CC [M]  fs/jffs2/scan.o
+00:04:02   CC [M]  net/bridge/netfilter/nft_reject_bridge.o
+00:04:02   CC [M]  drivers/gpu/drm/gma500/cdv_intel_crt.o
+00:04:02   CC [M]  drivers/gpu/drm/nouveau/nvif/notify.o
+00:04:02   CC [M]  fs/ntfs3/lznt.o
+00:04:02   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_rap.o
+00:04:03   CC [M]  net/netfilter/nft_socket.o
+00:04:03   CC [M]  sound/soc/intel/boards/cht_bsw_rt5645.o
+00:04:03   CC [M]  drivers/misc/dw-xdata-pcie.o
+00:04:03   CC [M]  fs/ubifs/sb.o
+00:04:03   CC [M]  drivers/scsi/megaraid/megaraid_sas_fusion.o
+00:04:03   CC [M]  fs/nfs/callback_xdr.o
+00:04:03   AR      drivers/nvme/host/built-in.a
+00:04:03   CC [M]  fs/ntfs3/namei.o
+00:04:03   CC [M]  drivers/nvme/host/core.o
+00:04:03   CC [M]  drivers/gpu/drm/radeon/rs780_dpm.o
+00:04:03   CC [M]  drivers/gpu/drm/nouveau/nvif/timer.o
+00:04:03   CC [M]  drivers/gpu/drm/gma500/cdv_intel_display.o
+00:04:03   CC [M]  drivers/gpu/drm/i915/gt/intel_execlists_submission.o
+00:04:03   CC [M]  fs/jffs2/gc.o
+00:04:03   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_fw_attestation.o
+00:04:03   CC [M]  net/bridge/netfilter/nf_conntrack_bridge.o
+00:04:03   CC [M]  fs/cifs/link.o
+00:04:03   CC [M]  sound/soc/intel/boards/cht_bsw_max98090_ti.o
+00:04:04   AR      drivers/misc/built-in.a
+00:04:04   CC [M]  drivers/nvme/host/ioctl.o
+00:04:04   CC [M]  net/netfilter/nft_tproxy.o
+00:04:04   CC [M]  fs/ntfs3/record.o
+00:04:04   CC [M]  fs/ubifs/io.o
+00:04:04   CC [M]  drivers/gpu/drm/nouveau/nvif/vmm.o
+00:04:04   CC [M]  sound/soc/intel/boards/cht_bsw_nau8824.o
+00:04:04   CC [M]  fs/jffs2/symlink.o
+00:04:04   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_securedisplay.o
+00:04:04   CC [M]  drivers/gpu/drm/gma500/cdv_intel_dp.o
+00:04:04   CC [M]  drivers/gpu/drm/radeon/rv6xx_dpm.o
+00:04:05   CC [M]  drivers/scsi/libsas/sas_init.o
+00:04:05   CC [M]  fs/nfs/callback_proc.o
+00:04:05   CC [M]  fs/ntfs3/run.o
+00:04:05   CC [M]  fs/jffs2/build.o
+00:04:05   CC [M]  net/bridge/netfilter/ebtables.o
+00:04:05   CC [M]  net/netfilter/nft_xfrm.o
+00:04:05   CC [M]  sound/soc/intel/boards/bytcht_cx2072x.o
+00:04:05   CC [M]  drivers/gpu/drm/nouveau/nvif/user.o
+00:04:05   CC [M]  fs/cifs/misc.o
+00:04:05   CC [M]  drivers/scsi/megaraid/megaraid_sas_fp.o
+00:04:05   CC [M]  fs/ubifs/tnc.o
+00:04:05   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_hdp.o
+00:04:05   CC [M]  fs/jffs2/erase.o
+00:04:05   CC [M]  drivers/gpu/drm/i915/gt/intel_ggtt.o
+00:04:05   CC [M]  sound/soc/intel/boards/bytcht_da7213.o
+00:04:05   CC [M]  drivers/scsi/libsas/sas_phy.o
+00:04:06   CC [M]  drivers/gpu/drm/nouveau/nvif/userc361.o
+00:04:06   CC [M]  drivers/gpu/drm/gma500/cdv_intel_hdmi.o
+00:04:06   CC [M]  fs/ntfs3/super.o
+00:04:06   CC [M]  drivers/gpu/drm/radeon/rv770_dpm.o
+00:04:06   CC [M]  net/netfilter/nft_synproxy.o
+00:04:06   CC [M]  drivers/nvme/host/trace.o
+00:04:06   CC [M]  fs/jffs2/background.o
+00:04:06   CC [M]  fs/nfs/nfs4namespace.o
+00:04:06   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_eeprom.o
+00:04:06   CC [M]  drivers/scsi/libsas/sas_port.o
+00:04:06   CC [M]  sound/soc/intel/boards/bytcht_es8316.o
+00:04:06   CC [M]  drivers/scsi/megaraid/megaraid_sas_debugfs.o
+00:04:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/client.o
+00:04:07   CC [M]  drivers/gpu/drm/gma500/cdv_intel_lvds.o
+00:04:07   CC [M]  net/bridge/netfilter/ebtable_broute.o
+00:04:07   CC [M]  fs/jffs2/fs.o
+00:04:07   CC [M]  fs/cifs/netmisc.o
+00:04:07   CC [M]  drivers/nvme/host/multipath.o
+00:04:07   CC [M]  fs/ntfs3/upcase.o
+00:04:07   CC [M]  drivers/gpu/drm/i915/gt/intel_ggtt_fencing.o
+00:04:07   CC [M]  fs/ubifs/master.o
+00:04:07   LD [M]  drivers/scsi/megaraid/megaraid_sas.o
+00:04:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/engine.o
+00:04:07   CC [M]  net/netfilter/nft_chain_nat.o
+00:04:07   CC [M]  drivers/scsi/libsas/sas_event.o
+00:04:07   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_mca.o
+00:04:07   CC [M]  sound/soc/intel/boards/bytcht_nocodec.o
+00:04:07   CC [M]  fs/nfs/nfs4getroot.o
+00:04:07   CC [M]  net/bridge/br.o
+00:04:07   CC [M]  fs/jffs2/writev.o
+00:04:07   CC [M]  drivers/gpu/drm/radeon/rv730_dpm.o
+00:04:07   CC [M]  fs/ntfs3/xattr.o
+00:04:07   CC [M]  drivers/gpu/drm/gma500/framebuffer.o
+00:04:08   CC [M]  net/bridge/netfilter/ebtable_filter.o
+00:04:08   CC [M]  sound/soc/intel/boards/cml_rt1011_rt5682.o
+00:04:08   CC [M]  fs/ubifs/scan.o
+00:04:08   CC [M]  drivers/scsi/libsas/sas_discover.o
+00:04:08   CC [M]  drivers/nvme/host/zns.o
+00:04:08   CC [M]  fs/cifs/smbencrypt.o
+00:04:08   CC [M]  fs/jffs2/super.o
+00:04:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/enum.o
+00:04:08   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_fdinfo.o
+00:04:08   CC [M]  net/netfilter/nft_dup_netdev.o
+00:04:08   CC [M]  drivers/gpu/drm/i915/gt/intel_gt.o
+00:04:08   CC [M]  fs/nfs/nfs4client.o
+00:04:08   CC [M]  drivers/gpu/drm/radeon/rv740_dpm.o
+00:04:08   CC [M]  fs/ntfs3/lib/decompress_common.o
+00:04:08   CC [M]  drivers/gpu/drm/gma500/gem.o
+00:04:08   CC [M]  fs/ntfs3/lib/lzx_decompress.o
+00:04:08   CC [M]  fs/jffs2/debug.o
+00:04:08   CC [M]  net/bridge/netfilter/ebtable_nat.o
+00:04:09   CC [M]  fs/ubifs/replay.o
+00:04:09   CC [M]  drivers/nvme/host/hwmon.o
+00:04:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/event.o
+00:04:09   CC [M]  sound/soc/intel/boards/skl_hda_dsp_generic.o
+00:04:09   CC [M]  drivers/scsi/libsas/sas_expander.o
+00:04:09   CC [M]  drivers/gpu/drm/udl/udl_drv.o
+00:04:09   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_pmu.o
+00:04:09   CC [M]  fs/ntfs3/lib/xpress_decompress.o
+00:04:09   CC [M]  fs/cifs/transport.o
+00:04:09   CC [M]  fs/jffs2/wbuf.o
+00:04:09   CC [M]  net/netfilter/nft_fwd_netdev.o
+00:04:09   CC [M]  drivers/gpu/drm/radeon/rv770_smc.o
+00:04:09   CC [M]  drivers/gpu/drm/gma500/gma_device.o
+00:04:09   CC [M]  sound/soc/intel/boards/skl_hda_dsp_common.o
+00:04:09   LD [M]  fs/ntfs3/ntfs3.o
+00:04:09   CC [M]  fs/jffs2/xattr.o
+00:04:09   CC [M]  drivers/nvme/host/pci.o
+00:04:09   CC [M]  net/bridge/netfilter/ebt_802_3.o
+00:04:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/firmware.o
+00:04:10   CC [M]  fs/nfs/nfs4session.o
+00:04:10   CC [M]  drivers/gpu/drm/udl/udl_modeset.o
+00:04:10   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_buffer_pool.o
+00:04:10   CC [M]  fs/ubifs/log.o
+00:04:10   CC [M]  sound/soc/intel/boards/ehl_rt5660.o
+00:04:10   CC [M]  drivers/gpu/drm/amd/amdgpu/cik.o
+00:04:10   CC [M]  drivers/gpu/drm/gma500/gma_display.o
+00:04:10   CC [M]  net/netfilter/nf_flow_table_core.o
+00:04:10   AR      drivers/nvme/target/built-in.a
+00:04:10   CC [M]  drivers/nvme/target/core.o
+00:04:10   CC [M]  drivers/gpu/drm/radeon/cypress_dpm.o
+00:04:10   CC [M]  drivers/scsi/libsas/sas_scsi_host.o
+00:04:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/gpuobj.o
+00:04:10   CC [M]  net/bridge/netfilter/ebt_among.o
+00:04:10   CC [M]  fs/jffs2/xattr_trusted.o
+00:04:10   CC [M]  sound/soc/intel/boards/sof_sdw.o
+00:04:10   CC [M]  drivers/gpu/drm/udl/udl_connector.o
+00:04:11   CC [M]  fs/ubifs/commit.o
+00:04:11   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_clock_utils.o
+00:04:11   CC [M]  fs/nfs/dns_resolve.o
+00:04:11   CC [M]  fs/cifs/cifs_unicode.o
+00:04:11   CC [M]  fs/jffs2/xattr_user.o
+00:04:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/ioctl.o
+00:04:11   CC [M]  drivers/gpu/drm/gma500/gtt.o
+00:04:11   CC [M]  drivers/scsi/libsas/sas_task.o
+00:04:11   CC [M]  drivers/nvme/host/fabrics.o
+00:04:11   CC [M]  drivers/gpu/drm/amd/amdgpu/cik_ih.o
+00:04:11   CC [M]  drivers/gpu/drm/udl/udl_main.o
+00:04:11   CC [M]  net/bridge/netfilter/ebt_arp.o
+00:04:11   CC [M]  fs/jffs2/security.o
+00:04:11   CC [M]  fs/ubifs/gc.o
+00:04:11   CC [M]  sound/soc/intel/boards/sof_sdw_max98373.o
+00:04:12   CC [M]  net/netfilter/nf_flow_table_ip.o
+00:04:12   CC [M]  drivers/nvme/target/configfs.o
+00:04:12   CC [M]  drivers/gpu/drm/radeon/btc_dpm.o
+00:04:12   CC [M]  fs/nfs/nfs4trace.o
+00:04:12   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_irq.o
+00:04:12   CC [M]  drivers/scsi/libsas/sas_ata.o
+00:04:12   CC [M]  fs/cifs/nterr.o
+00:04:12   CC [M]  fs/jffs2/acl.o
+00:04:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/memory.o
+00:04:12   CC [M]  drivers/gpu/drm/gma500/intel_bios.o
+00:04:12   CC [M]  sound/soc/intel/boards/sof_sdw_rt1308.o
+00:04:12   CC [M]  drivers/gpu/drm/udl/udl_transfer.o
+00:04:12   CC [M]  drivers/gpu/drm/amd/amdgpu/dce_v8_0.o
+00:04:12   CC [M]  fs/cifs/cifsencrypt.o
+00:04:12   CC [M]  drivers/nvme/host/rdma.o
+00:04:12   CC [M]  net/bridge/netfilter/ebt_ip.o
+00:04:12   CC [M]  fs/ubifs/orphan.o
+00:04:13   CC [M]  fs/jffs2/compr_rtime.o
+00:04:13   CC [M]  sound/soc/intel/boards/sof_sdw_rt1316.o
+00:04:13   CC [M]  drivers/nvme/target/admin-cmd.o
+00:04:13   CC [M]  net/netfilter/nf_flow_table_offload.o
+00:04:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/mm.o
+00:04:13   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_pm.o
+00:04:13   CC [M]  drivers/scsi/libsas/sas_host_smp.o
+00:04:13   CC [M]  drivers/gpu/drm/radeon/sumo_dpm.o
+00:04:13   LD [M]  drivers/gpu/drm/udl/udl.o
+00:04:13   CC [M]  drivers/gpu/drm/gma500/intel_gmbus.o
+00:04:13   CC [M]  fs/jffs2/compr_zlib.o
+00:04:13   CC      drivers/ata/libata-core.o
+00:04:13   CC [M]  sound/soc/intel/boards/sof_sdw_rt5682.o
+00:04:13   CC [M]  net/bridge/netfilter/ebt_ip6.o
+00:04:14   CC [M]  fs/ubifs/budget.o
+00:04:14   CC [M]  fs/jffs2/summary.o
+00:04:14   LD [M]  drivers/scsi/libsas/libsas.o
+00:04:14   CC [M]  fs/cifs/readdir.o
+00:04:14   CC [M]  drivers/scsi/libfc/fc_libfc.o
+00:04:14   CC [M]  drivers/nvme/target/fabrics-cmd.o
+00:04:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/notify.o
+00:04:14   CC [M]  sound/soc/intel/boards/sof_sdw_rt700.o
+00:04:14   CC [M]  drivers/gpu/drm/gma500/intel_i2c.o
+00:04:14   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_pm_irq.o
+00:04:14   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v7_0.o
+00:04:14   CC [M]  net/netfilter/nf_flow_table_procfs.o
+00:04:14   CC [M]  drivers/nvme/host/fc.o
+00:04:14   LD [M]  fs/jffs2/jffs2.o
+00:04:14   CC [M]  net/bridge/netfilter/ebt_limit.o
+00:04:14   CC [M]  net/dsa/dsa.o
+00:04:14   CC [M]  drivers/nvme/target/discovery.o
+00:04:14   CC [M]  fs/ubifs/find.o
+00:04:14   CC [M]  sound/soc/intel/boards/sof_sdw_rt711.o
+00:04:14   CC [M]  drivers/scsi/libfc/fc_disc.o
+00:04:15   CC [M]  drivers/gpu/drm/radeon/sumo_smc.o
+00:04:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/object.o
+00:04:15   CC [M]  drivers/gpu/drm/gma500/mid_bios.o
+00:04:15   CC [M]  drivers/gpu/drm/i915/gt/intel_gt_requests.o
+00:04:15   CC [M]  sound/soc/intel/boards/sof_sdw_rt711_sdca.o
+00:04:15   CC [M]  net/netfilter/nf_flow_table_inet.o
+00:04:15   CC [M]  drivers/nvme/target/io-cmd-file.o
+00:04:15   CC [M]  fs/nfs/nfs4sysctl.o
+00:04:15   CC [M]  fs/cifs/ioctl.o
+00:04:15   CC [M]  net/bridge/netfilter/ebt_mark_m.o
+00:04:15   CC [M]  fs/ubifs/tnc_commit.o
+00:04:15   CC [M]  drivers/gpu/drm/radeon/trinity_dpm.o
+00:04:15   CC [M]  drivers/scsi/libfc/fc_exch.o
+00:04:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/oproxy.o
+00:04:16   CC [M]  net/dsa/dsa2.o
+00:04:16   CC [M]  sound/soc/intel/boards/sof_sdw_rt715.o
+00:04:16   CC [M]  drivers/gpu/drm/gma500/mmu.o
+00:04:16   CC [M]  drivers/nvme/target/io-cmd-bdev.o
+00:04:16   CC      drivers/ata/libata-scsi.o
+00:04:16   CC [M]  net/netfilter/xt_mark.o
+00:04:16   CC [M]  fs/nfs/pnfs.o
+00:04:16   CC [M]  drivers/nvme/host/tcp.o
+00:04:16   CC [M]  net/bridge/netfilter/ebt_pkttype.o
+00:04:16   CC [M]  drivers/gpu/drm/i915/gt/intel_gtt.o
+00:04:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/option.o
+00:04:16   CC [M]  sound/soc/intel/boards/sof_sdw_rt715_sdca.o
+00:04:16   CC [M]  drivers/gpu/drm/amd/amdgpu/cik_sdma.o
+00:04:16   CC [M]  fs/ubifs/compress.o
+00:04:17   CC [M]  fs/cifs/sess.o
+00:04:17   CC [M]  drivers/nvme/target/passthru.o
+00:04:17   CC [M]  net/netfilter/xt_connmark.o
+00:04:17   CC [M]  drivers/gpu/drm/gma500/oaktrail_device.o
+00:04:17   CC [M]  drivers/gpu/drm/radeon/trinity_smc.o
+00:04:17   CC [M]  sound/soc/intel/boards/sof_sdw_dmic.o
+00:04:17   CC [M]  drivers/scsi/libfc/fc_elsct.o
+00:04:17   CC [M]  net/dsa/master.o
+00:04:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/ramht.o
+00:04:17   CC [M]  net/bridge/netfilter/ebt_stp.o
+00:04:17   CC [M]  fs/ubifs/lpt.o
+00:04:17   CC [M]  sound/soc/intel/boards/sof_sdw_hdmi.o
+00:04:17   CC [M]  drivers/gpu/drm/i915/gt/intel_llc.o
+00:04:18   CC [M]  drivers/nvme/target/zns.o
+00:04:18   CC [M]  drivers/gpu/drm/radeon/ni_dpm.o
+00:04:18   CC [M]  drivers/gpu/drm/gma500/oaktrail_crtc.o
+00:04:18   CC [M]  drivers/scsi/libfc/fc_frame.o
+00:04:18   CC [M]  net/netfilter/xt_set.o
+00:04:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/core/subdev.o
+00:04:18   CC [M]  drivers/gpu/drm/amd/amdgpu/uvd_v4_2.o
+00:04:18   CC      drivers/ata/libata-eh.o
+00:04:18   CC [M]  sound/soc/intel/boards/hda_dsp_common.o
+00:04:18   CC [M]  net/dsa/port.o
+00:04:18   CC [M]  net/bridge/netfilter/ebt_vlan.o
+00:04:18   LD [M]  drivers/nvme/host/nvme-core.o
+00:04:18   LD [M]  drivers/nvme/host/nvme.o
+00:04:18   LD [M]  drivers/nvme/host/nvme-fabrics.o
+00:04:18   LD [M]  drivers/nvme/host/nvme-rdma.o
+00:04:18   LD [M]  drivers/nvme/host/nvme-fc.o
+00:04:18   LD [M]  drivers/nvme/host/nvme-tcp.o
+00:04:18   CC [M]  net/bridge/br_device.o
+00:04:18   CC [M]  fs/cifs/export.o
+00:04:18   CC [M]  drivers/nvme/target/trace.o
+00:04:18   CC [M]  drivers/scsi/libfc/fc_lport.o
+00:04:18   CC [M]  drivers/gpu/drm/i915/gt/intel_lrc.o
+00:04:19   CC [M]  sound/soc/intel/boards/sof_maxim_common.o
+00:04:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/nvfw/fw.o
+00:04:19   CC [M]  fs/nfs/pnfs_dev.o
+00:04:19   CC [M]  drivers/gpu/drm/gma500/oaktrail_hdmi.o
+00:04:19   CC [M]  fs/ubifs/lprops.o
+00:04:19   CC [M]  net/netfilter/xt_nat.o
+00:04:19   CC [M]  drivers/gpu/drm/amd/amdgpu/vce_v2_0.o
+00:04:19   CC [M]  net/bridge/netfilter/ebt_arpreply.o
+00:04:19   CC [M]  drivers/nvme/target/loop.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sof_rt5682.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sof_cs42l42.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-haswell.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bxt-da7219_max98357a.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-sof-pcm512x.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-sof-wm8804.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-glk-rt5682_max98357a.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-broadwell.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bdw-rt5650-mach.o
+00:04:19   CC [M]  fs/cifs/smb1ops.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bdw-rt5677-mach.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bytcr-rt5640.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bytcr-rt5651.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-bytcr-wm5102.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5672.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5645.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-cht-bsw-max98090_ti.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-cht-bsw-nau8824.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-byt-cht-cx2072x.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-byt-cht-da7213.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-byt-cht-es8316.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sst-byt-cht-nocodec.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-cml_rt1011_rt5682.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-skl_hda_dsp.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-ehl-rt5660.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-sof-sdw.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-intel-hda-dsp-common.o
+00:04:19   LD [M]  sound/soc/intel/boards/snd-soc-intel-sof-maxim-common.o
+00:04:19   CC [M]  fs/nfs/pnfs_nfs.o
+00:04:19   CC [M]  net/dsa/slave.o
+00:04:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/nvfw/hs.o
+00:04:20   CC [M]  sound/soc/sof/intel/atom.o
+00:04:20   CC [M]  drivers/gpu/drm/gma500/oaktrail_hdmi_i2c.o
+00:04:20   CC [M]  drivers/gpu/drm/radeon/si_smc.o
+00:04:20   CC [M]  drivers/scsi/libfc/fc_rport.o
+00:04:20   CC      drivers/ata/libata-transport.o
+00:04:20   CC [M]  net/netfilter/xt_AUDIT.o
+00:04:20   CC [M]  net/bridge/netfilter/ebt_mark.o
+00:04:20   CC [M]  fs/ubifs/recovery.o
+00:04:20   CC [M]  drivers/gpu/drm/i915/gt/intel_migrate.o
+00:04:20   CC [M]  drivers/gpu/drm/amd/amdgpu/si.o
+00:04:20   CC [M]  drivers/gpu/drm/i915/gt/intel_mocs.o
+00:04:20   CC [M]  drivers/nvme/target/rdma.o
+00:04:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/nvfw/ls.o
+00:04:20   CC [M]  sound/soc/sof/intel/byt.o
+00:04:21   CC [M]  drivers/gpu/drm/gma500/oaktrail_lvds.o
+00:04:21   CC [M]  fs/cifs/unc.o
+00:04:21   CC [M]  drivers/gpu/drm/radeon/si_dpm.o
+00:04:21   CC      drivers/ata/libata-trace.o
+00:04:21   CC [M]  fs/nfs/nfs42proc.o
+00:04:21   CC [M]  net/bridge/netfilter/ebt_dnat.o
+00:04:21   CC [M]  net/netfilter/xt_CHECKSUM.o
+00:04:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/nvfw/acr.o
+00:04:21   CC [M]  sound/soc/sof/intel/bdw.o
+00:04:21   CC [M]  drivers/gpu/drm/gma500/oaktrail_lvds_i2c.o
+00:04:21   CC [M]  fs/ubifs/ioctl.o
+00:04:21   CC [M]  net/dsa/switch.o
+00:04:21   CC [M]  drivers/scsi/libfc/fc_fcp.o
+00:04:21   CC [M]  drivers/gpu/drm/i915/gt/intel_ppgtt.o
+00:04:21   CC [M]  drivers/gpu/drm/amd/amdgpu/gmc_v6_0.o
+00:04:21   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v6_0.o
+00:04:22   CC      drivers/ata/libata-sata.o
+00:04:22   CC [M]  fs/cifs/winucase.o
+00:04:22   CC [M]  sound/soc/sof/intel/intel-ipc.o
+00:04:22   CC [M]  fs/cifs/smb2ops.o
+00:04:22   CC [M]  drivers/nvme/target/fc.o
+00:04:22   CC [M]  fs/ubifs/lpt_commit.o
+00:04:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/nvfw/flcn.o
+00:04:22   CC [M]  net/bridge/netfilter/ebt_redirect.o
+00:04:22   CC [M]  drivers/gpu/drm/gma500/power.o
+00:04:22   CC [M]  net/netfilter/xt_CLASSIFY.o
+00:04:22   CC [M]  sound/soc/sof/intel/hda.o
+00:04:22   CC [M]  net/dsa/tag_8021q.o
+00:04:23   CC [M]  fs/nfs/nfs42xattr.o
+00:04:23   CC [M]  drivers/gpu/drm/i915/gt/intel_rc6.o
+00:04:23   CC [M]  drivers/scsi/fcoe/fcoe.o
+00:04:23   CC      drivers/ata/libata-sff.o
+00:04:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/falcon/base.o
+00:04:23   CC [M]  drivers/gpu/drm/gma500/psb_device.o
+00:04:23   CC [M]  drivers/scsi/libfc/fc_npiv.o
+00:04:23   CC [M]  net/bridge/netfilter/ebt_snat.o
+00:04:23   CC [M]  net/netfilter/xt_CONNSECMARK.o
+00:04:23   CC [M]  fs/ubifs/tnc_misc.o
+00:04:23   CC [M]  drivers/nvme/target/fcloop.o
+00:04:23   CC [M]  sound/soc/sof/intel/hda-loader.o
+00:04:23   CC [M]  drivers/gpu/drm/amd/amdgpu/si_ih.o
+00:04:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/falcon/cmdq.o
+00:04:23   LD [M]  drivers/scsi/libfc/libfc.o
+00:04:23   CC [M]  drivers/gpu/drm/radeon/kv_smc.o
+00:04:24   CC [M]  net/netfilter/xt_CT.o
+00:04:24   CC [M]  drivers/gpu/drm/gma500/psb_drv.o
+00:04:24   CC [M]  net/dsa/tag_brcm.o
+00:04:24   CC [M]  drivers/gpu/drm/i915/gt/intel_region_lmem.o
+00:04:24   CC [M]  net/bridge/netfilter/ebt_log.o
+00:04:24   LD [M]  fs/nfs/nfs.o
+00:04:24   LD [M]  fs/nfs/nfsv3.o
+00:04:24   LD [M]  fs/nfs/nfsv4.o
+00:04:24   CC [M]  fs/cifs/smb2maperror.o
+00:04:24   CC [M]  net/bridge/br_fdb.o
+00:04:24   CC [M]  drivers/scsi/fcoe/fcoe_ctlr.o
+00:04:24   CC      drivers/ata/libata-pmp.o
+00:04:24   CC [M]  fs/ubifs/debug.o
+00:04:24   CC [M]  sound/soc/sof/intel/hda-stream.o
+00:04:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/falcon/msgq.o
+00:04:24   CC [M]  drivers/gpu/drm/amd/amdgpu/si_dma.o
+00:04:24   CC [M]  drivers/gpu/drm/radeon/kv_dpm.o
+00:04:24   CC [M]  drivers/nvme/target/tcp.o
+00:04:24   CC [M]  drivers/gpu/drm/gma500/psb_intel_display.o
+00:04:25   CC [M]  net/netfilter/xt_DSCP.o
+00:04:25   CC [M]  net/dsa/tag_dsa.o
+00:04:25   CC [M]  drivers/gpu/drm/i915/gt/intel_renderstate.o
+00:04:25   CC [M]  net/bridge/netfilter/ebt_nflog.o
+00:04:25   CC      drivers/ata/libata-acpi.o
+00:04:25   CC [M]  net/appletalk/aarp.o
+00:04:25   CC [M]  sound/soc/sof/intel/hda-trace.o
+00:04:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/falcon/qmgr.o
+00:04:25   CC [M]  fs/cifs/smb2transport.o
+00:04:25   CC [M]  drivers/gpu/drm/gma500/psb_intel_lvds.o
+00:04:26   CC [M]  drivers/gpu/drm/amd/amdgpu/dce_v6_0.o
+00:04:26   CC [M]  net/netfilter/xt_HL.o
+00:04:26   CC [M]  sound/soc/sof/xtensa/core.o
+00:04:26   CC [M]  fs/ubifs/misc.o
+00:04:26   CC [M]  sound/soc/sof/intel/hda-dsp.o
+00:04:26   CC [M]  net/bridge/br_forward.o
+00:04:26   CC [M]  net/dsa/tag_gswip.o
+00:04:26   CC [M]  drivers/scsi/fcoe/fcoe_transport.o
+00:04:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/falcon/v1.o
+00:04:26   CC      drivers/ata/libata-pata-timings.o
+00:04:26   CC [M]  drivers/gpu/drm/i915/gt/intel_reset.o
+00:04:26   LD [M]  drivers/nvme/target/nvmet.o
+00:04:26   CC [M]  drivers/gpu/drm/radeon/ci_smc.o
+00:04:26   LD [M]  drivers/nvme/target/nvme-loop.o
+00:04:26   LD [M]  drivers/nvme/target/nvmet-rdma.o
+00:04:26   LD [M]  drivers/nvme/target/nvmet-fc.o
+00:04:26   LD [M]  drivers/nvme/target/nvme-fcloop.o
+00:04:26   LD [M]  drivers/nvme/target/nvmet-tcp.o
+00:04:26   AR      drivers/nvme/built-in.a
+00:04:26   CC [M]  drivers/gpu/drm/ast/ast_drv.o
+00:04:26   LD [M]  sound/soc/sof/xtensa/snd-sof-xtensa-dsp.o
+00:04:26   CC [M]  net/appletalk/ddp.o
+00:04:26   CC [M]  net/netrom/af_netrom.o
+00:04:26   CC [M]  fs/ubifs/crypto.o
+00:04:26   CC [M]  drivers/gpu/drm/gma500/psb_intel_modes.o
+00:04:27   CC [M]  net/netfilter/xt_HMARK.o
+00:04:27   CC [M]  sound/soc/sof/intel/hda-ipc.o
+00:04:27   CC      drivers/ata/ahci.o
+00:04:27   CC [M]  net/dsa/tag_hellcreek.o
+00:04:27   CC [M]  fs/cifs/smb2misc.o
+00:04:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/base.o
+00:04:27   CC [M]  net/bridge/br_if.o
+00:04:27   CC [M]  drivers/gpu/drm/radeon/ci_dpm.o
+00:04:27   CC [M]  drivers/gpu/drm/ast/ast_main.o
+00:04:27   CC [M]  drivers/scsi/fcoe/fcoe_sysfs.o
+00:04:27   CC [M]  fs/ubifs/xattr.o
+00:04:27   CC [M]  drivers/gpu/drm/gma500/psb_intel_sdvo.o
+00:04:27   CC [M]  sound/soc/sof/intel/hda-ctrl.o
+00:04:27   CC [M]  drivers/gpu/drm/amd/amdgpu/uvd_v3_1.o
+00:04:28   CC [M]  drivers/gpu/drm/i915/gt/intel_ring.o
+00:04:28   CC [M]  net/netfilter/xt_LED.o
+00:04:28   CC [M]  net/netrom/nr_dev.o
+00:04:28   CC      drivers/ata/libahci.o
+00:04:28   CC [M]  net/dsa/tag_ksz.o
+00:04:28   CC [M]  net/appletalk/dev.o
+00:04:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/hsfw.o
+00:04:28   CC [M]  drivers/gpu/drm/ast/ast_mm.o
+00:04:28   CC [M]  sound/soc/sof/intel/hda-pcm.o
+00:04:28   CC [M]  fs/ubifs/auth.o
+00:04:28   LD [M]  drivers/scsi/fcoe/libfcoe.o
+00:04:28   CC [M]  drivers/scsi/fnic/fnic_attrs.o
+00:04:28   CC [M]  net/bridge/br_input.o
+00:04:28   CC [M]  fs/cifs/smb2pdu.o
+00:04:28   CC [M]  net/netfilter/xt_LOG.o
+00:04:28   CC [M]  net/appletalk/atalk_proc.o
+00:04:29   CC [M]  drivers/gpu/drm/amd/amdgpu/vi.o
+00:04:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/lsfw.o
+00:04:29   CC [M]  drivers/gpu/drm/gma500/psb_lid.o
+00:04:29   CC [M]  sound/soc/sof/intel/hda-dai.o
+00:04:29   CC [M]  drivers/gpu/drm/ast/ast_mode.o
+00:04:29   CC [M]  net/netrom/nr_in.o
+00:04:29   CC [M]  drivers/gpu/drm/i915/gt/intel_ring_submission.o
+00:04:29   CC [M]  net/dsa/tag_rtl4_a.o
+00:04:29   LD [M]  fs/ubifs/ubifs.o
+00:04:29   CC [M]  net/netrom/nr_loopback.o
+00:04:29   CC [M]  drivers/scsi/fnic/fnic_isr.o
+00:04:29   CC      drivers/ata/ata_piix.o
+00:04:29   CC [M]  net/bridge/br_ioctl.o
+00:04:29   CC [M]  net/appletalk/sysctl_net_atalk.o
+00:04:29   CC [M]  sound/soc/sof/intel/hda-bus.o
+00:04:29   CC [M]  net/netfilter/xt_NETMAP.o
+00:04:29   CC [M]  drivers/gpu/drm/gma500/psb_irq.o
+00:04:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/gm200.o
+00:04:30   CC [M]  drivers/gpu/drm/radeon/dce6_afmt.o
+00:04:30   CC      drivers/spi/spi.o
+00:04:30   CC [M]  net/netrom/nr_out.o
+00:04:30   CC [M]  drivers/scsi/fnic/fnic_main.o
+00:04:30   CC [M]  net/dsa/tag_lan9303.o
+00:04:30   CC [M]  drivers/gpu/drm/amd/amdgpu/mxgpu_vi.o
+00:04:30   CC [M]  drivers/gpu/drm/ast/ast_post.o
+00:04:30   CC [M]  sound/soc/sof/intel/apl.o
+00:04:30   CC [M]  drivers/ata/acard-ahci.o
+00:04:30   LD [M]  net/appletalk/appletalk.o
+00:04:30   CC [M]  drivers/gpu/drm/i915/gt/intel_rps.o
+00:04:30   CC      drivers/spi/spi-mem.o
+00:04:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/gm20b.o
+00:04:30   CC [M]  drivers/gpu/drm/gma500/opregion.o
+00:04:31   CC [M]  net/bridge/br_stp.o
+00:04:31   CC [M]  net/netfilter/xt_NFLOG.o
+00:04:31   CC [M]  drivers/gpu/drm/radeon/radeon_vm.o
+00:04:31   CC [M]  sound/soc/sof/intel/cnl.o
+00:04:31   CC [M]  net/netrom/nr_route.o
+00:04:31   CC [M]  net/dsa/tag_mtk.o
+00:04:31   CC [M]  drivers/gpu/drm/amd/amdgpu/nbio_v6_1.o
+00:04:31   CC [M]  drivers/scsi/fnic/fnic_res.o
+00:04:31   CC [M]  drivers/ata/ahci_platform.o
+00:04:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/gp102.o
+00:04:31   CC [M]  drivers/net/phy/mscc/mscc_main.o
+00:04:31   CC [M]  net/netfilter/xt_NFQUEUE.o
+00:04:31   LD [M]  drivers/gpu/drm/gma500/gma500_gfx.o
+00:04:31   CC      drivers/spi/spi-amd.o
+00:04:31   CC [M]  sound/soc/sof/intel/tgl.o
+00:04:31   CC [M]  drivers/gpu/drm/ast/ast_dp501.o
+00:04:32   CC [M]  fs/cifs/smb2inode.o
+00:04:32   CC [M]  net/bridge/br_stp_bpdu.o
+00:04:32   CC [M]  drivers/ata/libahci_platform.o
+00:04:32   CC [M]  net/dsa/tag_ocelot.o
+00:04:32   CC [M]  drivers/gpu/drm/radeon/radeon_ucode.o
+00:04:32   CC [M]  sound/soc/sof/intel/icl.o
+00:04:32   CC      drivers/net/phy/mdio-boardinfo.o
+00:04:32   CC [M]  drivers/gpu/drm/i915/gt/intel_sseu.o
+00:04:32   CC [M]  drivers/spi/spi-mux.o
+00:04:32   CC [M]  drivers/scsi/fnic/fnic_fcs.o
+00:04:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/gp108.o
+00:04:32   CC [M]  net/netrom/nr_subr.o
+00:04:32   CC [M]  drivers/gpu/drm/amd/amdgpu/soc15.o
+00:04:32   LD [M]  drivers/gpu/drm/ast/ast.o
+00:04:32   CC [M]  net/netfilter/xt_RATEEST.o
+00:04:32   CC [M]  drivers/scsi/fnic/fnic_scsi.o
+00:04:33   CC [M]  drivers/net/phy/mscc/mscc_serdes.o
+00:04:33   CC [M]  sound/soc/sof/intel/hda-codec.o
+00:04:33   CC [M]  drivers/spi/spidev.o
+00:04:33   CC [M]  drivers/spi/spi-altera-core.o
+00:04:33   CC [M]  drivers/gpu/drm/radeon/radeon_ib.o
+00:04:33   CC [M]  net/bridge/br_stp_if.o
+00:04:33   CC [M]  drivers/ata/sata_inic162x.o
+00:04:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/gp10b.o
+00:04:33   CC [M]  net/dsa/tag_ocelot_8021q.o
+00:04:33   CC [M]  fs/cifs/smb2file.o
+00:04:33   CC [M]  net/netfilter/xt_REDIRECT.o
+00:04:33   CC [M]  net/netrom/nr_timer.o
+00:04:33   CC [M]  sound/soc/sof/intel/pci-tng.o
+00:04:33   CC [M]  drivers/net/phy/mscc/mscc_macsec.o
+00:04:33   CC [M]  fs/affs/super.o
+00:04:33   CC [M]  drivers/gpu/drm/i915/gt/intel_sseu_debugfs.o
+00:04:33   CC [M]  net/rose/af_rose.o
+00:04:33   CC [M]  drivers/spi/spi-altera-dfl.o
+00:04:34   CC [M]  drivers/gpu/drm/radeon/radeon_sync.o
+00:04:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/acr/tu102.o
+00:04:34   CC [M]  drivers/ata/sata_sil24.o
+00:04:34   CC [M]  drivers/gpu/drm/amd/amdgpu/emu_soc.o
+00:04:34   CC [M]  sound/soc/sof/intel/pci-apl.o
+00:04:34   CC [M]  net/bridge/br_stp_timer.o
+00:04:34   CC [M]  net/dsa/tag_qca.o
+00:04:34   CC [M]  drivers/scsi/fnic/fnic_trace.o
+00:04:34   CC [M]  net/netrom/sysctl_net_netrom.o
+00:04:34   CC [M]  net/netfilter/xt_MASQUERADE.o
+00:04:34   CC [M]  drivers/spi/spi-dln2.o
+00:04:34   CC [M]  drivers/net/phy/mscc/mscc_ptp.o
+00:04:34   CC [M]  fs/affs/namei.o
+00:04:34   CC [M]  fs/cifs/cifsacl.o
+00:04:34   CC [M]  sound/soc/sof/intel/pci-cnl.o
+00:04:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/base.o
+00:04:34   CC [M]  drivers/gpu/drm/radeon/radeon_audio.o
+00:04:35   CC [M]  drivers/gpu/drm/i915/gt/intel_timeline.o
+00:04:35   CC [M]  drivers/gpu/drm/amd/amdgpu/mxgpu_ai.o
+00:04:35   CC [M]  drivers/ata/pdc_adma.o
+00:04:35   CC [M]  drivers/spi/spi-pxa2xx.o
+00:04:35   CC [M]  fs/affs/inode.o
+00:04:35   CC [M]  net/bridge/br_netlink.o
+00:04:35   LD [M]  net/netrom/netrom.o
+00:04:35   CC [M]  net/rose/rose_dev.o
+00:04:35   CC [M]  net/dsa/tag_sja1105.o
+00:04:35   CC [M]  drivers/scsi/snic/snic_attrs.o
+00:04:35   CC [M]  drivers/scsi/fnic/fnic_debugfs.o
+00:04:35   CC [M]  sound/soc/sof/intel/pci-icl.o
+00:04:35   CC [M]  net/netfilter/xt_SECMARK.o
+00:04:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/nv50.o
+00:04:35   CC [M]  drivers/ata/sata_qstor.o
+00:04:35   CC [M]  drivers/gpu/drm/radeon/radeon_dp_auxch.o
+00:04:36   LD [M]  drivers/net/phy/mscc/mscc.o
+00:04:36   CC [M]  fs/affs/file.o
+00:04:36   CC      drivers/net/phy/mdio_devres.o
+00:04:36   CC [M]  drivers/gpu/drm/i915/gt/intel_workarounds.o
+00:04:36   CC [M]  sound/soc/sof/intel/pci-tgl.o
+00:04:36   CC [M]  drivers/scsi/snic/snic_main.o
+00:04:36   CC [M]  net/netfilter/xt_TPROXY.o
+00:04:36   CC [M]  drivers/gpu/drm/amd/amdgpu/nbio_v7_0.o
+00:04:36   CC [M]  net/rose/rose_in.o
+00:04:36   CC [M]  drivers/spi/spi-pxa2xx-dma.o
+00:04:36   CC [M]  drivers/scsi/fnic/vnic_cq.o
+00:04:36   CC [M]  fs/cifs/fs_context.o
+00:04:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/g84.o
+00:04:36   CC      drivers/net/phy/phy.o
+00:04:36   CC [M]  net/dsa/tag_trailer.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-intel-atom.o
+00:04:36   CC [M]  drivers/ata/sata_sx4.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-acpi-intel-byt.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-acpi-intel-bdw.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-intel-ipc.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-intel-hda-common.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-intel-hda.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-pci-intel-tng.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-pci-intel-apl.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-pci-intel-cnl.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-pci-intel-icl.o
+00:04:36   LD [M]  sound/soc/sof/intel/snd-sof-pci-intel-tgl.o
+00:04:36   CC [M]  drivers/gpu/drm/radeon/radeon_dp_mst.o
+00:04:36   CC [M]  sound/soc/sof/core.o
+00:04:36   CC [M]  net/bridge/br_netlink_tunnel.o
+00:04:37   CC [M]  drivers/scsi/fnic/vnic_dev.o
+00:04:37   CC [M]  fs/affs/dir.o
+00:04:37   CC [M]  drivers/spi/spi-pxa2xx-pci.o
+00:04:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/gf100.o
+00:04:37   CC [M]  drivers/scsi/snic/snic_res.o
+00:04:37   CC [M]  net/rose/rose_link.o
+00:04:37   CC [M]  net/netfilter/xt_TCPMSS.o
+00:04:37   CC [M]  drivers/gpu/drm/amd/amdgpu/vega10_reg_init.o
+00:04:37   CC [M]  sound/soc/sof/ops.o
+00:04:37   CC [M]  fs/affs/amigaffs.o
+00:04:37   LD [M]  drivers/spi/spi-pxa2xx-platform.o
+00:04:37   AR      drivers/spi/built-in.a
+00:04:37   CC [M]  net/dsa/tag_xrs700x.o
+00:04:37   CC [M]  fs/cifs/dns_resolve.o
+00:04:37   CC [M]  drivers/ata/sata_mv.o
+00:04:37   CC [M]  drivers/scsi/fnic/vnic_intr.o
+00:04:37   CC      drivers/net/phy/phy-c45.o
+00:04:37   CC [M]  drivers/gpu/drm/radeon/radeon_mn.o
+00:04:38   CC [M]  drivers/gpu/drm/i915/gt/shmem_utils.o
+00:04:38   CC [M]  net/bridge/br_arp_nd_proxy.o
+00:04:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/gk20a.o
+00:04:38   CC [M]  sound/soc/sof/loader.o
+00:04:38   CC [M]  drivers/gpu/drm/qxl/qxl_drv.o
+00:04:38   CC [M]  drivers/scsi/snic/snic_isr.o
+00:04:38   CC [M]  net/rose/rose_loopback.o
+00:04:38   CC [M]  fs/affs/bitmap.o
+00:04:38   CC [M]  drivers/scsi/fnic/vnic_rq.o
+00:04:38   CC [M]  drivers/gpu/drm/amd/amdgpu/vega20_reg_init.o
+00:04:38   CC [M]  net/netfilter/xt_TCPOPTSTRIP.o
+00:04:38   CC      drivers/net/phy/phy-core.o
+00:04:38   LD [M]  net/dsa/dsa_core.o
+00:04:38   CC [M]  drivers/gpu/drm/radeon/r600_dma.o
+00:04:38   CC [M]  drivers/gpu/drm/amd/amdgpu/nbio_v7_4.o
+00:04:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/gm107.o
+00:04:38   CC [M]  drivers/gpu/drm/i915/gt/sysfs_engines.o
+00:04:38   ASN.1   fs/cifs/cifs_spnego_negtokeninit.asn1.[ch]
+00:04:38   CC [M]  fs/cifs/xattr.o
+00:04:39   CC [M]  drivers/scsi/fnic/vnic_wq_copy.o
+00:04:39   CC [M]  fs/affs/symlink.o
+00:04:39   CC [M]  drivers/scsi/snic/snic_ctl.o
+00:04:39   CC [M]  drivers/gpu/drm/qxl/qxl_kms.o
+00:04:39   CC [M]  sound/soc/sof/ipc.o
+00:04:39   CC [M]  net/bridge/br_sysfs_if.o
+00:04:39   CC [M]  net/rose/rose_out.o
+00:04:39   CC      drivers/net/mdio/acpi_mdio.o
+00:04:39   CC      drivers/net/phy/phy_device.o
+00:04:39   LD [M]  fs/affs/affs.o
+00:04:39   CC [M]  drivers/ata/sata_nv.o
+00:04:39   AR      drivers/net/pcs/built-in.a
+00:04:39   CC [M]  drivers/net/pcs/pcs-xpcs.o
+00:04:39   CC [M]  net/netfilter/xt_TEE.o
+00:04:39   CC [M]  drivers/scsi/fnic/vnic_wq.o
+00:04:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/gm20b.o
+00:04:39   CC [M]  drivers/gpu/drm/radeon/rv770_dma.o
+00:04:39   CC [M]  sound/soc/sof/pcm.o
+00:04:39   CC [M]  drivers/scsi/snic/snic_io.o
+00:04:39   CC [M]  drivers/gpu/drm/i915/gt/gen6_renderstate.o
+00:04:40   CC [M]  drivers/gpu/drm/qxl/qxl_display.o
+00:04:40   CC      drivers/net/mdio/fwnode_mdio.o
+00:04:40   CC [M]  drivers/gpu/drm/amd/amdgpu/nbio_v2_3.o
+00:04:40   CC [M]  net/rose/rose_route.o
+00:04:40   CC [M]  fs/cifs/cifs_spnego.o
+00:04:40   LD [M]  drivers/scsi/fnic/fnic.o
+00:04:40   AR      drivers/message/fusion/built-in.a
+00:04:40   CC [M]  drivers/message/fusion/mptbase.o
+00:04:40   CC [M]  drivers/gpu/drm/i915/gt/gen7_renderstate.o
+00:04:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bar/tu102.o
+00:04:40   CC [M]  net/bridge/br_sysfs_br.o
+00:04:40   CC [M]  drivers/net/pcs/pcs-xpcs-nxp.o
+00:04:40   CC [M]  net/netfilter/xt_TRACE.o
+00:04:40   CC [M]  drivers/gpu/drm/i915/gt/gen8_renderstate.o
+00:04:40   CC [M]  drivers/gpu/drm/radeon/evergreen_dma.o
+00:04:40   CC [M]  drivers/net/mdio/mdio-bcm-unimac.o
+00:04:40   CC [M]  sound/soc/sof/pm.o
+00:04:40   CC [M]  drivers/ata/sata_promise.o
+00:04:40   CC [M]  drivers/gpu/drm/i915/gt/gen9_renderstate.o
+00:04:40   CC [M]  drivers/scsi/snic/snic_scsi.o
+00:04:41   CC      drivers/net/phy/linkmode.o
+00:04:41   LD [M]  drivers/net/pcs/pcs_xpcs.o
+00:04:41   CC      drivers/firewire/init_ohci1394_dma.o
+00:04:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/base.o
+00:04:41   CC [M]  drivers/gpu/drm/qxl/qxl_ttm.o
+00:04:41   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_busy.o
+00:04:41   CC [M]  net/netfilter/xt_IDLETIMER.o
+00:04:41   CC [M]  drivers/gpu/drm/amd/amdgpu/nv.o
+00:04:41   CC [M]  fs/cifs/cifs_dfs_ref.o
+00:04:41   CC [M]  drivers/net/mdio/mdio-bitbang.o
+00:04:41   CC [M]  net/rose/rose_subr.o
+00:04:41   CC [M]  sound/soc/sof/debug.o
+00:04:41   CC [M]  drivers/gpu/drm/radeon/ni_dma.o
+00:04:41   CC [M]  net/bridge/br_nf_core.o
+00:04:41   CC      drivers/net/phy/mdio_bus.o
+00:04:41   CC [M]  drivers/firewire/core-card.o
+00:04:41   CC [M]  drivers/ata/sata_sil.o
+00:04:42   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_clflush.o
+00:04:42   CC [M]  drivers/net/mdio/mdio-i2c.o
+00:04:42   CC [M]  drivers/gpu/drm/qxl/qxl_object.o
+00:04:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/bit.o
+00:04:42   CC [M]  net/netfilter/xt_addrtype.o
+00:04:42   CC [M]  sound/soc/sof/topology.o
+00:04:42   CC [M]  drivers/firewire/core-cdev.o
+00:04:42   CC [M]  net/rose/rose_timer.o
+00:04:42   CC [M]  net/bridge/br_multicast.o
+00:04:42   CC [M]  fs/cifs/dfs_cache.o
+00:04:42   CC [M]  drivers/gpu/drm/amd/amdgpu/navi10_reg_init.o
+00:04:42   CC [M]  drivers/gpu/drm/radeon/si_dma.o
+00:04:42   CC      drivers/net/phy/mdio_device.o
+00:04:42   CC [M]  drivers/scsi/snic/snic_disc.o
+00:04:42   CC [M]  drivers/ata/sata_sis.o
+00:04:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/boost.o
+00:04:42   CC [M]  drivers/net/mdio/mdio-mvusb.o
+00:04:43   CC [M]  drivers/gpu/drm/qxl/qxl_gem.o
+00:04:43   CC [M]  drivers/message/fusion/mptscsih.o
+00:04:43   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_context.o
+00:04:43   CC [M]  net/netfilter/xt_bpf.o
+00:04:43   CC      drivers/net/phy/swphy.o
+00:04:43   CC [M]  drivers/ata/sata_svw.o
+00:04:43   CC [M]  net/rose/sysctl_net_rose.o
+00:04:43   CC [M]  drivers/firewire/core-device.o
+00:04:43   CC [M]  drivers/gpu/drm/amd/amdgpu/navi14_reg_init.o
+00:04:43   AR      drivers/net/mdio/built-in.a
+00:04:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/conn.o
+00:04:43   CC [M]  net/netfilter/xt_cluster.o
+00:04:43   CC [M]  drivers/gpu/drm/radeon/cik_sdma.o
+00:04:43   CC [M]  drivers/scsi/snic/vnic_cq.o
+00:04:43   CC [M]  drivers/gpu/drm/qxl/qxl_cmd.o
+00:04:43   CC [M]  sound/soc/sof/control.o
+00:04:43   CC      drivers/net/phy/phy_led_triggers.o
+00:04:44   CC [M]  net/ax25/ax25_addr.o
+00:04:44   CC [M]  drivers/scsi/snic/vnic_intr.o
+00:04:44   CC [M]  drivers/ata/sata_uli.o
+00:04:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/cstep.o
+00:04:44   LD [M]  net/rose/rose.o
+00:04:44   CC [M]  drivers/firewire/core-iso.o
+00:04:44   CC [M]  drivers/message/fusion/mptspi.o
+00:04:44   CC [M]  drivers/gpu/drm/amd/amdgpu/arct_reg_init.o
+00:04:44   CC [M]  drivers/scsi/bnx2fc/bnx2fc_els.o
+00:04:44   CC [M]  fs/cifs/netlink.o
+00:04:44   CC [M]  sound/soc/sof/trace.o
+00:04:44   CC [M]  net/netfilter/xt_comment.o
+00:04:44   CC [M]  drivers/scsi/snic/vnic_dev.o
+00:04:44   CC      drivers/net/phy/mii_timestamper.o
+00:04:44   CC [M]  drivers/gpu/drm/qxl/qxl_image.o
+00:04:44   CC [M]  drivers/gpu/drm/radeon/radeon_uvd.o
+00:04:44   CC [M]  drivers/ata/sata_via.o
+00:04:45   CC [M]  drivers/firewire/core-topology.o
+00:04:45   CC [M]  net/ax25/ax25_dev.o
+00:04:45   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_create.o
+00:04:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/dcb.o
+00:04:45   CC [M]  net/netfilter/xt_connbytes.o
+00:04:45   CC      drivers/net/phy/sfp-bus.o
+00:04:45   CC [M]  drivers/gpu/drm/amd/amdgpu/navi12_reg_init.o
+00:04:45   CC [M]  sound/soc/sof/utils.o
+00:04:45   CC [M]  fs/cifs/cifs_swn.o
+00:04:45   CC [M]  drivers/scsi/snic/vnic_wq.o
+00:04:45   CC [M]  drivers/message/fusion/mptfc.o
+00:04:45   CC [M]  drivers/scsi/bnx2fc/bnx2fc_fcoe.o
+00:04:45   CC [M]  net/bridge/br_mdb.o
+00:04:45   CC [M]  drivers/gpu/drm/qxl/qxl_draw.o
+00:04:45   CC [M]  drivers/firewire/core-transaction.o
+00:04:45   CC [M]  drivers/ata/sata_vsc.o
+00:04:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/disp.o
+00:04:46   CC [M]  sound/soc/sof/sof-audio.o
+00:04:46   CC [M]  drivers/gpu/drm/radeon/uvd_v1_0.o
+00:04:46   CC [M]  net/ax25/ax25_iface.o
+00:04:46   LD [M]  drivers/scsi/snic/snic.o
+00:04:46   CC [M]  drivers/firewire/ohci.o
+00:04:46   CC [M]  drivers/gpu/drm/amd/amdgpu/mxgpu_nv.o
+00:04:46   CC      drivers/net/phy/fixed_phy.o
+00:04:46   CC [M]  net/netfilter/xt_connlabel.o
+00:04:46   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_dmabuf.o
+00:04:46   CC [M]  drivers/gpu/drm/qxl/qxl_debugfs.o
+00:04:46   AR      drivers/net/dsa/b53/built-in.a
+00:04:46   CC [M]  drivers/net/dsa/b53/b53_common.o
+00:04:46   CC [M]  drivers/ata/pata_ali.o
+00:04:46   CC [M]  drivers/message/fusion/mptsas.o
+00:04:46   CC [M]  sound/soc/sof/sof-acpi-dev.o
+00:04:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/dp.o
+00:04:46   CC [M]  fs/cifs/fscache.o
+00:04:47   CC [M]  net/ax25/ax25_in.o
+00:04:47   CC [M]  drivers/gpu/drm/radeon/uvd_v2_2.o
+00:04:47   CC [M]  drivers/net/phy/phylink.o
+00:04:47   CC [M]  net/bridge/br_multicast_eht.o
+00:04:47   CC [M]  drivers/scsi/bnx2fc/bnx2fc_hwi.o
+00:04:47   CC [M]  net/netfilter/xt_connlimit.o
+00:04:47   CC [M]  drivers/gpu/drm/qxl/qxl_irq.o
+00:04:47   CC [M]  drivers/ata/pata_amd.o
+00:04:47   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_domain.o
+00:04:47   CC [M]  sound/soc/sof/sof-pci-dev.o
+00:04:47   CC [M]  drivers/gpu/drm/amd/amdgpu/sienna_cichlid_reg_init.o
+00:04:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/extdev.o
+00:04:47   CC [M]  drivers/firewire/sbp2.o
+00:04:47   CC [M]  drivers/gpu/drm/radeon/uvd_v3_1.o
+00:04:48   CC [M]  net/ax25/ax25_ip.o
+00:04:48   LD [M]  sound/soc/sof/snd-sof.o
+00:04:48   LD [M]  sound/soc/sof/snd-sof-acpi.o
+00:04:48   LD [M]  sound/soc/sof/snd-sof-pci.o
+00:04:48   CC [M]  drivers/gpu/drm/qxl/qxl_dumb.o
+00:04:48   CC [M]  fs/cifs/cache.o
+00:04:48   CC [M]  drivers/ata/pata_artop.o
+00:04:48   CC [M]  sound/soc/soc-topology-test.o
+00:04:48   CC [M]  drivers/gpu/drm/amd/amdgpu/vangogh_reg_init.o
+00:04:48   CC [M]  net/netfilter/xt_conntrack.o
+00:04:48   CC [M]  net/bridge/br_vlan.o
+00:04:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/fan.o
+00:04:48   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_execbuffer.o
+00:04:48   CC [M]  drivers/scsi/bnx2fc/bnx2fc_io.o
+00:04:48   CC [M]  drivers/net/dsa/b53/b53_spi.o
+00:04:48   CC [M]  drivers/net/phy/sfp.o
+00:04:48   CC [M]  drivers/gpu/drm/radeon/uvd_v4_2.o
+00:04:48   CC [M]  drivers/firewire/net.o
+00:04:48   CC [M]  drivers/message/fusion/mptctl.o
+00:04:48   CC [M]  drivers/gpu/drm/qxl/qxl_ioctl.o
+00:04:49   CC [M]  drivers/ata/pata_atiixp.o
+00:04:49   CC [M]  net/ax25/ax25_out.o
+00:04:49   CC [M]  fs/cifs/cifs_spnego_negtokeninit.asn1.o
+00:04:49   CC [M]  sound/soc/soc-acpi.o
+00:04:49   CC [M]  fs/cifs/asn1.o
+00:04:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/gpio.o
+00:04:49   CC [M]  drivers/gpu/drm/amd/amdgpu/nbio_v7_2.o
+00:04:49   CC [M]  net/netfilter/xt_cpu.o
+00:04:49   CC [M]  sound/soc/soc-core.o
+00:04:49   CC [M]  drivers/gpu/drm/radeon/radeon_vce.o
+00:04:49   CC [M]  drivers/net/dsa/b53/b53_mdio.o
+00:04:49   CC [M]  drivers/ata/pata_atp867x.o
+00:04:49   CC [M]  drivers/gpu/drm/qxl/qxl_release.o
+00:04:49   CC [M]  drivers/firewire/nosy.o
+00:04:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/i2c.o
+00:04:50   CC [M]  drivers/scsi/bnx2fc/bnx2fc_tgt.o
+00:04:50   CC [M]  net/ax25/ax25_route.o
+00:04:50   CC [M]  net/netfilter/xt_dccp.o
+00:04:50   CC [M]  drivers/net/phy/adin.o
+00:04:50   LD [M]  fs/cifs/cifs.o
+00:04:50   CC [M]  drivers/message/fusion/mptlan.o
+00:04:50   CC [M]  fs/romfs/storage.o
+00:04:50   CC [M]  net/bridge/br_vlan_tunnel.o
+00:04:50   CC [M]  drivers/gpu/drm/amd/amdgpu/dimgrey_cavefish_reg_init.o
+00:04:50   CC [M]  drivers/ata/pata_cmd64x.o
+00:04:50   LD [M]  drivers/firewire/firewire-core.o
+00:04:50   LD [M]  drivers/firewire/firewire-ohci.o
+00:04:50   LD [M]  drivers/firewire/firewire-sbp2.o
+00:04:50   LD [M]  drivers/firewire/firewire-net.o
+00:04:50   AR      drivers/firewire/built-in.a
+00:04:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/iccsense.o
+00:04:50   CC [M]  drivers/gpu/drm/radeon/vce_v1_0.o
+00:04:50   AR      drivers/net/ethernet/3com/built-in.a
+00:04:50   CC [M]  drivers/net/dsa/b53/b53_mmap.o
+00:04:50   CC [M]  drivers/gpu/drm/qxl/qxl_prime.o
+00:04:50   CC [M]  drivers/net/ethernet/3com/3c589_cs.o
+00:04:50   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_internal.o
+00:04:50   CC [M]  fs/romfs/super.o
+00:04:51   CC [M]  drivers/scsi/bnx2fc/bnx2fc_debug.o
+00:04:51   CC [M]  drivers/net/phy/amd.o
+00:04:51   CC [M]  net/ax25/ax25_std_in.o
+00:04:51   CC [M]  net/netfilter/xt_devgroup.o
+00:04:51   CC [M]  drivers/ata/pata_efar.o
+00:04:51   AR      drivers/message/built-in.a
+00:04:51   CC [M]  drivers/gpu/drm/amd/amdgpu/hdp_v4_0.o
+00:04:51   CC [M]  drivers/gpu/drm/amd/amdgpu/hdp_v5_0.o
+00:04:51   CC [M]  net/bridge/br_vlan_options.o
+00:04:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/image.o
+00:04:51   LD [M]  drivers/gpu/drm/qxl/qxl.o
+00:04:51   CC [M]  sound/soc/soc-dapm.o
+00:04:51   CC [M]  drivers/ata/pata_hpt366.o
+00:04:51   LD [M]  fs/romfs/romfs.o
+00:04:51   CC [M]  drivers/net/phy/aquantia_main.o
+00:04:51   CC [M]  fs/fuse/dev.o
+00:04:51   CC [M]  drivers/gpu/drm/radeon/vce_v2_0.o
+00:04:51   CC [M]  drivers/net/ethernet/3com/3c574_cs.o
+00:04:51   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_object.o
+00:04:51   LD [M]  drivers/scsi/bnx2fc/bnx2fc.o
+00:04:51   CC [M]  drivers/net/dsa/b53/b53_srab.o
+00:04:51   CC [M]  net/netfilter/xt_dscp.o
+00:04:51   CC [M]  drivers/scsi/qedf/qedf_dbg.o
+00:04:52   AR      drivers/net/ethernet/8390/built-in.a
+00:04:52   CC [M]  drivers/net/ethernet/8390/ne2k-pci.o
+00:04:52   CC [M]  net/ax25/ax25_std_subr.o
+00:04:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/init.o
+00:04:52   CC [M]  drivers/ata/pata_hpt37x.o
+00:04:52   CC [M]  drivers/ata/pata_hpt3x2n.o
+00:04:52   CC [M]  drivers/gpu/drm/amd/amdgpu/aldebaran_reg_init.o
+00:04:52   CC [M]  drivers/net/phy/aquantia_hwmon.o
+00:04:52   CC [M]  drivers/gpu/drm/radeon/radeon_atpx_handler.o
+00:04:52   CC [M]  net/bridge/br_switchdev.o
+00:04:52   CC [M]  drivers/scsi/qedf/qedf_main.o
+00:04:52   CC [M]  net/netfilter/xt_ecn.o
+00:04:52   CC [M]  drivers/net/ethernet/3com/3c59x.o
+00:04:53   CC [M]  drivers/net/ethernet/8390/8390.o
+00:04:53   CC [M]  drivers/net/dsa/b53/b53_serdes.o
+00:04:53   CC [M]  net/ax25/ax25_std_timer.o
+00:04:53   CC [M]  drivers/net/phy/at803x.o
+00:04:53   AR      drivers/net/hamradio/built-in.a
+00:04:53   CC [M]  drivers/net/hamradio/mkiss.o
+00:04:53   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_lmem.o
+00:04:53   CC [M]  drivers/ata/pata_hpt3x3.o
+00:04:53   CC [M]  drivers/gpu/drm/amd/amdgpu/aldebaran.o
+00:04:53   CC [M]  fs/fuse/dir.o
+00:04:53   CC [M]  drivers/gpu/drm/radeon/radeon_acpi.o
+00:04:53   CC [M]  net/bridge/br_mrp_switchdev.o
+00:04:53   CC [M]  net/netfilter/xt_esp.o
+00:04:53   CC [M]  net/ax25/ax25_subr.o
+00:04:53   CC [M]  drivers/net/ethernet/8390/axnet_cs.o
+00:04:53   CC [M]  drivers/ata/pata_it8213.o
+00:04:54   CC [M]  sound/soc/soc-jack.o
+00:04:54   AR      drivers/net/dsa/hirschmann/built-in.a
+00:04:54   CC [M]  drivers/net/dsa/hirschmann/hellcreek.o
+00:04:54   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_mman.o
+00:04:54   CC [M]  drivers/net/phy/ax88796b.o
+00:04:54   CC [M]  drivers/gpu/drm/amd/amdgpu/beige_goby_reg_init.o
+00:04:54   CC [M]  drivers/net/hamradio/6pack.o
+00:04:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/mxm.o
+00:04:54   MKREG   drivers/gpu/drm/radeon/r100_reg_safe.h
+00:04:54   MKREG   drivers/gpu/drm/radeon/rn50_reg_safe.h
+00:04:54   MKREG   drivers/gpu/drm/radeon/r300_reg_safe.h
+00:04:54   MKREG   drivers/gpu/drm/radeon/r420_reg_safe.h
+00:04:54   CC [M]  drivers/gpu/drm/radeon/rs600.o
+00:04:54   CC [M]  fs/fuse/file.o
+00:04:54   CC [M]  drivers/ata/pata_it821x.o
+00:04:54   CC [M]  drivers/scsi/qedf/qedf_io.o
+00:04:54   CC [M]  drivers/net/ethernet/3com/typhoon.o
+00:04:54   CC [M]  net/bridge/br_mrp.o
+00:04:54   CC [M]  sound/soc/soc-utils.o
+00:04:54   CC [M]  drivers/net/phy/bcm54140.o
+00:04:54   CC [M]  net/ax25/ax25_timer.o
+00:04:54   CC [M]  net/netfilter/xt_hashlimit.o
+00:04:55   CC [M]  drivers/net/ethernet/8390/pcnet_cs.o
+00:04:55   CC [M]  drivers/gpu/drm/amd/amdgpu/yellow_carp_reg_init.o
+00:04:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/npde.o
+00:04:55   CC [M]  sound/soc/soc-dai.o
+00:04:55   CC [M]  drivers/net/hamradio/yam.o
+00:04:55   CC [M]  drivers/ata/pata_jmicron.o
+00:04:55   CC [M]  drivers/net/dsa/hirschmann/hellcreek_ptp.o
+00:04:55   CC [M]  drivers/net/phy/bcm7xxx.o
+00:04:55   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_pages.o
+00:04:55   CC [M]  drivers/gpu/drm/radeon/rv515.o
+00:04:55   CC [M]  net/ax25/ax25_uid.o
+00:04:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/pcir.o
+00:04:56   CC [M]  drivers/gpu/drm/amd/amdgpu/cyan_skillfish_reg_init.o
+00:04:56   CC [M]  net/bridge/br_mrp_netlink.o
+00:04:56   CC [M]  sound/soc/soc-component.o
+00:04:56   CC [M]  drivers/net/wireless/ath/ath5k/caps.o
+00:04:56   AR      drivers/net/ethernet/adaptec/built-in.a
+00:04:56   CC [M]  drivers/net/ethernet/adaptec/starfire.o
+00:04:56   CC [M]  drivers/ata/pata_marvell.o
+00:04:56   CC [M]  drivers/scsi/qedf/qedf_fip.o
+00:04:56   CC [M]  net/netfilter/xt_helper.o
+00:04:56   CC [M]  drivers/net/phy/bcm87xx.o
+00:04:56   CC [M]  fs/fuse/inode.o
+00:04:56   CC [M]  drivers/net/dsa/hirschmann/hellcreek_hwtstamp.o
+00:04:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/perf.o
+00:04:56   CC [M]  drivers/net/hamradio/bpqether.o
+00:04:56   CC [M]  net/ax25/af_ax25.o
+00:04:56   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_phys.o
+00:04:57   CC [M]  drivers/gpu/drm/amd/amdgpu/df_v1_7.o
+00:04:57   CC [M]  drivers/ata/pata_netcell.o
+00:04:57   CC [M]  drivers/net/phy/bcm-phy-lib.o
+00:04:57   CC [M]  sound/soc/soc-pcm.o
+00:04:57   CC [M]  drivers/scsi/qedf/qedf_attr.o
+00:04:57   CC [M]  net/bridge/br_cfm.o
+00:04:57   CC [M]  drivers/net/wireless/ath/ath5k/initvals.o
+00:04:57   CC [M]  net/netfilter/xt_hl.o
+00:04:57   CC [M]  drivers/gpu/drm/radeon/r200.o
+00:04:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/pll.o
+00:04:57   AR      drivers/net/ethernet/agere/built-in.a
+00:04:57   CC [M]  drivers/net/ethernet/agere/et131x.o
+00:04:57   CC [M]  drivers/ata/pata_ninja32.o
+00:04:57   LD [M]  drivers/net/dsa/hirschmann/hellcreek_sw.o
+00:04:57   AR      drivers/net/dsa/microchip/built-in.a
+00:04:57   CC [M]  drivers/net/hamradio/baycom_ser_fdx.o
+00:04:57   CC [M]  drivers/gpu/drm/amd/amdgpu/df_v3_6.o
+00:04:57   CC [M]  fs/fuse/control.o
+00:04:57   AR      drivers/net/dsa/mv88e6xxx/built-in.a
+00:04:57   CC [M]  drivers/net/dsa/mv88e6xxx/chip.o
+00:04:58   CC [M]  drivers/net/phy/broadcom.o
+00:04:58   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_pm.o
+00:04:58   CC [M]  drivers/scsi/qedf/qedf_els.o
+00:04:58   CC [M]  net/netfilter/xt_ipcomp.o
+00:04:58   CC [M]  drivers/ata/pata_ns87415.o
+00:04:58   CC [M]  net/ax25/ax25_ds_in.o
+00:04:58   CC [M]  drivers/net/wireless/ath/ath5k/eeprom.o
+00:04:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/pmu.o
+00:04:58   CC [M]  net/bridge/br_cfm_netlink.o
+00:04:58   CC [M]  fs/fuse/xattr.o
+00:04:58   CC [M]  drivers/gpu/drm/radeon/r600_cs.o
+00:04:58   CC [M]  drivers/net/hamradio/hdlcdrv.o
+00:04:58   CC [M]  drivers/net/phy/cicada.o
+00:04:59   CC [M]  drivers/gpu/drm/amd/amdgpu/gmc_v7_0.o
+00:04:59   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_region.o
+00:04:59   CC [M]  net/netfilter/xt_iprange.o
+00:04:59   CC [M]  drivers/ata/pata_oldpiix.o
+00:04:59   CC [M]  sound/soc/soc-devres.o
+00:04:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/power_budget.o
+00:04:59   CC [M]  drivers/scsi/qedf/drv_scsi_fw_funcs.o
+00:04:59   AR      drivers/net/ethernet/alteon/built-in.a
+00:04:59   CC [M]  drivers/net/ethernet/alteon/acenic.o
+00:04:59   CC [M]  fs/fuse/acl.o
+00:04:59   CC [M]  net/ax25/ax25_ds_subr.o
+00:04:59   CC [M]  drivers/net/phy/cortina.o
+00:04:59   CC [M]  drivers/scsi/qedf/drv_fcoe_fw_funcs.o
+00:04:59   CC [M]  net/bridge/br_netfilter_hooks.o
+00:04:59   CC [M]  sound/soc/soc-ops.o
+00:04:59   CC [M]  drivers/net/hamradio/baycom_ser_hdx.o
+00:04:59   CC [M]  drivers/ata/pata_optidma.o
+00:05:00   CC [M]  net/netfilter/xt_ipvs.o
+00:05:00   CC [M]  fs/fuse/readdir.o
+00:05:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/ramcfg.o
+00:05:00   CC [M]  drivers/net/phy/davicom.o
+00:05:00   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_shmem.o
+00:05:00   CC [M]  drivers/gpu/drm/amd/amdgpu/gmc_v8_0.o
+00:05:00   CC [M]  drivers/net/wireless/ath/ath5k/gpio.o
+00:05:00   CC [M]  drivers/net/dsa/mv88e6xxx/devlink.o
+00:05:00   CC [M]  net/ax25/ax25_ds_timer.o
+00:05:00   CC [M]  drivers/scsi/qedf/qedf_debugfs.o
+00:05:00   CC [M]  drivers/gpu/drm/radeon/evergreen_cs.o
+00:05:00   CC [M]  drivers/ata/pata_pdc2027x.o
+00:05:00   CC [M]  sound/soc/soc-link.o
+00:05:00   CC [M]  drivers/net/hamradio/baycom_par.o
+00:05:00   CC [M]  drivers/net/phy/dp83640.o
+00:05:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/rammap.o
+00:05:01   CC [M]  fs/fuse/ioctl.o
+00:05:01   CC [M]  net/netfilter/xt_l2tp.o
+00:05:01   CC [M]  drivers/net/ethernet/amazon/ena/ena_netdev.o
+00:05:01   CC [M]  drivers/net/wireless/ath/ath5k/desc.o
+00:05:01   CC [M]  sound/soc/soc-card.o
+00:05:01   CC [M]  net/ax25/sysctl_net_ax25.o
+00:05:01   LD [M]  drivers/scsi/qedf/qedf.o
+00:05:01   CC [M]  net/bridge/br_netfilter_ipv6.o
+00:05:01   CC [M]  drivers/scsi/arcmsr/arcmsr_attr.o
+00:05:01   CC [M]  drivers/ata/pata_pdc202xx_old.o
+00:05:01   CC [M]  drivers/net/dsa/mv88e6xxx/global1.o
+00:05:01   CC [M]  drivers/gpu/drm/amd/amdgpu/gfxhub_v1_0.o
+00:05:01   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_shrinker.o
+00:05:01   CC [M]  drivers/net/wireless/ath/ath5k/dma.o
+00:05:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadow.o
+00:05:01   CC [M]  fs/fuse/dax.o
+00:05:01   CC [M]  sound/soc/soc-topology.o
+00:05:02   CC [M]  drivers/net/phy/dp83822.o
+00:05:02   CC [M]  drivers/scsi/arcmsr/arcmsr_hba.o
+00:05:02   LD [M]  net/ax25/ax25.o
+00:05:02   CC [M]  net/netfilter/xt_length.o
+00:05:02   CC [M]  drivers/ata/pata_sch.o
+00:05:02   CC [M]  drivers/gpu/drm/virtio/virtgpu_drv.o
+00:05:02   CC [M]  drivers/net/wireless/ath/ath9k/beacon.o
+00:05:02   LD [M]  net/bridge/bridge.o
+00:05:02   LD [M]  net/bridge/br_netfilter.o
+00:05:02   CC [M]  fs/overlayfs/super.o
+00:05:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadowacpi.o
+00:05:02   CC [M]  drivers/net/dsa/mv88e6xxx/global1_atu.o
+00:05:02   CC [M]  drivers/gpu/drm/amd/amdgpu/mmhub_v1_0.o
+00:05:02   CC [M]  drivers/net/wireless/ath/ath5k/qcu.o
+00:05:02   CC [M]  drivers/gpu/drm/radeon/r100.o
+00:05:02   CC [M]  drivers/net/phy/dp83848.o
+00:05:02   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_stolen.o
+00:05:02   CC [M]  fs/fuse/cuse.o
+00:05:02   CC [M]  drivers/ata/pata_serverworks.o
+00:05:03   CC [M]  drivers/gpu/drm/virtio/virtgpu_kms.o
+00:05:03   CC [M]  sound/soc/soc-generic-dmaengine-pcm.o
+00:05:03   CC [M]  net/netfilter/xt_limit.o
+00:05:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadowof.o
+00:05:03   CC [M]  drivers/net/phy/dp83867.o
+00:05:03   CC [M]  drivers/net/wireless/ath/ath9k/gpio.o
+00:05:03   CC [M]  fs/overlayfs/namei.o
+00:05:03   CC [M]  fs/fuse/virtio_fs.o
+00:05:03   CC [M]  drivers/ata/pata_sil680.o
+00:05:03   CC [M]  drivers/net/dsa/mv88e6xxx/global1_vtu.o
+00:05:03   CC [M]  sound/soc/soc-ac97.o
+00:05:03   CC [M]  net/netfilter/xt_mac.o
+00:05:03   CC [M]  drivers/net/ethernet/amazon/ena/ena_com.o
+00:05:04   CC [M]  drivers/net/wireless/ath/ath5k/pcu.o
+00:05:04   CC [M]  drivers/gpu/drm/virtio/virtgpu_gem.o
+00:05:04   CC [M]  drivers/gpu/drm/amd/amdgpu/gmc_v9_0.o
+00:05:04   LD [M]  drivers/scsi/arcmsr/arcmsr.o
+00:05:04   SHIPPED drivers/scsi/aic7xxx/aic7xxx_seq.h
+00:05:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadowpci.o
+00:05:04   SHIPPED drivers/scsi/aic7xxx/aic7xxx_reg.h
+00:05:04   SHIPPED drivers/scsi/aic7xxx/aic79xx_seq.h
+00:05:04   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_throttle.o
+00:05:04   SHIPPED drivers/scsi/aic7xxx/aic79xx_reg.h
+00:05:04   CC [M]  drivers/scsi/aic7xxx/aic7xxx_core.o
+00:05:04   CC [M]  drivers/net/phy/dp83869.o
+00:05:04   CC [M]  sound/soc/soc-compress.o
+00:05:04   CC [M]  drivers/ata/pata_sis.o
+00:05:04   CC [M]  fs/overlayfs/util.o
+00:05:04   CC [M]  drivers/net/wireless/ath/ath9k/init.o
+00:05:04   CC [M]  drivers/gpu/drm/virtio/virtgpu_vram.o
+00:05:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadowramin.o
+00:05:04   CC [M]  net/netfilter/xt_multiport.o
+00:05:05   LD [M]  fs/fuse/fuse.o
+00:05:05   LD [M]  fs/fuse/virtiofs.o
+00:05:05   CC [M]  drivers/scsi/aic7xxx/aic7xxx_93cx6.o
+00:05:05   CC [M]  drivers/net/dsa/mv88e6xxx/global2.o
+00:05:05   CC [M]  drivers/net/wireless/ath/ath5k/phy.o
+00:05:05   LD [M]  sound/soc/snd-soc-acpi.o
+00:05:05   LD [M]  sound/soc/snd-soc-core.o
+00:05:05   CC [M]  drivers/net/phy/icplus.o
+00:05:05   CC [M]  drivers/gpu/drm/radeon/r300.o
+00:05:05   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_tiling.o
+00:05:05   CC [M]  drivers/net/ethernet/amazon/ena/ena_eth_com.o
+00:05:05   CC [M]  drivers/net/dsa/mv88e6xxx/global2_avb.o
+00:05:05   CC [M]  drivers/ata/pata_piccolo.o
+00:05:05   CC [M]  fs/overlayfs/inode.o
+00:05:05   CC [M]  drivers/gpu/drm/amd/amdgpu/gfxhub_v1_1.o
+00:05:05   CC [M]  drivers/gpu/drm/virtio/virtgpu_display.o
+00:05:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/shadowrom.o
+00:05:05   AR      drivers/net/dsa/ocelot/built-in.a
+00:05:05   AR      drivers/net/ethernet/amazon/built-in.a
+00:05:05   CC      drivers/cdrom/cdrom.o
+00:05:06   CC [M]  drivers/net/wireless/ath/ath9k/main.o
+00:05:06   CC [M]  net/netfilter/xt_nfacct.o
+00:05:06   CC [M]  drivers/net/phy/intel-xway.o
+00:05:06   CC [M]  drivers/ata/pata_triflex.o
+00:05:06   CC [M]  drivers/net/ethernet/amazon/ena/ena_ethtool.o
+00:05:06   CC [M]  fs/overlayfs/file.o
+00:05:06   CC [M]  drivers/net/dsa/mv88e6xxx/global2_scratch.o
+00:05:06   CC [M]  drivers/net/wwan/iosm/iosm_ipc_task_queue.o
+00:05:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/timing.o
+00:05:06   CC [M]  drivers/gpu/drm/amd/amdgpu/mmhub_v9_4.o
+00:05:06   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_ttm.o
+00:05:06   CC [M]  drivers/gpu/drm/virtio/virtgpu_vq.o
+00:05:06   CC [M]  drivers/net/phy/et1011c.o
+00:05:06   CC [M]  net/netfilter/xt_osf.o
+00:05:06   CC [M]  drivers/gpu/drm/radeon/r420.o
+00:05:06   CC [M]  drivers/scsi/aic7xxx/aic7xxx_pci.o
+00:05:06   CC [M]  drivers/ata/pata_via.o
+00:05:07   CC [M]  fs/overlayfs/dir.o
+00:05:07   CC [M]  drivers/net/wwan/iosm/iosm_ipc_imem.o
+00:05:07   LD [M]  drivers/net/ethernet/amazon/ena/ena.o
+00:05:07   CC [M]  drivers/net/wireless/ath/ath5k/reset.o
+00:05:07   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-main.o
+00:05:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/therm.o
+00:05:07   CC [M]  drivers/net/phy/lxt.o
+00:05:07   CC [M]  drivers/net/dsa/mv88e6xxx/phy.o
+00:05:07   CC [M]  drivers/net/wireless/ath/ath9k/recv.o
+00:05:07   AR      drivers/cdrom/built-in.a
+00:05:07   CC [M]  drivers/ata/pata_sl82c105.o
+00:05:07   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-drv.o
+00:05:07   LD [M]  drivers/gpu/drm/radeon/radeon.o
+00:05:07   CC [M]  net/netfilter/xt_owner.o
+00:05:07   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_userptr.o
+00:05:07   CC [M]  drivers/gpu/drm/virtio/virtgpu_fence.o
+00:05:07   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_main.o
+00:05:07   CC [M]  drivers/gpu/drm/amd/amdgpu/gfxhub_v2_0.o
+00:05:07   CC [M]  drivers/scsi/aic7xxx/aic7xxx_osm.o
+00:05:07   CC [M]  fs/overlayfs/readdir.o
+00:05:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/vmap.o
+00:05:08   CC [M]  drivers/net/wireless/ath/carl9170/main.o
+00:05:08   CC [M]  drivers/net/wwan/iosm/iosm_ipc_imem_ops.o
+00:05:08   CC [M]  drivers/net/phy/marvell10g.o
+00:05:08   CC [M]  drivers/ata/pata_cmd640.o
+00:05:08   CC [M]  drivers/net/dsa/mv88e6xxx/port.o
+00:05:08   CC [M]  drivers/net/wireless/ath/ath5k/attach.o
+00:05:08   CC [M]  drivers/gpu/drm/virtio/virtgpu_object.o
+00:05:08   CC [M]  net/netfilter/xt_cgroup.o
+00:05:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/volt.o
+00:05:08   CC [M]  drivers/net/wwan/iosm/iosm_ipc_mmio.o
+00:05:08   CC [M]  fs/overlayfs/copy_up.o
+00:05:08   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_nic.o
+00:05:08   CC [M]  drivers/net/wireless/ath/ath9k/xmit.o
+00:05:08   CC [M]  drivers/gpu/drm/i915/gem/i915_gem_wait.o
+00:05:09   CC [M]  drivers/net/phy/marvell.o
+00:05:09   CC [M]  drivers/gpu/drm/amd/amdgpu/mmhub_v2_0.o
+00:05:09   CC [M]  drivers/ata/pata_mpiix.o
+00:05:09   CC [M]  drivers/scsi/aic7xxx/aic7xxx_proc.o
+00:05:09   CC [M]  drivers/net/wwan/iosm/iosm_ipc_port.o
+00:05:09   CC [M]  drivers/gpu/drm/virtio/virtgpu_debugfs.o
+00:05:09   CC [M]  drivers/net/wireless/ath/ath5k/base.o
+00:05:09   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-dev.o
+00:05:09   CC [M]  drivers/net/wireless/ath/carl9170/usb.o
+00:05:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/vpstate.o
+00:05:09   CC [M]  net/netfilter/xt_physdev.o
+00:05:09   CC [M]  fs/overlayfs/export.o
+00:05:09   CC [M]  drivers/gpu/drm/i915/gem/i915_gemfs.o
+00:05:09   CC [M]  drivers/ata/pata_ns87410.o
+00:05:09   CC [M]  drivers/scsi/aic7xxx/aic7xxx_osm_pci.o
+00:05:09   CC [M]  drivers/net/wwan/iosm/iosm_ipc_wwan.o
+00:05:10   CC [M]  drivers/net/dsa/mv88e6xxx/port_hidden.o
+00:05:10   CC [M]  drivers/gpu/drm/amd/amdgpu/gmc_v10_0.o
+00:05:10   CC [M]  drivers/gpu/drm/virtio/virtgpu_plane.o
+00:05:10   CC [M]  drivers/net/phy/marvell-88x2222.o
+00:05:10   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_pci_func.o
+00:05:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/xpio.o
+00:05:10   LD [M]  fs/overlayfs/overlay.o
+00:05:10   CC [M]  fs/orangefs/acl.o
+00:05:10   CC [M]  drivers/ata/pata_opti.o
+00:05:10   CC [M]  net/netfilter/xt_pkttype.o
+00:05:10   CC [M]  drivers/scsi/aic7xxx/aic79xx_core.o
+00:05:10   CC [M]  drivers/gpu/drm/i915/i915_active.o
+00:05:10   CC [M]  drivers/net/wwan/iosm/iosm_ipc_uevent.o
+00:05:10   CC [M]  drivers/net/wireless/ath/carl9170/cmd.o
+00:05:11   CC [M]  drivers/net/dsa/mv88e6xxx/serdes.o
+00:05:11   CC [M]  drivers/net/wireless/ath/ath9k/link.o
+00:05:11   CC [M]  drivers/net/wwan/iosm/iosm_ipc_pm.o
+00:05:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/M0203.o
+00:05:11   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_vec.o
+00:05:11   CC [M]  fs/orangefs/file.o
+00:05:11   CC [M]  drivers/net/phy/mxl-gpy.o
+00:05:11   CC [M]  drivers/gpu/drm/virtio/virtgpu_ioctl.o
+00:05:11   CC [M]  drivers/ata/pata_pcmcia.o
+00:05:11   CC [M]  drivers/net/wireless/ath/ath5k/led.o
+00:05:11   CC [M]  net/netfilter/xt_policy.o
+00:05:11   CC [M]  drivers/gpu/drm/amd/amdgpu/gfxhub_v2_1.o
+00:05:11   CC [M]  drivers/net/wwan/iosm/iosm_ipc_pcie.o
+00:05:11   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-desc.o
+00:05:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/M0205.o
+00:05:12   CC [M]  drivers/ata/pata_acpi.o
+00:05:12   CC [M]  drivers/net/wireless/ath/carl9170/mac.o
+00:05:12   CC [M]  fs/orangefs/orangefs-cache.o
+00:05:12   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_ring.o
+00:05:12   CC [M]  drivers/net/phy/mediatek-ge.o
+00:05:12   CC [M]  drivers/net/wireless/ath/ath9k/antenna.o
+00:05:12   CC [M]  drivers/gpu/drm/virtio/virtgpu_prime.o
+00:05:12   CC [M]  drivers/gpu/drm/i915/i915_buddy.o
+00:05:12   CC [M]  drivers/net/dsa/mv88e6xxx/smi.o
+00:05:12   CC [M]  drivers/net/wireless/ath/ath5k/rfkill.o
+00:05:12   CC [M]  net/netfilter/xt_quota.o
+00:05:12   CC [M]  drivers/net/wwan/iosm/iosm_ipc_irq.o
+00:05:12   CC [M]  drivers/net/phy/micrel.o
+00:05:12   CC [M]  drivers/ata/ata_generic.o
+00:05:12   CC [M]  fs/orangefs/orangefs-utils.o
+00:05:12   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-ethtool.o
+00:05:12   CC [M]  drivers/gpu/drm/i915/i915_cmd_parser.o
+00:05:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/M0209.o
+00:05:12   CC [M]  drivers/gpu/drm/amd/amdgpu/mmhub_v2_3.o
+00:05:13   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_hw_utils.o
+00:05:13   CC [M]  drivers/gpu/drm/virtio/virtgpu_trace_points.o
+00:05:13   CC [M]  drivers/net/wireless/ath/carl9170/phy.o
+00:05:13   CC [M]  drivers/net/wwan/iosm/iosm_ipc_chnl_cfg.o
+00:05:13   CC [M]  net/netfilter/xt_rateest.o
+00:05:13   CC [M]  drivers/net/wireless/ath/ath9k/channel.o
+00:05:13   CC [M]  drivers/net/dsa/mv88e6xxx/trace.o
+00:05:13   AR      drivers/ata/built-in.a
+00:05:13   CC [M]  drivers/net/wireless/ath/ath5k/ani.o
+00:05:13   CC [M]  fs/orangefs/xattr.o
+00:05:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bios/P0260.o
+00:05:13   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-mdio.o
+00:05:13   CC [M]  drivers/net/phy/microchip.o
+00:05:13   CC [M]  fs/udf/balloc.o
+00:05:13   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_ethtool.o
+00:05:13   LD [M]  drivers/gpu/drm/virtio/virtio-gpu.o
+00:05:13   CC [M]  drivers/net/wwan/iosm/iosm_ipc_protocol.o
+00:05:13   AR      drivers/net/ethernet/aquantia/built-in.a
+00:05:13   CC [M]  drivers/net/wireless/broadcom/b43/main.o
+00:05:14   CC [M]  net/netfilter/xt_realm.o
+00:05:14   CC [M]  drivers/gpu/drm/i915/i915_gem_evict.o
+00:05:14   CC [M]  drivers/net/dsa/mv88e6xxx/hwtstamp.o
+00:05:14   CC [M]  drivers/gpu/drm/amd/amdgpu/mmhub_v1_7.o
+00:05:14   CC [M]  drivers/scsi/aic7xxx/aic79xx_pci.o
+00:05:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/base.o
+00:05:14   CC [M]  drivers/net/phy/motorcomm.o
+00:05:14   CC [M]  drivers/net/wireless/ath/ath9k/mci.o
+00:05:14   CC [M]  fs/orangefs/dcache.o
+00:05:14   CC [M]  fs/udf/dir.o
+00:05:14   CC [M]  drivers/net/wwan/iosm/iosm_ipc_protocol_ops.o
+00:05:14   CC [M]  drivers/net/wireless/ath/carl9170/led.o
+00:05:14   CC [M]  drivers/net/wireless/ath/ath5k/sysfs.o
+00:05:14   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_drvinfo.o
+00:05:14   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-ptp.o
+00:05:14   CC [M]  net/netfilter/xt_recent.o
+00:05:15   CC [M]  drivers/net/phy/national.o
+00:05:15   CC [M]  drivers/scsi/aic7xxx/aic79xx_osm.o
+00:05:15   CC [M]  fs/udf/file.o
+00:05:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/hwsq.o
+00:05:15   CC [M]  fs/orangefs/inode.o
+00:05:15   CC [M]  drivers/net/wwan/iosm/iosm_ipc_mux.o
+00:05:15   CC [M]  drivers/gpu/drm/i915/i915_gem_gtt.o
+00:05:15   CC [M]  drivers/net/dsa/mv88e6xxx/ptp.o
+00:05:15   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_filters.o
+00:05:15   CC [M]  drivers/gpu/drm/amd/amdgpu/umc_v6_0.o
+00:05:15   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-i2c.o
+00:05:15   CC [M]  drivers/net/wireless/ath/ath9k/pci.o
+00:05:15   CC [M]  drivers/net/wireless/ath/carl9170/fw.o
+00:05:15   CC [M]  drivers/net/phy/nxp-c45-tja11xx.o
+00:05:15   CC [M]  fs/udf/ialloc.o
+00:05:15   CC [M]  drivers/net/wireless/ath/ath5k/mac80211-ops.o
+00:05:15   CC [M]  drivers/net/wwan/iosm/iosm_ipc_mux_codec.o
+00:05:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/nv04.o
+00:05:16   CC [M]  net/netfilter/xt_sctp.o
+00:05:16   CC [M]  fs/udf/inode.o
+00:05:16   CC [M]  fs/orangefs/orangefs-sysfs.o
+00:05:16   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-phy-v1.o
+00:05:16   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_phy.o
+00:05:16   CC [M]  drivers/gpu/drm/amd/amdgpu/umc_v6_1.o
+00:05:16   CC [M]  drivers/gpu/drm/i915/i915_gem_ww.o
+00:05:16   LD [M]  drivers/net/dsa/mv88e6xxx/mv88e6xxx.o
+00:05:16   AR      drivers/net/dsa/qca/built-in.a
+00:05:16   CC [M]  drivers/scsi/aic7xxx/aic79xx_proc.o
+00:05:16   CC [M]  drivers/net/wireless/broadcom/b43/bus.o
+00:05:16   AR      drivers/net/dsa/sja1105/built-in.a
+00:05:16   AR      drivers/net/dsa/xrs700x/built-in.a
+00:05:16   CC [M]  drivers/net/dsa/xrs700x/xrs700x.o
+00:05:16   CC [M]  drivers/net/phy/qsemi.o
+00:05:16   LD [M]  drivers/net/wwan/iosm/iosm.o
+00:05:16   CC [M]  drivers/net/wireless/ath/ath9k/ahb.o
+00:05:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/nv31.o
+00:05:16   CC      drivers/net/wwan/wwan_core.o
+00:05:16   CC [M]  drivers/net/wireless/ath/carl9170/tx.o
+00:05:16   CC [M]  drivers/net/wireless/ath/ath5k/debug.o
+00:05:17   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl/hw_atl_a0.o
+00:05:17   CC [M]  drivers/gpu/drm/i915/i915_gem.o
+00:05:17   CC [M]  fs/orangefs/orangefs-mod.o
+00:05:17   CC [M]  drivers/scsi/aic7xxx/aic79xx_osm_pci.o
+00:05:17   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-phy-v2.o
+00:05:17   CC [M]  net/netfilter/xt_socket.o
+00:05:17   CC [M]  drivers/net/phy/realtek.o
+00:05:17   CC [M]  drivers/gpu/drm/amd/amdgpu/umc_v6_7.o
+00:05:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/nv50.o
+00:05:17   CC [M]  drivers/net/wireless/broadcom/b43/phy_g.o
+00:05:17   CC [M]  drivers/net/wwan/wwan_hwsim.o
+00:05:17   CC [M]  drivers/net/wireless/ath/ath9k/debug.o
+00:05:17   CC [M]  fs/udf/lowlevel.o
+00:05:17   CC [M]  drivers/net/dsa/xrs700x/xrs700x_i2c.o
+00:05:17   CC [M]  fs/orangefs/super.o
+00:05:17   LD [M]  drivers/scsi/aic7xxx/aic7xxx.o
+00:05:18   LD [M]  drivers/scsi/aic7xxx/aic79xx.o
+00:05:18   CC [M]  drivers/scsi/aacraid/linit.o
+00:05:18   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl/hw_atl_b0.o
+00:05:18   CC [M]  drivers/net/phy/smsc.o
+00:05:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/g94.o
+00:05:18   CC [M]  drivers/net/wireless/ath/ath5k/pci.o
+00:05:18   CC [M]  drivers/net/wireless/ath/carl9170/rx.o
+00:05:18   CC [M]  drivers/gpu/drm/amd/amdgpu/umc_v8_7.o
+00:05:18   CC [M]  fs/udf/namei.o
+00:05:18   CC [M]  net/netfilter/xt_state.o
+00:05:18   CC [M]  drivers/net/wwan/mhi_wwan_ctrl.o
+00:05:18   CC [M]  drivers/net/dsa/xrs700x/xrs700x_mdio.o
+00:05:18   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-platform.o
+00:05:18   CC [M]  fs/orangefs/devorangefs-req.o
+00:05:18   CC [M]  drivers/gpu/drm/i915/i915_query.o
+00:05:19   CC [M]  drivers/net/phy/ste10Xp.o
+00:05:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/bus/gf100.o
+00:05:19   CC [M]  fs/udf/partition.o
+00:05:19   CC [M]  drivers/scsi/aacraid/aachba.o
+00:05:19   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl/hw_atl_utils.o
+00:05:19   CC [M]  drivers/net/wwan/mhi_wwan_mbim.o
+00:05:19   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_irq.o
+00:05:19   LD [M]  drivers/net/wireless/ath/ath5k/ath5k.o
+00:05:19   CC      drivers/net/dsa/dsa_loop_bdinfo.o
+00:05:19   CC [M]  drivers/net/wireless/ath/ath9k/ar9002_hw.o
+00:05:19   CC [M]  net/netfilter/xt_statistic.o
+00:05:19   AR      drivers/net/mctp/built-in.a
+00:05:19   AR      drivers/net/ethernet/amd/built-in.a
+00:05:19   CC [M]  fs/udf/super.o
+00:05:19   CC [M]  drivers/net/wireless/broadcom/b43/tables.o
+00:05:19   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-pci.o
+00:05:19   LD [M]  drivers/net/wireless/ath/carl9170/carl9170.o
+00:05:19   CC [M]  fs/orangefs/namei.o
+00:05:19   CC [M]  drivers/net/phy/teranetics.o
+00:05:19   AR      drivers/net/ethernet/arc/built-in.a
+00:05:19   CC [M]  drivers/net/phy/vitesse.o
+00:05:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/base.o
+00:05:19   CC [M]  net/can/j1939/address-claim.o
+00:05:19   CC [M]  drivers/gpu/drm/i915/i915_request.o
+00:05:20   CC [M]  net/netfilter/xt_string.o
+00:05:20   AR      drivers/net/wwan/built-in.a
+00:05:20   CC [M]  net/can/j1939/bus.o
+00:05:20   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl/hw_atl_utils_fw2x.o
+00:05:20   AR      drivers/net/wireless/cisco/built-in.a
+00:05:20   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-dcb.o
+00:05:20   CC [M]  drivers/net/dsa/bcm_sf2.o
+00:05:20   CC [M]  drivers/net/phy/xilinx_gmii2rgmii.o
+00:05:20   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ih.o
+00:05:20   CC [M]  fs/orangefs/symlink.o
+00:05:20   CC [M]  drivers/scsi/pm8001/pm8001_init.o
+00:05:20   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_hw.o
+00:05:20   CC [M]  drivers/net/wireless/broadcom/b43/lo.o
+00:05:20   CC [M]  drivers/scsi/isci/init.o
+00:05:20   CC [M]  net/netfilter/xt_tcpmss.o
+00:05:20   CC [M]  fs/udf/truncate.o
+00:05:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/nv04.o
+00:05:21   CC [M]  drivers/scsi/aacraid/commctrl.o
+00:05:21   LD [M]  drivers/net/phy/aquantia.o
+00:05:21   AR      drivers/net/phy/built-in.a
+00:05:21   CC [M]  drivers/net/ethernet/amd/xgbe/xgbe-debugfs.o
+00:05:21   CC [M]  fs/orangefs/dir.o
+00:05:21   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl/hw_atl_llh.o
+00:05:21   CC [M]  drivers/gpu/drm/vboxvideo/hgsmi_base.o
+00:05:21   CC [M]  net/can/j1939/main.o
+00:05:21   CC [M]  drivers/gpu/drm/amd/amdgpu/iceland_ih.o
+00:05:21   CC [M]  fs/udf/symlink.o
+00:05:21   CC [M]  drivers/net/dsa/bcm_sf2_cfp.o
+00:05:21   CC [M]  drivers/scsi/pm8001/pm8001_sas.o
+00:05:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/nv40.o
+00:05:21   CC [M]  drivers/gpu/drm/i915/i915_scheduler.o
+00:05:21   CC [M]  drivers/scsi/isci/phy.o
+00:05:21   CC [M]  net/netfilter/xt_time.o
+00:05:21   CC [M]  fs/orangefs/orangefs-bufmap.o
+00:05:21   LD [M]  drivers/net/ethernet/amd/xgbe/amd-xgbe.o
+00:05:21   CC [M]  drivers/net/ethernet/amd/amd8111e.o
+00:05:21   CC [M]  drivers/net/wireless/broadcom/b43/wa.o
+00:05:22   CC [M]  fs/udf/directory.o
+00:05:22   CC [M]  drivers/net/wireless/ath/ath9k/hw.o
+00:05:22   CC [M]  drivers/gpu/drm/vboxvideo/modesetting.o
+00:05:22   CC [M]  drivers/scsi/aacraid/comminit.o
+00:05:22   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl2/hw_atl2.o
+00:05:22   CC [M]  net/can/j1939/socket.o
+00:05:22   CC [M]  drivers/gpu/drm/amd/amdgpu/tonga_ih.o
+00:05:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/nv50.o
+00:05:22   CC [M]  net/netfilter/xt_u32.o
+00:05:22   CC [M]  drivers/scsi/isci/request.o
+00:05:22   CC [M]  drivers/scsi/pm8001/pm8001_ctl.o
+00:05:22   CC [M]  fs/orangefs/orangefs-debugfs.o
+00:05:22   CC [M]  fs/udf/misc.o
+00:05:22   CC [M]  drivers/gpu/drm/vboxvideo/vbva_base.o
+00:05:22   CC [M]  drivers/gpu/drm/i915/i915_trace_points.o
+00:05:22   CC [M]  drivers/scsi/aacraid/commsup.o
+00:05:23   CC [M]  drivers/net/dsa/dsa_loop.o
+00:05:23   CC [M]  drivers/net/wireless/broadcom/b43/tables_nphy.o
+00:05:23   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl2/hw_atl2_utils.o
+00:05:23   CC [M]  drivers/net/ethernet/amd/nmclan_cs.o
+00:05:23   LD [M]  net/netfilter/nf_conntrack.o
+00:05:23   LD [M]  net/netfilter/nf_conntrack_h323.o
+00:05:23   LD [M]  net/netfilter/nf_nat.o
+00:05:23   LD [M]  net/netfilter/nf_tables.o
+00:05:23   LD [M]  net/netfilter/nf_flow_table.o
+00:05:23   AR      net/netfilter/built-in.a
+00:05:23   CC [M]  fs/udf/udftime.o
+00:05:23   CC [M]  drivers/gpu/drm/amd/amdgpu/cz_ih.o
+00:05:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/g84.o
+00:05:23   CC [M]  net/can/j1939/transport.o
+00:05:23   CC [M]  drivers/gpu/drm/vboxvideo/vbox_drv.o
+00:05:23   CC [M]  drivers/scsi/pm8001/pm8001_hwi.o
+00:05:23   CC [M]  fs/orangefs/waitqueue.o
+00:05:23   CC [M]  fs/udf/unicode.o
+00:05:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/gt215.o
+00:05:23   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl2/hw_atl2_utils_fw.o
+00:05:24   CC [M]  drivers/scsi/isci/remote_device.o
+00:05:24   CC [M]  drivers/net/dsa/mt7530.o
+00:05:24   CC [M]  drivers/net/ethernet/amd/pcnet32.o
+00:05:24   CC [M]  drivers/scsi/aacraid/dpcsup.o
+00:05:24   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_phy.o
+00:05:24   CC [M]  drivers/net/wireless/ath/ath6kl/debug.o
+00:05:24   CC [M]  drivers/gpu/drm/amd/amdgpu/vega10_ih.o
+00:05:24   CC [M]  drivers/net/wireless/broadcom/b43/radio_2055.o
+00:05:24   LD [M]  fs/udf/udf.o
+00:05:24   CC [M]  drivers/gpu/drm/vboxvideo/vbox_hgsmi.o
+00:05:24   CC [M]  drivers/net/wireless/ath/ath6kl/hif.o
+00:05:24   LD [M]  fs/orangefs/orangefs.o
+00:05:24   CC [M]  fs/jfs/super.o
+00:05:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/mcp77.o
+00:05:24   CC [M]  drivers/net/ethernet/aquantia/atlantic/hw_atl2/hw_atl2_llh.o
+00:05:24   CC [M]  drivers/scsi/aacraid/rx.o
+00:05:25   CC [M]  drivers/gpu/drm/i915/i915_ttm_buddy_manager.o
+00:05:25   CC [M]  drivers/gpu/drm/vboxvideo/vbox_irq.o
+00:05:25   LD [M]  net/can/j1939/can-j1939.o
+00:05:25   CC [M]  drivers/scsi/isci/port.o
+00:05:25   CC [M]  net/can/af_can.o
+00:05:25   AR      drivers/auxdisplay/built-in.a
+00:05:25   CC [M]  drivers/auxdisplay/charlcd.o
+00:05:25   CC [M]  drivers/gpu/drm/amd/amdgpu/vega20_ih.o
+00:05:25   CC [M]  fs/jfs/file.o
+00:05:25   CC [M]  drivers/net/wireless/broadcom/b43/radio_2056.o
+00:05:25   CC [M]  drivers/net/ethernet/aquantia/atlantic/macsec/macsec_api.o
+00:05:25   CC [M]  drivers/net/wireless/ath/ath6kl/htc_mbox.o
+00:05:25   CC [M]  drivers/scsi/aacraid/sa.o
+00:05:25   CC [M]  drivers/net/wireless/ath/ath9k/ar9002_phy.o
+00:05:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/gf100.o
+00:05:25   CC [M]  drivers/net/dsa/qca8k.o
+00:05:25   CC [M]  drivers/gpu/drm/i915/i915_vma.o
+00:05:25   CC [M]  drivers/auxdisplay/hd44780_common.o
+00:05:25   CC [M]  drivers/net/wireless/intel/iwlegacy/common.o
+00:05:25   CC [M]  fs/jfs/inode.o
+00:05:26   CC [M]  drivers/gpu/drm/vboxvideo/vbox_main.o
+00:05:26   CC [M]  drivers/scsi/pm8001/pm80xx_hwi.o
+00:05:26   CC [M]  drivers/auxdisplay/ks0108.o
+00:05:26   CC [M]  drivers/scsi/aacraid/rkt.o
+00:05:26   CC [M]  drivers/gpu/drm/amd/amdgpu/navi10_ih.o
+00:05:26   CC [M]  net/can/proc.o
+00:05:26   CC [M]  drivers/scsi/isci/host.o
+00:05:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/gk104.o
+00:05:26   CC [M]  fs/jfs/namei.o
+00:05:26   CC [M]  drivers/net/wireless/ath/ath9k/ar5008_phy.o
+00:05:26   CC [M]  drivers/auxdisplay/cfag12864b.o
+00:05:26   CC [M]  drivers/net/wireless/broadcom/b43/radio_2057.o
+00:05:26   CC [M]  drivers/net/dsa/lan9303-core.o
+00:05:26   CC [M]  drivers/gpu/drm/vboxvideo/vbox_mode.o
+00:05:27   CC [M]  drivers/scsi/aacraid/nark.o
+00:05:27   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_ptp.o
+00:05:27   CC [M]  drivers/net/wireless/ath/ath6kl/htc_pipe.o
+00:05:27   CC [M]  net/can/raw.o
+00:05:27   CC [M]  drivers/auxdisplay/cfag12864bfb.o
+00:05:27   CC [M]  drivers/gpu/drm/i915/intel_wopcm.o
+00:05:27   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_psp.o
+00:05:27   CC [M]  fs/jfs/jfs_mount.o
+00:05:27   CC [M]  drivers/scsi/aacraid/src.o
+00:05:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/gk20a.o
+00:05:27   CC [M]  drivers/net/wireless/broadcom/b43/phy_common.o
+00:05:27   CC [M]  drivers/scsi/isci/task.o
+00:05:28   CC [M]  drivers/gpu/drm/vboxvideo/vbox_ttm.o
+00:05:28   CC [M]  drivers/auxdisplay/hd44780.o
+00:05:28   CC [M]  drivers/net/ethernet/aquantia/atlantic/aq_macsec.o
+00:05:28   CC [M]  drivers/net/wireless/ath/ath9k/ar9002_calib.o
+00:05:28   CC [M]  drivers/net/dsa/lan9303_i2c.o
+00:05:28   CC [M]  fs/jfs/jfs_umount.o
+00:05:28   CC [M]  drivers/net/wireless/ath/ath6kl/bmi.o
+00:05:28   CC [M]  net/can/bcm.o
+00:05:28   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_uc.o
+00:05:28   CC [M]  drivers/scsi/qla2xxx/qla_os.o
+00:05:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/gm20b.o
+00:05:28   LD [M]  drivers/scsi/pm8001/pm80xx.o
+00:05:28   LD [M]  drivers/scsi/aacraid/aacraid.o
+00:05:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/pllnv04.o
+00:05:28   CC [M]  drivers/net/wireless/ath/ar5523/ar5523.o
+00:05:28   LD [M]  drivers/gpu/drm/vboxvideo/vboxvideo.o
+00:05:28   CC [M]  fs/jfs/jfs_xtree.o
+00:05:28   CC [M]  drivers/net/wireless/ath/wil6210/main.o
+00:05:28   CC [M]  drivers/scsi/isci/probe_roms.o
+00:05:29   CC [M]  drivers/net/wireless/broadcom/b43/phy_n.o
+00:05:29   CC [M]  drivers/net/wireless/intel/iwlegacy/debug.o
+00:05:29   CC [M]  drivers/net/wireless/ath/ath6kl/cfg80211.o
+00:05:29   CC [M]  drivers/net/dsa/lan9303_mdio.o
+00:05:29   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v3_1.o
+00:05:29   CC [M]  drivers/net/wireless/broadcom/b43legacy/main.o
+00:05:29   LD [M]  drivers/net/ethernet/aquantia/atlantic/atlantic.o
+00:05:29   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_calib.o
+00:05:29   CC [M]  drivers/scsi/isci/remote_node_context.o
+00:05:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/clk/pllgt215.o
+00:05:29   CC [M]  drivers/net/ethernet/atheros/atlx/atl1.o
+00:05:29   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_uc_debugfs.o
+00:05:29   CC [M]  net/can/gw.o
+00:05:30   CC [M]  fs/jfs/jfs_imap.o
+00:05:30   CC [M]  drivers/net/wireless/ath/wil6210/netdev.o
+00:05:30   LD [M]  drivers/net/dsa/bcm-sf2.o
+00:05:30   AR      drivers/net/dsa/built-in.a
+00:05:30   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v10_0.o
+00:05:30   CC [M]  net/can/isotp.o
+00:05:30   CC [M]  drivers/net/wireless/ath/ath9k/calib.o
+00:05:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/base.o
+00:05:30   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_uc_fw.o
+00:05:30   CC [M]  drivers/scsi/isci/remote_node_table.o
+00:05:30   CC [M]  drivers/net/wireless/intel/iwlegacy/4965.o
+00:05:30   CC [M]  drivers/scsi/isci/unsolicited_frame_control.o
+00:05:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv04.o
+00:05:31   CC [M]  drivers/net/wireless/ath/ath6kl/init.o
+00:05:31   CC [M]  drivers/net/wireless/ath/wil6210/cfg80211.o
+00:05:31   CC [M]  drivers/net/wireless/broadcom/b43legacy/ilt.o
+00:05:31   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v11_0.o
+00:05:31   CC [M]  fs/xfs/xfs_trace.o
+00:05:31   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc.o
+00:05:31   CC [M]  fs/jfs/jfs_debug.o
+00:05:31   CC [M]  drivers/net/wireless/ath/ath9k/eeprom.o
+00:05:31   CC [M]  drivers/net/ethernet/atheros/atlx/atl2.o
+00:05:31   CC [M]  drivers/scsi/qla2xxx/qla_init.o
+00:05:31   CC [M]  drivers/scsi/isci/port_config.o
+00:05:31   CC [M]  fs/9p/vfs_super.o
+00:05:31   LD [M]  net/can/can.o
+00:05:31   LD [M]  net/can/can-raw.o
+00:05:31   LD [M]  net/can/can-bcm.o
+00:05:31   LD [M]  net/can/can-gw.o
+00:05:31   LD [M]  net/can/can-isotp.o
+00:05:31   CC [M]  net/bluetooth/rfcomm/core.o
+00:05:31   CC [M]  fs/jfs/jfs_dmap.o
+00:05:32   CC [M]  drivers/net/wireless/intel/iwlegacy/4965-mac.o
+00:05:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv05.o
+00:05:32   CC [M]  drivers/net/wireless/broadcom/b43legacy/phy.o
+00:05:32   CC [M]  drivers/net/wireless/ath/ath6kl/main.o
+00:05:32   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v11_0_8.o
+00:05:32   CC [M]  drivers/net/wireless/broadcom/b43/phy_lp.o
+00:05:32   CC [M]  fs/9p/vfs_inode.o
+00:05:32   LD [M]  drivers/scsi/isci/isci.o
+00:05:32   CC [M]  net/bluetooth/rfcomm/sock.o
+00:05:32   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_ads.o
+00:05:33   CC [M]  drivers/net/wireless/ath/ath9k/eeprom_def.o
+00:05:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv10.o
+00:05:33   CC [M]  drivers/net/wireless/ath/wil6210/pcie_bus.o
+00:05:33   CC [M]  drivers/net/ethernet/atheros/atl1e/atl1e_main.o
+00:05:33   CC [M]  fs/jfs/jfs_unicode.o
+00:05:33   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v12_0.o
+00:05:33   CC [M]  fs/9p/vfs_inode_dotl.o
+00:05:33   CC      drivers/pcmcia/cs.o
+00:05:33   CC [M]  drivers/net/wireless/ath/ath6kl/txrx.o
+00:05:33   CC [M]  fs/jfs/jfs_dtree.o
+00:05:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv1a.o
+00:05:33   CC [M]  net/bluetooth/rfcomm/tty.o
+00:05:34   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_ct.o
+00:05:34   CC [M]  drivers/net/wireless/broadcom/b43/tables_lpphy.o
+00:05:34   CC [M]  drivers/net/wireless/ath/wil6210/debugfs.o
+00:05:34   CC [M]  drivers/net/wireless/broadcom/b43legacy/radio.o
+00:05:34   CC      drivers/pcmcia/socket_sysfs.o
+00:05:34   CC [M]  drivers/gpu/drm/amd/amdgpu/psp_v13_0.o
+00:05:34   CC [M]  drivers/net/wireless/ath/ath9k/eeprom_4k.o
+00:05:34   CC [M]  fs/9p/vfs_addr.o
+00:05:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv20.o
+00:05:34   CC [M]  drivers/net/wireless/ath/ath6kl/wmi.o
+00:05:34   CC      drivers/pcmcia/cardbus.o
+00:05:35   CC [M]  drivers/net/ethernet/atheros/atl1e/atl1e_hw.o
+00:05:35   LD [M]  net/bluetooth/rfcomm/rfcomm.o
+00:05:35   CC [M]  net/bluetooth/bnep/core.o
+00:05:35   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_debugfs.o
+00:05:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/nv50.o
+00:05:35   CC [M]  fs/9p/vfs_file.o
+00:05:35   CC [M]  drivers/net/wireless/broadcom/b43/phy_ht.o
+00:05:35   CC [M]  drivers/gpu/drm/amd/amdgpu/dce_v10_0.o
+00:05:35   CC      drivers/pcmcia/ds.o
+00:05:35   CC [M]  fs/jfs/jfs_inode.o
+00:05:35   CC [M]  drivers/net/wireless/ath/wil6210/wmi.o
+00:05:35   CC [M]  drivers/scsi/qla2xxx/qla_mbx.o
+00:05:35   CC [M]  drivers/net/wireless/ath/ath9k/eeprom_9287.o
+00:05:35   CC [M]  drivers/net/wireless/intel/iwlegacy/4965-rs.o
+00:05:35   CC [M]  fs/jfs/jfs_discard.o
+00:05:36   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_fw.o
+00:05:36   CC [M]  drivers/net/ethernet/atheros/atl1e/atl1e_ethtool.o
+00:05:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/g84.o
+00:05:36   CC [M]  drivers/net/wireless/broadcom/b43legacy/sysfs.o
+00:05:36   CC [M]  fs/9p/vfs_dir.o
+00:05:36   CC [M]  net/bluetooth/bnep/sock.o
+00:05:36   CC      drivers/pcmcia/pcmcia_resource.o
+00:05:36   CC [M]  fs/jfs/jfs_extent.o
+00:05:36   CC [M]  drivers/net/wireless/broadcom/b43/tables_phy_ht.o
+00:05:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/g98.o
+00:05:37   CC [M]  drivers/net/wireless/ath/ath6kl/core.o
+00:05:37   CC [M]  fs/9p/vfs_dentry.o
+00:05:37   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_log.o
+00:05:37   CC [M]  fs/jfs/symlink.o
+00:05:37   CC [M]  drivers/net/wireless/broadcom/b43legacy/xmit.o
+00:05:37   CC [M]  drivers/net/ethernet/atheros/atl1e/atl1e_param.o
+00:05:37   CC [M]  drivers/net/wireless/ath/ath9k/ani.o
+00:05:37   CC [M]  drivers/gpu/drm/amd/amdgpu/dce_v11_0.o
+00:05:37   CC [M]  net/bluetooth/bnep/netdev.o
+00:05:37   CC      drivers/pcmcia/cistpl.o
+00:05:37   CC [M]  fs/jfs/jfs_metapage.o
+00:05:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/gt215.o
+00:05:37   CC [M]  fs/9p/v9fs.o
+00:05:37   CC [M]  drivers/net/wireless/ath/wil6210/interrupt.o
+00:05:37   CC [M]  drivers/net/wireless/ath/ath6kl/recovery.o
+00:05:37   CC [M]  drivers/net/wireless/broadcom/b43/radio_2059.o
+00:05:38   CC [M]  drivers/net/wireless/intel/iwlegacy/4965-calib.o
+00:05:38   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_log_debugfs.o
+00:05:38   LD [M]  drivers/net/ethernet/atheros/atl1e/atl1e.o
+00:05:38   CC [M]  drivers/net/ethernet/atheros/atl1c/atl1c_main.o
+00:05:38   CC [M]  drivers/net/wireless/ath/ath9k/mac.o
+00:05:38   CC [M]  drivers/net/wireless/broadcom/b43legacy/rfkill.o
+00:05:38   CC [M]  fs/jfs/jfs_logmgr.o
+00:05:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/mcp89.o
+00:05:38   LD [M]  net/bluetooth/bnep/bnep.o
+00:05:38   CC [M]  net/bluetooth/hidp/core.o
+00:05:38   CC [M]  drivers/net/wireless/ath/ath6kl/sdio.o
+00:05:38   CC [M]  fs/9p/fid.o
+00:05:38   CC [M]  drivers/scsi/qla2xxx/qla_iocb.o
+00:05:38   CC      drivers/pcmcia/pcmcia_cis.o
+00:05:38   CC [M]  drivers/net/wireless/ath/wil6210/txrx.o
+00:05:38   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_rc.o
+00:05:38   CC [M]  drivers/net/wireless/broadcom/b43/sysfs.o
+00:05:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/gf100.o
+00:05:39   CC [M]  drivers/net/wireless/intel/iwlegacy/4965-debug.o
+00:05:39   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vkms.o
+00:05:39   CC [M]  fs/9p/xattr.o
+00:05:39   CC      drivers/pcmcia/rsrc_mgr.o
+00:05:39   CC [M]  drivers/net/wireless/broadcom/b43legacy/leds.o
+00:05:39   CC [M]  fs/jfs/jfs_txnmgr.o
+00:05:39   CC [M]  drivers/net/wireless/ath/ath9k/ar9002_mac.o
+00:05:39   CC [M]  fs/xfs/libxfs/xfs_ag.o
+00:05:39   CC [M]  drivers/net/wireless/ath/ath6kl/usb.o
+00:05:39   CC [M]  net/bluetooth/hidp/sock.o
+00:05:39   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_slpc.o
+00:05:39   CC [M]  fs/9p/cache.o
+00:05:40   CC      drivers/pcmcia/rsrc_nonstatic.o
+00:05:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/gm107.o
+00:05:40   CC [M]  drivers/net/wireless/broadcom/b43/xmit.o
+00:05:40   CC [M]  drivers/net/ethernet/atheros/atl1c/atl1c_hw.o
+00:05:40   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_gfx.o
+00:05:40   CC [M]  drivers/net/wireless/broadcom/b43legacy/dma.o
+00:05:40   CC [M]  drivers/net/wireless/intel/iwlegacy/3945-mac.o
+00:05:40   CC [M]  fs/9p/acl.o
+00:05:40   CC [M]  fs/jfs/jfs_uniupr.o
+00:05:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/gm200.o
+00:05:40   LD [M]  drivers/net/wireless/ath/ath6kl/ath6kl_core.o
+00:05:40   LD [M]  drivers/net/wireless/ath/ath6kl/ath6kl_sdio.o
+00:05:40   LD [M]  drivers/net/wireless/ath/ath6kl/ath6kl_usb.o
+00:05:40   CC [M]  drivers/scsi/qla2xxx/qla_isr.o
+00:05:40   CC [M]  drivers/pcmcia/yenta_socket.o
+00:05:40   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_mac.o
+00:05:40   CC      drivers/usb/common/common.o
+00:05:40   CC [M]  drivers/net/wireless/ath/wil6210/txrx_edma.o
+00:05:40   LD [M]  net/bluetooth/hidp/hidp.o
+00:05:40   CC [M]  net/bluetooth/af_bluetooth.o
+00:05:41   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_guc_submission.o
+00:05:41   CC [M]  fs/jfs/resize.o
+00:05:41   CC [M]  drivers/net/wireless/broadcom/b43/dma.o
+00:05:41   LD [M]  fs/9p/9p.o
+00:05:41   CC      drivers/usb/core/usb.o
+00:05:41   CC [M]  drivers/net/ethernet/atheros/atl1c/atl1c_ethtool.o
+00:05:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/gv100.o
+00:05:41   CC      drivers/usb/common/debug.o
+00:05:41   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_rlc.o
+00:05:41   CC [M]  drivers/pcmcia/pd6729.o
+00:05:41   CC [M]  fs/jfs/xattr.o
+00:05:41   CC [M]  fs/xfs/libxfs/xfs_alloc.o
+00:05:41   CC [M]  drivers/net/wireless/broadcom/b43legacy/pio.o
+00:05:42   CC      drivers/usb/common/led.o
+00:05:42   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_eeprom.o
+00:05:42   CC [M]  net/bluetooth/hci_core.o
+00:05:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/tu102.o
+00:05:42   CC [M]  drivers/usb/common/ulpi.o
+00:05:42   CC      drivers/usb/core/hub.o
+00:05:42   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v8_0.o
+00:05:42   CC [M]  drivers/net/wireless/ath/wil6210/debug.o
+00:05:42   CC [M]  drivers/pcmcia/i82092.o
+00:05:42   CC [M]  fs/jfs/ioctl.o
+00:05:42   LD [M]  drivers/net/ethernet/atheros/atl1c/atl1c.o
+00:05:42   CC [M]  drivers/net/ethernet/atheros/alx/main.o
+00:05:42   CC [M]  drivers/net/wireless/broadcom/b43/pio.o
+00:05:42   AR      drivers/usb/common/built-in.a
+00:05:42   AR      drivers/net/ethernet/cadence/built-in.a
+00:05:42   CC [M]  drivers/net/ethernet/cadence/macb_main.o
+00:05:42   CC [M]  drivers/net/wireless/intel/iwlegacy/3945.o
+00:05:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/devinit/ga100.o
+00:05:43   CC [M]  drivers/scsi/qla2xxx/qla_gs.o
+00:05:43   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_huc.o
+00:05:43   LD [M]  drivers/net/wireless/broadcom/b43legacy/b43legacy.o
+00:05:43   AR      drivers/net/usb/built-in.a
+00:05:43   CC [M]  drivers/net/usb/catc.o
+00:05:43   CC [M]  fs/jfs/acl.o
+00:05:43   CC [M]  drivers/net/wireless/ath/wil6210/rx_reorder.o
+00:05:43   AR      drivers/pcmcia/built-in.a
+00:05:43   CC [M]  drivers/net/ethernet/cadence/macb_ptp.o
+00:05:43   LD [M]  fs/jfs/jfs.o
+00:05:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/base.o
+00:05:43   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/main.o
+00:05:44   CC [M]  drivers/net/wireless/broadcom/b43/rfkill.o
+00:05:44   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_huc_debugfs.o
+00:05:44   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_paprd.o
+00:05:44   CC [M]  drivers/net/wireless/ath/wil6210/fw.o
+00:05:44   AR      drivers/net/wireless/intel/built-in.a
+00:05:44   CC [M]  drivers/net/usb/kaweth.o
+00:05:44   CC      drivers/usb/phy/phy.o
+00:05:44   CC [M]  drivers/net/ethernet/atheros/alx/ethtool.o
+00:05:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/user.o
+00:05:44   CC [M]  fs/xfs/libxfs/xfs_alloc_btree.o
+00:05:44   CC [M]  drivers/gpu/drm/i915/gt/uc/intel_huc_fw.o
+00:05:44   CC [M]  drivers/net/wireless/intel/iwlegacy/3945-rs.o
+00:05:44   CC [M]  drivers/usb/phy/phy-generic.o
+00:05:44   CC [M]  net/bluetooth/hci_conn.o
+00:05:45   CC [M]  drivers/scsi/qla2xxx/qla_dbg.o
+00:05:45   CC      drivers/usb/core/hcd.o
+00:05:45   CC [M]  drivers/net/wireless/broadcom/b43/ppr.o
+00:05:45   CC [M]  drivers/net/usb/pegasus.o
+00:05:45   CC [M]  drivers/net/wireless/ath/wil6210/pm.o
+00:05:45   CC [M]  drivers/net/ethernet/cadence/macb_pci.o
+00:05:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/gp100.o
+00:05:45   CC [M]  drivers/net/ethernet/atheros/alx/hw.o
+00:05:45   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/rs.o
+00:05:45   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v9_0.o
+00:05:45   AR      drivers/usb/phy/built-in.a
+00:05:45   CC [M]  drivers/net/wireless/ath/ath9k/btcoex.o
+00:05:45   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmutil/utils.o
+00:05:45   CC [M]  drivers/gpu/drm/i915/display/intel_atomic.o
+00:05:46   LD [M]  drivers/net/ethernet/cadence/macb.o
+00:05:46   CC [M]  drivers/net/wireless/ath/wil6210/pmc.o
+00:05:46   CC [M]  drivers/net/wireless/intel/iwlegacy/3945-debug.o
+00:05:46   CC [M]  net/sunrpc/auth_gss/auth_gss.o
+00:05:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/gp10b.o
+00:05:46   CC [M]  drivers/net/wireless/broadcom/b43/leds.o
+00:05:46   CC [M]  drivers/net/usb/rtl8150.o
+00:05:46   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmutil/d11.o
+00:05:46   LD [M]  drivers/net/ethernet/atheros/alx/alx.o
+00:05:46   AR      drivers/net/ethernet/atheros/built-in.a
+00:05:46   CC [M]  net/bluetooth/hci_event.o
+00:05:46   CC [M]  drivers/net/ethernet/broadcom/genet/bcmgenet.o
+00:05:46   CC      drivers/usb/core/urb.o
+00:05:46   CC [M]  fs/xfs/libxfs/xfs_attr.o
+00:05:46   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_mci.o
+00:05:46   CC [M]  drivers/gpu/drm/i915/display/intel_atomic_plane.o
+00:05:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/gv100.o
+00:05:47   CC [M]  drivers/net/wireless/ath/wil6210/wil_platform.o
+00:05:47   LD [M]  drivers/net/wireless/broadcom/brcm80211/brcmutil/brcmutil.o
+00:05:47   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.o
+00:05:47   LD [M]  drivers/net/wireless/intel/iwlegacy/iwlegacy.o
+00:05:47   CC [M]  drivers/net/usb/r8152.o
+00:05:47   LD [M]  drivers/net/wireless/intel/iwlegacy/iwl4965.o
+00:05:47   LD [M]  drivers/net/wireless/intel/iwlegacy/iwl3945.o
+00:05:47   CC [M]  drivers/net/wireless/ath/wil6210/ethtool.o
+00:05:47   CC      drivers/usb/core/message.o
+00:05:47   CC [M]  drivers/net/wireless/broadcom/b43/sdio.o
+00:05:47   CC [M]  net/sunrpc/auth_gss/gss_generic_token.o
+00:05:47   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/mac80211.o
+00:05:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fault/tu102.o
+00:05:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/base.o
+00:05:48   CC [M]  net/sunrpc/auth_gss/gss_mech_switch.o
+00:05:48   CC [M]  drivers/net/wireless/ath/wil6210/wil_crash_dump.o
+00:05:48   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_aic.o
+00:05:48   CC [M]  drivers/gpu/drm/i915/display/intel_audio.o
+00:05:48   LD [M]  drivers/net/wireless/broadcom/b43/b43.o
+00:05:48   CC [M]  drivers/net/bonding/bond_main.o
+00:05:48   CC [M]  drivers/gpu/drm/hyperv/hyperv_drm_drv.o
+00:05:48   CC [M]  drivers/scsi/qla2xxx/qla_sup.o
+00:05:48   CC      drivers/usb/core/driver.o
+00:05:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv04.o
+00:05:48   CC [M]  fs/xfs/libxfs/xfs_attr_leaf.o
+00:05:48   CC [M]  drivers/net/wireless/ath/wil6210/p2p.o
+00:05:48   CC [M]  drivers/net/ethernet/broadcom/genet/bcmmii.o
+00:05:49   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/ucode.o
+00:05:49   CC [M]  net/sunrpc/auth_gss/svcauth_gss.o
+00:05:49   CC [M]  drivers/net/wireless/ath/ath9k/ar9003_rtt.o
+00:05:49   CC [M]  drivers/gpu/drm/hyperv/hyperv_drm_modeset.o
+00:05:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv10.o
+00:05:49   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v9_4.o
+00:05:49   LD [M]  drivers/net/wireless/ath/wil6210/wil6210.o
+00:05:49   CC [M]  drivers/gpu/drm/i915/display/intel_bios.o
+00:05:49   CC      drivers/gpu/drm/drm_bridge_connector.o
+00:05:49   CC      drivers/usb/core/config.o
+00:05:49   CC [M]  drivers/net/ethernet/broadcom/genet/bcmgenet_wol.o
+00:05:49   CC [M]  net/bluetooth/mgmt.o
+00:05:50   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/tx.o
+00:05:50   CC [M]  drivers/gpu/drm/hyperv/hyperv_drm_proto.o
+00:05:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv1a.o
+00:05:50   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.o
+00:05:50   CC [M]  drivers/net/wireless/ath/ath9k/common.o
+00:05:50   CC [M]  fs/afs/cache.o
+00:05:50   CC [M]  drivers/scsi/qla2xxx/qla_attr.o
+00:05:50   CC      drivers/usb/core/file.o
+00:05:50   LD [M]  drivers/net/ethernet/broadcom/genet/genet.o
+00:05:50   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_main.o
+00:05:50   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v9_4_2.o
+00:05:50   CC [M]  net/sunrpc/auth_gss/gss_rpc_upcall.o
+00:05:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv20.o
+00:05:51   LD [M]  drivers/gpu/drm/hyperv/hyperv_drm.o
+00:05:51   CC [M]  fs/afs/addr_list.o
+00:05:51   CC      drivers/usb/core/buffer.o
+00:05:51   CC [M]  drivers/net/usb/hso.o
+00:05:51   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/fwil.o
+00:05:51   CC      drivers/usb/mon/mon_main.o
+00:05:51   CC [M]  drivers/gpu/drm/i915/display/intel_bw.o
+00:05:51   CC [M]  drivers/net/wireless/ath/ath9k/common-init.o
+00:05:51   CC [M]  fs/xfs/libxfs/xfs_attr_remote.o
+00:05:51   CC [M]  drivers/net/bonding/bond_3ad.o
+00:05:51   CC      drivers/usb/core/sysfs.o
+00:05:51   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/lib.o
+00:05:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv25.o
+00:05:51   CC [M]  net/sunrpc/auth_gss/gss_rpc_xdr.o
+00:05:52   CC      drivers/usb/mon/mon_stat.o
+00:05:52   CC [M]  drivers/gpu/drm/amd/amdgpu/gfx_v10_0.o
+00:05:52   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/fweh.o
+00:05:52   CC [M]  fs/afs/callback.o
+00:05:52   CC [M]  drivers/scsi/qla2xxx/qla_mid.o
+00:05:52   CC      drivers/usb/mon/mon_text.o
+00:05:52   CC      drivers/usb/core/endpoint.o
+00:05:52   CC [M]  drivers/net/wireless/ath/ath9k/common-beacon.o
+00:05:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv30.o
+00:05:52   CC [M]  drivers/gpu/drm/i915/display/intel_cdclk.o
+00:05:53   CC [M]  drivers/net/usb/lan78xx.o
+00:05:53   CC [M]  drivers/net/bonding/bond_alb.o
+00:05:53   CC [M]  net/sunrpc/auth_gss/trace.o
+00:05:53   CC      drivers/usb/core/devio.o
+00:05:53   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.o
+00:05:53   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/calib.o
+00:05:53   CC      drivers/usb/mon/mon_bin.o
+00:05:53   CC [M]  fs/afs/cell.o
+00:05:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv35.o
+00:05:53   CC [M]  drivers/scsi/qla2xxx/qla_dfs.o
+00:05:53   CC [M]  drivers/net/wireless/ath/ath9k/common-debug.o
+00:05:53   CC [M]  fs/xfs/libxfs/xfs_bit.o
+00:05:54   CC [M]  net/bluetooth/hci_sock.o
+00:05:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv36.o
+00:05:54   AR      drivers/usb/mon/built-in.a
+00:05:54   CC [M]  drivers/gpu/drm/i915/display/intel_color.o
+00:05:54   CC [M]  fs/xfs/libxfs/xfs_bmap.o
+00:05:54   CC [M]  drivers/scsi/qla2xxx/qla_bsg.o
+00:05:54   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/proto.o
+00:05:54   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/tt.o
+00:05:54   CC [M]  drivers/net/bonding/bond_sysfs.o
+00:05:54   CC [M]  drivers/net/wireless/ath/ath9k/htc_hst.o
+00:05:54   CC      drivers/usb/core/notify.o
+00:05:54   CC [M]  fs/afs/cmservice.o
+00:05:54   CC [M]  net/sunrpc/auth_gss/gss_krb5_mech.o
+00:05:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv40.o
+00:05:55   CC [M]  net/rxrpc/af_rxrpc.o
+00:05:55   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.o
+00:05:55   CC      drivers/usb/core/generic.o
+00:05:55   CC [M]  drivers/net/usb/asix_devices.o
+00:05:55   CC [M]  drivers/net/bonding/bond_sysfs_slave.o
+00:05:55   CC [M]  net/bluetooth/hci_sysfs.o
+00:05:55   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/sta.o
+00:05:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv41.o
+00:05:55   CC [M]  net/sunrpc/auth_gss/gss_krb5_seal.o
+00:05:55   CC      drivers/usb/core/quirks.o
+00:05:55   CC [M]  drivers/net/wireless/ath/ath9k/hif_usb.o
+00:05:56   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.o
+00:05:56   CC [M]  fs/afs/dir.o
+00:05:56   CC [M]  drivers/scsi/qla2xxx/qla_nx.o
+00:05:56   CC [M]  drivers/gpu/drm/i915/display/intel_combo_phy.o
+00:05:56   CC [M]  drivers/net/bonding/bond_debugfs.o
+00:05:56   CC [M]  net/sunrpc/auth_gss/gss_krb5_unseal.o
+00:05:56   CC      drivers/usb/core/devices.o
+00:05:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv44.o
+00:05:56   CC [M]  drivers/net/usb/asix_common.o
+00:05:56   CC [M]  net/bluetooth/l2cap_core.o
+00:05:56   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_sdma.o
+00:05:56   CC [M]  drivers/net/bonding/bond_netlink.o
+00:05:57   CC [M]  net/sunrpc/auth_gss/gss_krb5_seqnum.o
+00:05:57   CC      drivers/usb/core/phy.o
+00:05:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv46.o
+00:05:57   CC [M]  drivers/net/wireless/ath/ath9k/wmi.o
+00:05:57   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/rx.o
+00:05:57   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.o
+00:05:57   CC [M]  drivers/gpu/drm/i915/display/intel_connector.o
+00:05:57   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v2_4.o
+00:05:57   CC [M]  net/sunrpc/auth_gss/gss_krb5_wrap.o
+00:05:57   CC [M]  drivers/net/usb/ax88172a.o
+00:05:57   CC [M]  net/rxrpc/call_accept.o
+00:05:57   CC      drivers/usb/core/port.o
+00:05:57   CC [M]  drivers/net/bonding/bond_options.o
+00:05:57   CC [M]  fs/afs/dir_edit.o
+00:05:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv47.o
+00:05:58   CC [M]  drivers/scsi/qla2xxx/qla_mr.o
+00:05:58   CC [M]  fs/xfs/libxfs/xfs_bmap_btree.o
+00:05:58   CC [M]  net/sunrpc/auth_gss/gss_krb5_crypto.o
+00:05:58   CC [M]  drivers/net/wireless/ath/ath9k/htc_drv_txrx.o
+00:05:58   CC [M]  drivers/net/usb/ax88179_178a.o
+00:05:58   CC      drivers/usb/core/hcd-pci.o
+00:05:58   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/feature.o
+00:05:58   CC [M]  drivers/gpu/drm/i915/display/intel_crtc.o
+00:05:58   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/power.o
+00:05:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv49.o
+00:05:58   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v3_0.o
+00:05:58   CC [M]  drivers/net/bonding/bond_procfs.o
+00:05:59   CC [M]  net/rxrpc/call_event.o
+00:05:59   CC      drivers/usb/core/usb-acpi.o
+00:05:59   CC [M]  fs/afs/dir_silly.o
+00:05:59   CC [M]  net/sunrpc/auth_gss/gss_krb5_keys.o
+00:05:59   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_link.o
+00:05:59   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/btcoex.o
+00:05:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv4e.o
+00:05:59   CC [M]  drivers/net/usb/cdc_ether.o
+00:05:59   LD [M]  drivers/net/bonding/bonding.o
+00:05:59   CC [M]  drivers/net/wireless/ath/ath9k/htc_drv_main.o
+00:05:59   CC [M]  drivers/scsi/qla2xxx/qla_nx2.o
+00:05:59   CC [M]  net/sunrpc/xprtrdma/transport.o
+00:05:59   CC [M]  drivers/usb/core/ledtrig-usbport.o
+00:05:59   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/scan.o
+00:05:59   CC [M]  drivers/gpu/drm/i915/display/intel_cursor.o
+00:05:59   LD [M]  net/sunrpc/auth_gss/auth_rpcgss.o
+00:05:59   LD [M]  net/sunrpc/auth_gss/rpcsec_gss_krb5.o
+00:05:59   CC [M]  net/sunrpc/xprtrdma/rpc_rdma.o
+00:06:00   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/vendor.o
+00:06:00   CC [M]  net/rxrpc/call_object.o
+00:06:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/nv50.o
+00:06:00   CC [M]  fs/afs/dynroot.o
+00:06:00   CC [M]  fs/xfs/libxfs/xfs_btree.o
+00:06:00   CC [M]  net/bluetooth/l2cap_sock.o
+00:06:00   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v4_0.o
+00:06:00   CC [M]  drivers/net/usb/cdc_eem.o
+00:06:00   AR      drivers/usb/core/built-in.a
+00:06:00   CC      drivers/usb/host/pci-quirks.o
+00:06:00   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/pno.o
+00:06:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/g84.o
+00:06:01   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/mac80211_if.o
+00:06:01   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/rxon.o
+00:06:01   CC [M]  drivers/net/usb/dm9601.o
+00:06:01   CC [M]  drivers/gpu/drm/i915/display/intel_display.o
+00:06:01   CC [M]  drivers/net/wireless/ath/ath9k/htc_drv_beacon.o
+00:06:01   CC [M]  fs/afs/file.o
+00:06:01   CC      drivers/usb/host/ehci-hcd.o
+00:06:01   CC [M]  drivers/scsi/qla2xxx/qla_target.o
+00:06:01   CC [M]  net/rxrpc/conn_client.o
+00:06:01   CC [M]  net/sunrpc/xprtrdma/verbs.o
+00:06:01   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/xtlv.o
+00:06:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gt215.o
+00:06:01   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcdc.o
+00:06:01   CC [M]  net/bluetooth/smp.o
+00:06:02   CC [M]  drivers/net/usb/sr9700.o
+00:06:02   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v4_4.o
+00:06:02   CC [M]  drivers/net/wireless/ath/ath9k/htc_drv_init.o
+00:06:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/mcp77.o
+00:06:02   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/ucode_loader.o
+00:06:02   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/devices.o
+00:06:02   CC [M]  fs/afs/flock.o
+00:06:02   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/fwsignal.o
+00:06:02   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/ampdu.o
+00:06:03   CC [M]  drivers/net/usb/smsc75xx.o
+00:06:03   CC [M]  net/rxrpc/conn_event.o
+00:06:03   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v5_0.o
+00:06:03   CC [M]  net/sunrpc/xprtrdma/frwr_ops.o
+00:06:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/mcp89.o
+00:06:03   CC [M]  drivers/net/wireless/ath/ath9k/htc_drv_gpio.o
+00:06:03   CC [M]  fs/xfs/libxfs/xfs_btree_staging.o
+00:06:03   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/led.o
+00:06:03   CC [M]  net/bluetooth/lib.o
+00:06:04   CC [M]  fs/afs/fsclient.o
+00:06:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gf100.o
+00:06:04   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/commonring.o
+00:06:04   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/antsel.o
+00:06:04   CC [M]  net/rxrpc/conn_object.o
+00:06:04   CC [M]  drivers/net/usb/smsc95xx.o
+00:06:04   CC [M]  drivers/scsi/qla2xxx/qla_tmpl.o
+00:06:04   CC [M]  net/sunrpc/xprtrdma/svc_rdma.o
+00:06:04   CC [M]  drivers/net/wireless/ath/ath9k/ath9k_pci_owl_loader.o
+00:06:04   CC [M]  net/bluetooth/ecdh_helper.o
+00:06:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gf108.o
+00:06:04   CC [M]  drivers/net/wireless/intel/iwlwifi/dvm/debugfs.o
+00:06:04   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/flowring.o
+00:06:04   CC [M]  drivers/gpu/drm/amd/amdgpu/sdma_v5_2.o
+00:06:04   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_cmn.o
+00:06:04   CC      drivers/usb/host/ehci-pci.o
+00:06:05   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/channel.o
+00:06:05   CC [M]  net/bluetooth/hci_request.o
+00:06:05   LD [M]  drivers/net/wireless/ath/ath9k/ath9k.o
+00:06:05   LD [M]  drivers/net/wireless/ath/ath9k/ath9k_hw.o
+00:06:05   LD [M]  drivers/net/wireless/ath/ath9k/ath9k_common.o
+00:06:05   LD [M]  drivers/net/wireless/ath/ath9k/ath9k_htc.o
+00:06:05   CC      drivers/usb/host/ohci-hcd.o
+00:06:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gk104.o
+00:06:05   CC [M]  drivers/scsi/qla2xxx/qla_nvme.o
+00:06:05   CC [M]  net/rxrpc/conn_service.o
+00:06:05   CC [M]  drivers/net/wireless/ath/ath10k/mac.o
+00:06:05   CC [M]  net/sunrpc/xprtrdma/svc_rdma_backchannel.o
+00:06:05   CC [M]  fs/xfs/libxfs/xfs_da_btree.o
+00:06:05   CC [M]  fs/afs/fs_operation.o
+00:06:05   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/msgbuf.o
+00:06:05   CC [M]  drivers/net/usb/gl620a.o
+00:06:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gk110.o
+00:06:06   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/main.o
+00:06:06   CC [M]  drivers/net/usb/net1080.o
+00:06:06   CC [M]  drivers/scsi/qla2xxx/qla_edif.o
+00:06:06   CC [M]  net/rxrpc/input.o
+00:06:06   LD [M]  drivers/net/wireless/intel/iwlwifi/dvm/iwldvm.o
+00:06:06   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/fw.o
+00:06:06   CC [M]  fs/afs/fs_probe.o
+00:06:06   CC [M]  drivers/gpu/drm/amd/amdgpu/mes_v10_1.o
+00:06:06   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.o
+00:06:06   CC [M]  net/sunrpc/xprtrdma/svc_rdma_transport.o
+00:06:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gk20a.o
+00:06:07   CC [M]  drivers/net/usb/plusb.o
+00:06:07   CC [M]  net/bluetooth/mgmt_util.o
+00:06:07   CC      drivers/usb/host/ohci-pci.o
+00:06:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gm107.o
+00:06:07   CC [M]  drivers/gpu/drm/i915/display/intel_display_power.o
+00:06:08   CC [M]  drivers/net/usb/rndis_host.o
+00:06:08   CC [M]  fs/afs/inode.o
+00:06:08   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.o
+00:06:08   CC      drivers/usb/host/uhci-hcd.o
+00:06:08   CC [M]  net/rxrpc/insecure.o
+00:06:08   CC [M]  net/sunrpc/xprtrdma/svc_rdma_sendto.o
+00:06:08   CC [M]  fs/xfs/libxfs/xfs_defer.o
+00:06:08   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/mac80211.o
+00:06:08   CC [M]  net/bluetooth/mgmt_config.o
+00:06:08   CC [M]  drivers/scsi/qla2xxx/tcm_qla2xxx.o
+00:06:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gm200.o
+00:06:08   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcmsdh.o
+00:06:08   CC [M]  drivers/net/usb/cdc_subset.o
+00:06:09   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_ethtool.o
+00:06:09   CC [M]  net/rxrpc/key.o
+00:06:09   CC [M]  fs/afs/main.o
+00:06:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gm20b.o
+00:06:09   CC [M]  drivers/gpu/drm/amd/amdgpu/uvd_v5_0.o
+00:06:09   CC [M]  net/bluetooth/sco.o
+00:06:09   CC [M]  drivers/net/usb/zaurus.o
+00:06:09   CC [M]  net/sunrpc/xprtrdma/svc_rdma_recvfrom.o
+00:06:09   LD [M]  drivers/scsi/qla2xxx/qla2xxx.o
+00:06:09   CC [M]  drivers/net/wireless/ath/ath10k/debug.o
+00:06:09   CC [M]  drivers/scsi/qla4xxx/ql4_os.o
+00:06:10   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy_shim.o
+00:06:10   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/usb.o
+00:06:10   CC      drivers/usb/host/xhci.o
+00:06:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gp100.o
+00:06:10   CC [M]  fs/xfs/libxfs/xfs_dir2.o
+00:06:10   CC [M]  drivers/net/usb/mcs7830.o
+00:06:10   CC [M]  drivers/gpu/drm/i915/display/intel_dmc.o
+00:06:10   CC [M]  drivers/gpu/drm/amd/amdgpu/uvd_v6_0.o
+00:06:10   CC [M]  net/rxrpc/local_event.o
+00:06:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gp102.o
+00:06:10   CC [M]  net/bluetooth/leds.o
+00:06:11   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/nvm.o
+00:06:11   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/pmu.o
+00:06:11   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.o
+00:06:11   CC [M]  net/sunrpc/xprtrdma/svc_rdma_rw.o
+00:06:11   CC [M]  drivers/net/usb/usbnet.o
+00:06:11   CC [M]  drivers/net/wireless/ath/ath10k/core.o
+00:06:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gp10b.o
+00:06:11   CC [M]  fs/afs/misc.o
+00:06:11   CC [M]  net/rxrpc/local_object.o
+00:06:11   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/rate.o
+00:06:11   CC [M]  drivers/gpu/drm/i915/display/intel_dpio_phy.o
+00:06:11   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_stats.o
+00:06:11   CC [M]  net/bluetooth/msft.o
+00:06:12   CC [M]  drivers/gpu/drm/amd/amdgpu/uvd_v7_0.o
+00:06:12   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/dmi.o
+00:06:12   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/ops.o
+00:06:12   CC [M]  fs/xfs/libxfs/xfs_dir2_block.o
+00:06:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gv100.o
+00:06:12   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/stf.o
+00:06:12   CC [M]  net/sunrpc/xprtrdma/svc_rdma_pcl.o
+00:06:12   CC [M]  drivers/net/usb/int51x1.o
+00:06:12   CC [M]  fs/afs/mntpt.o
+00:06:12   CC      drivers/usb/host/xhci-mem.o
+00:06:12   CC [M]  net/bluetooth/aosp.o
+00:06:13   CC [M]  net/rxrpc/misc.o
+00:06:13   LD [M]  drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.o
+00:06:13   CC [M]  drivers/scsi/lpfc/lpfc_mem.o
+00:06:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ga100.o
+00:06:13   CC [M]  drivers/gpu/drm/i915/display/intel_dpll.o
+00:06:13   CC [M]  drivers/net/usb/kalmia.o
+00:06:13   CC [M]  drivers/net/wireless/ath/ath10k/htc.o
+00:06:13   CC [M]  drivers/scsi/qla4xxx/ql4_init.o
+00:06:13   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/aiutils.o
+00:06:13   CC [M]  fs/afs/rotate.o
+00:06:13   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_dcb.o
+00:06:13   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/phy-ctxt.o
+00:06:13   CC [M]  net/bluetooth/6lowpan.o
+00:06:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ga102.o
+00:06:14   CC [M]  net/sunrpc/xprtrdma/module.o
+00:06:14   CC [M]  drivers/scsi/lpfc/lpfc_sli.o
+00:06:14   CC [M]  net/rxrpc/net_ns.o
+00:06:14   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vce.o
+00:06:14   CC [M]  drivers/net/usb/ipheth.o
+00:06:14   CC      drivers/usb/host/xhci-ext-caps.o
+00:06:14   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phy_cmn.o
+00:06:14   CC [M]  fs/xfs/libxfs/xfs_dir2_data.o
+00:06:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ram.o
+00:06:14   CC [M]  drivers/net/wireless/ath/ath10k/htt.o
+00:06:14   CC [M]  fs/afs/rxrpc.o
+00:06:15   CC      drivers/usb/host/xhci-ring.o
+00:06:15   CC [M]  net/rxrpc/output.o
+00:06:15   CC [M]  drivers/gpu/drm/i915/display/intel_dpll_mgr.o
+00:06:15   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/mac-ctxt.o
+00:06:15   CC [M]  drivers/net/usb/sierra_net.o
+00:06:15   CC [M]  drivers/scsi/qla4xxx/ql4_mbx.o
+00:06:15   LD [M]  net/bluetooth/bluetooth.o
+00:06:15   LD [M]  net/bluetooth/bluetooth_6lowpan.o
+00:06:15   CC [M]  drivers/net/wireless/marvell/libertas_tf/main.o
+00:06:15   CC [M]  drivers/gpu/drm/amd/amdgpu/vce_v3_0.o
+00:06:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv04.o
+00:06:15   CC [M]  fs/xfs/libxfs/xfs_dir2_leaf.o
+00:06:15   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_sp.o
+00:06:15   CC [M]  drivers/net/wireless/ath/ath10k/htt_rx.o
+00:06:16   CC [M]  drivers/net/usb/cx82310_eth.o
+00:06:16   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phy_lcn.o
+00:06:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv10.o
+00:06:16   CC [M]  fs/afs/security.o
+00:06:16   CC [M]  net/rxrpc/peer_event.o
+00:06:16   CC [M]  drivers/net/wireless/marvell/libertas_tf/cmd.o
+00:06:16   CC [M]  drivers/gpu/drm/amd/amdgpu/vce_v4_0.o
+00:06:16   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/utils.o
+00:06:16   CC [M]  drivers/scsi/qla4xxx/ql4_iocb.o
+00:06:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv1a.o
+00:06:17   CC [M]  drivers/net/usb/cdc_ncm.o
+00:06:17   CC      drivers/usb/host/xhci-hub.o
+00:06:17   CC [M]  fs/afs/server.o
+00:06:17   CC [M]  drivers/gpu/drm/i915/display/intel_dpt.o
+00:06:17   CC [M]  net/rxrpc/peer_object.o
+00:06:17   CC [M]  drivers/net/wireless/marvell/libertas_tf/if_usb.o
+00:06:17   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_vcn.o
+00:06:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv20.o
+00:06:18   CC [M]  fs/xfs/libxfs/xfs_dir2_node.o
+00:06:18   CC [M]  drivers/scsi/qla4xxx/ql4_isr.o
+00:06:18   CC [M]  net/sunrpc/xprtrdma/backchannel.o
+00:06:18   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/rx.o
+00:06:18   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phy_n.o
+00:06:18   CC [M]  drivers/net/wireless/ath/ath10k/htt_tx.o
+00:06:18   CC [M]  drivers/net/usb/huawei_cdc_ncm.o
+00:06:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv40.o
+00:06:18   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_self_test.o
+00:06:18   CC [M]  drivers/gpu/drm/i915/display/intel_drrs.o
+00:06:18   CC      drivers/usb/host/xhci-dbg.o
+00:06:18   LD [M]  drivers/net/wireless/marvell/libertas_tf/libertas_tf.o
+00:06:18   CC [M]  net/rxrpc/recvmsg.o
+00:06:18   CC [M]  fs/afs/server_list.o
+00:06:18   LD [M]  drivers/net/wireless/marvell/libertas_tf/libertas_tf_usb.o
+00:06:18   CC [M]  drivers/net/wireless/marvell/mwifiex/main.o
+00:06:19   CC [M]  drivers/gpu/drm/amd/amdgpu/vcn_v1_0.o
+00:06:19   CC [M]  drivers/net/usb/lg-vl600.o
+00:06:19   CC      drivers/usb/host/xhci-trace.o
+00:06:19   LD [M]  net/sunrpc/xprtrdma/rpcrdma.o
+00:06:19   CC [M]  net/sunrpc/clnt.o
+00:06:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv41.o
+00:06:19   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_vfpf.o
+00:06:19   CC [M]  drivers/scsi/qla4xxx/ql4_nx.o
+00:06:19   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/rxmq.o
+00:06:19   CC [M]  drivers/gpu/drm/i915/display/intel_dsb.o
+00:06:20   CC [M]  fs/afs/super.o
+00:06:20   CC [M]  drivers/net/wireless/ath/ath10k/txrx.o
+00:06:20   CC [M]  drivers/net/usb/qmi_wwan.o
+00:06:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv44.o
+00:06:20   CC [M]  net/rxrpc/rtt.o
+00:06:20   CC [M]  fs/xfs/libxfs/xfs_dir2_sf.o
+00:06:20   CC [M]  drivers/net/wireless/marvell/mwifiex/init.o
+00:06:21   CC      drivers/usb/host/xhci-dbgcap.o
+00:06:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv49.o
+00:06:21   CC [M]  drivers/net/usb/cdc_mbim.o
+00:06:21   CC [M]  drivers/gpu/drm/i915/display/intel_fb.o
+00:06:21   CC [M]  drivers/net/wireless/ath/ath10k/wmi.o
+00:06:21   CC [M]  fs/afs/vlclient.o
+00:06:21   CC [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x_sriov.o
+00:06:21   CC [M]  net/rxrpc/security.o
+00:06:21   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/tx.o
+00:06:21   CC [M]  drivers/scsi/lpfc/lpfc_ct.o
+00:06:21   CC [M]  net/sunrpc/xprt.o
+00:06:21   CC [M]  drivers/gpu/drm/amd/amdgpu/vcn_v2_0.o
+00:06:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv4e.o
+00:06:21   CC [M]  drivers/net/wireless/marvell/mwifiex/cfp.o
+00:06:21   CC [M]  drivers/scsi/qla4xxx/ql4_nvram.o
+00:06:22   CC      drivers/usb/host/xhci-dbgtty.o
+00:06:22   CC [M]  drivers/net/usb/ch9200.o
+00:06:22   CC [M]  net/rxrpc/sendmsg.o
+00:06:22   CC [M]  fs/afs/vl_alias.o
+00:06:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramnv50.o
+00:06:22   CC [M]  drivers/gpu/drm/i915/display/intel_fbc.o
+00:06:22   CC [M]  fs/xfs/libxfs/xfs_dquot_buf.o
+00:06:22   CC      drivers/usb/host/xhci-debugfs.o
+00:06:23   CC [M]  drivers/net/usb/aqc111.o
+00:06:23   CC [M]  drivers/net/wireless/marvell/mwifiex/cmdevt.o
+00:06:23   CC [M]  drivers/scsi/qla4xxx/ql4_dbg.o
+00:06:23   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/binding.o
+00:06:23   LD [M]  drivers/net/ethernet/broadcom/bnx2x/bnx2x.o
+00:06:23   CC [M]  net/sunrpc/socklib.o
+00:06:23   CC [M]  fs/xfs/libxfs/xfs_ialloc.o
+00:06:23   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt.o
+00:06:23   CC [M]  drivers/scsi/lpfc/lpfc_els.o
+00:06:23   CC [M]  fs/afs/vl_list.o
+00:06:23   CC      drivers/usb/host/xhci-pci.o
+00:06:23   CC [M]  net/rxrpc/server_key.o
+00:06:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgt215.o
+00:06:24   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phytbl_lcn.o
+00:06:24   CC [M]  drivers/scsi/qla4xxx/ql4_attr.o
+00:06:24   CC [M]  drivers/net/usb/r8153_ecm.o
+00:06:24   CC [M]  drivers/gpu/drm/i915/display/intel_fdi.o
+00:06:24   CC [M]  drivers/gpu/drm/amd/amdgpu/vcn_v2_5.o
+00:06:24   CC [M]  net/sunrpc/xprtsock.o
+00:06:24   CC [M]  drivers/net/wireless/marvell/mwifiex/util.o
+00:06:24   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/quota.o
+00:06:24   CC      drivers/usb/host/xhci-pci-renesas.o
+00:06:24   CC [M]  fs/afs/vl_probe.o
+00:06:24   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phytbl_n.o
+00:06:24   LD [M]  drivers/net/usb/asix.o
+00:06:24   CC [M]  net/rxrpc/skbuff.o
+00:06:25   CC [M]  drivers/net/wireless/ath/wcn36xx/main.o
+00:06:25   CC [M]  drivers/net/wireless/ath/ath10k/wmi-tlv.o
+00:06:25   CC [M]  drivers/scsi/qla4xxx/ql4_bsg.o
+00:06:25   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/phy/phy_qmath.o
+00:06:25   CC [M]  drivers/gpu/drm/i915/display/intel_fifo_underrun.o
+00:06:25   CC [M]  drivers/usb/host/xhci-plat.o
+00:06:25   CC [M]  drivers/net/wireless/marvell/mwifiex/txrx.o
+00:06:25   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/sta.o
+00:06:25   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/dma.o
+00:06:25   CC [M]  fs/afs/vl_rotate.o
+00:06:26   CC [M]  net/rxrpc/utils.o
+00:06:26   CC [M]  fs/xfs/libxfs/xfs_ialloc_btree.o
+00:06:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/rammcp77.o
+00:06:26   CC [M]  drivers/net/wireless/ath/wcn36xx/dxe.o
+00:06:26   CC [M]  drivers/usb/host/sl811-hcd.o
+00:06:26   CC [M]  net/sunrpc/sched.o
+00:06:26   CC [M]  drivers/scsi/qla4xxx/ql4_83xx.o
+00:06:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgf100.o
+00:06:26   CC [M]  drivers/net/wireless/marvell/mwifiex/wmm.o
+00:06:26   CC [M]  drivers/gpu/drm/i915/display/intel_frontbuffer.o
+00:06:26   CC [M]  fs/afs/volume.o
+00:06:27   CC [M]  net/rxrpc/proc.o
+00:06:27   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_events.o
+00:06:27   CC [M]  drivers/scsi/lpfc/lpfc_hbadisc.o
+00:06:27   LD [M]  drivers/usb/host/xhci-plat-hcd.o
+00:06:27   AR      drivers/usb/host/built-in.a
+00:06:27   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/debug.o
+00:06:27   AR      drivers/usb/storage/built-in.a
+00:06:27   CC [M]  drivers/usb/storage/uas.o
+00:06:27   CC [M]  drivers/net/wireless/ath/ath10k/bmi.o
+00:06:27   CC [M]  drivers/net/wireless/ath/wcn36xx/txrx.o
+00:06:27   CC [M]  drivers/gpu/drm/amd/amdgpu/vcn_v3_0.o
+00:06:28   CC [M]  fs/xfs/libxfs/xfs_iext_tree.o
+00:06:28   CC [M]  fs/afs/write.o
+00:06:28   LD [M]  drivers/scsi/qla4xxx/qla4xxx.o
+00:06:28   CC [M]  drivers/gpu/drm/i915/display/intel_global_state.o
+00:06:28   CC [M]  drivers/net/wireless/ath/ath10k/hw.o
+00:06:28   CC [M]  net/rxrpc/rxkad.o
+00:06:28   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/sf.o
+00:06:28   CC [M]  drivers/net/wireless/marvell/mwifiex/11n.o
+00:06:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgf108.o
+00:06:28   CC [M]  drivers/usb/storage/scsiglue.o
+00:06:28   CC [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/led.o
+00:06:28   CC      drivers/gpu/drm/drm_crtc_helper.o
+00:06:28   CC [M]  drivers/net/wireless/ath/wcn36xx/smd.o
+00:06:29   CC [M]  drivers/gpu/drm/i915/display/intel_hdcp.o
+00:06:29   CC [M]  drivers/net/wireless/ath/ath10k/p2p.o
+00:06:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgk104.o
+00:06:29   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_hwrm.o
+00:06:29   CC [M]  drivers/usb/storage/protocol.o
+00:06:29   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/scan.o
+00:06:29   CC [M]  fs/afs/xattr.o
+00:06:29   LD [M]  drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcmsmac.o
+00:06:29   CC [M]  drivers/net/wireless/marvell/mwifiex/11ac.o
+00:06:29   AR      drivers/net/wireless/broadcom/built-in.a
+00:06:29   CC [M]  net/rxrpc/sysctl.o
+00:06:29   CC [M]  drivers/net/wireless/ath/ath10k/swap.o
+00:06:29   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-io.o
+00:06:30   CC [M]  drivers/usb/storage/transport.o
+00:06:30   CC [M]  fs/xfs/libxfs/xfs_inode_fork.o
+00:06:30   CC      drivers/input/serio/serio.o
+00:06:30   CC [M]  drivers/scsi/lpfc/lpfc_init.o
+00:06:30   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_sriov.o
+00:06:30   CC [M]  fs/afs/yfsclient.o
+00:06:30   CC [M]  drivers/net/wireless/ath/wcn36xx/pmc.o
+00:06:30   LD [M]  net/rxrpc/rxrpc.o
+00:06:30   CC [M]  drivers/net/wireless/marvell/mwifiex/11n_aggr.o
+00:06:30   CC [M]  drivers/scsi/lpfc/lpfc_mbox.o
+00:06:30   CC [M]  drivers/net/wireless/ath/ath10k/thermal.o
+00:06:30   CC      drivers/input/serio/i8042.o
+00:06:31   CC [M]  drivers/usb/storage/usb.o
+00:06:31   AR      drivers/net/ethernet/broadcom/built-in.a
+00:06:31   CC [M]  drivers/net/ipvlan/ipvlan_core.o
+00:06:31   CC [M]  drivers/gpu/drm/i915/display/intel_hotplug.o
+00:06:31   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_jpeg.o
+00:06:31   CC [M]  drivers/net/wireless/ath/wcn36xx/debug.o
+00:06:31   CC [M]  net/sunrpc/auth.o
+00:06:31   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/time-event.o
+00:06:31   CC [M]  drivers/usb/storage/initializers.o
+00:06:31   CC [M]  drivers/net/wireless/marvell/mwifiex/11n_rxreorder.o
+00:06:32   CC [M]  drivers/net/wireless/ath/ath10k/debugfs_sta.o
+00:06:32   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_ethtool.o
+00:06:32   CC      drivers/input/serio/libps2.o
+00:06:32   CC      drivers/usb/serial/usb-serial.o
+00:06:32   CC [M]  fs/xfs/libxfs/xfs_inode_buf.o
+00:06:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgm107.o
+00:06:32   CC [M]  drivers/net/ipvlan/ipvlan_main.o
+00:06:32   CC [M]  fs/afs/proc.o
+00:06:32   CC [M]  drivers/usb/storage/sierra_ms.o
+00:06:32   CC [M]  drivers/gpu/drm/i915/display/intel_lpe_audio.o
+00:06:32   CC [M]  drivers/gpu/drm/amd/amdgpu/jpeg_v1_0.o
+00:06:32   LD [M]  drivers/net/wireless/ath/wcn36xx/wcn36xx.o
+00:06:32   CC [M]  drivers/input/serio/serport.o
+00:06:32   CC [M]  drivers/usb/misc/sisusbvga/sisusb.o
+00:06:33   CC [M]  drivers/usb/storage/option_ms.o
+00:06:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgm200.o
+00:06:33   CC      drivers/usb/serial/generic.o
+00:06:33   CC [M]  net/sunrpc/auth_null.o
+00:06:33   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/rs.o
+00:06:33   CC [M]  drivers/net/wireless/marvell/mwifiex/scan.o
+00:06:33   CC [M]  drivers/input/serio/serio_raw.o
+00:06:33   CC [M]  fs/xfs/libxfs/xfs_log_rlimit.o
+00:06:33   CC [M]  drivers/net/wireless/ath/ath10k/wow.o
+00:06:33   LD [M]  fs/afs/kafs.o
+00:06:33   CC [M]  net/sunrpc/auth_unix.o
+00:06:33   CC [M]  drivers/net/ipvlan/ipvlan_l3s.o
+00:06:33   CC [M]  drivers/gpu/drm/amd/amdgpu/jpeg_v2_0.o
+00:06:33   CC [M]  drivers/gpu/drm/i915/display/intel_overlay.o
+00:06:33   CC [M]  drivers/usb/storage/usual-tables.o
+00:06:33   CC [M]  drivers/input/serio/altera_ps2.o
+00:06:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgp100.o
+00:06:34   CC      drivers/usb/serial/bus.o
+00:06:34   CC [M]  fs/xfs/libxfs/xfs_ag_resv.o
+00:06:34   CC [M]  drivers/scsi/elx/efct/efct_driver.o
+00:06:34   CC [M]  drivers/usb/storage/alauda.o
+00:06:34   LD [M]  drivers/usb/misc/sisusbvga/sisusbvga.o
+00:06:34   AR      drivers/usb/misc/built-in.a
+00:06:34   CC [M]  drivers/usb/misc/adutux.o
+00:06:34   CC [M]  drivers/input/serio/arc_ps2.o
+00:06:34   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_dcb.o
+00:06:34   CC      drivers/usb/serial/console.o
+00:06:34   CC [M]  net/sunrpc/svc.o
+00:06:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramga102.o
+00:06:34   CC [M]  drivers/net/ipvlan/ipvtap.o
+00:06:34   CC [M]  drivers/net/wireless/ath/ath10k/coredump.o
+00:06:34   CC [M]  drivers/input/serio/hyperv-keyboard.o
+00:06:35   CC [M]  drivers/net/wireless/marvell/mwifiex/join.o
+00:06:35   CC [M]  drivers/gpu/drm/amd/amdgpu/jpeg_v2_5.o
+00:06:35   CC [M]  drivers/usb/misc/appledisplay.o
+00:06:35   CC [M]  drivers/usb/serial/aircable.o
+00:06:35   CC [M]  drivers/scsi/elx/efct/efct_io.o
+00:06:35   CC [M]  drivers/gpu/drm/i915/display/intel_psr.o
+00:06:35   CC [M]  drivers/usb/storage/cypress_atacb.o
+00:06:35   AR      drivers/input/serio/built-in.a
+00:06:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/sddr2.o
+00:06:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/sddr3.o
+00:06:35   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/rs-fw.o
+00:06:35   CC [M]  drivers/usb/serial/ark3116.o
+00:06:35   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_ulp.o
+00:06:35   LD [M]  drivers/net/ipvlan/ipvlan.o
+00:06:35   CC      drivers/gpu/drm/drm_dp_helper.o
+00:06:35   CC [M]  drivers/usb/misc/emi26.o
+00:06:35   CC [M]  fs/xfs/libxfs/xfs_rmap.o
+00:06:36   CC [M]  drivers/scsi/elx/efct/efct_scsi.o
+00:06:36   CC [M]  drivers/net/wireless/ath/ath10k/ce.o
+00:06:36   CC [M]  drivers/usb/storage/datafab.o
+00:06:36   CC [M]  drivers/scsi/lpfc/lpfc_nportdisc.o
+00:06:36   CC [M]  drivers/gpu/drm/amd/amdgpu/jpeg_v3_0.o
+00:06:36   AR      drivers/net/wireless/marvell/built-in.a
+00:06:36   CC [M]  net/kcm/kcmsock.o
+00:06:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gddr3.o
+00:06:36   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_ioctl.o
+00:06:36   CC [M]  drivers/usb/misc/emi62.o
+00:06:36   CC [M]  drivers/usb/serial/belkin_sa.o
+00:06:36   CC [M]  net/sunrpc/svcsock.o
+00:06:36   CC [M]  drivers/usb/storage/ene_ub6250.o
+00:06:36   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/power.o
+00:06:36   CC [M]  drivers/usb/misc/ezusb.o
+00:06:37   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.o
+00:06:37   CC [M]  drivers/scsi/elx/efct/efct_xport.o
+00:06:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fb/gddr5.o
+00:06:37   CC [M]  drivers/usb/serial/ch341.o
+00:06:37   CC [M]  drivers/gpu/drm/amd/amdgpu/athub_v1_0.o
+00:06:37   CC [M]  drivers/gpu/drm/i915/display/intel_quirks.o
+00:06:37   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-drv.o
+00:06:37   CC [M]  drivers/usb/misc/apple-mfi-fastcharge.o
+00:06:37   CC [M]  drivers/net/wireless/ath/ath10k/pci.o
+00:06:37   CC [M]  drivers/scsi/lpfc/lpfc_scsi.o
+00:06:37   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_cmd.o
+00:06:37   CC [M]  drivers/usb/serial/cp210x.o
+00:06:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fuse/base.o
+00:06:37   CC [M]  drivers/usb/misc/idmouse.o
+00:06:38   CC [M]  net/kcm/kcmproc.o
+00:06:38   CC [M]  drivers/usb/storage/freecom.o
+00:06:38   CC [M]  drivers/scsi/elx/efct/efct_hw.o
+00:06:38   CC [M]  drivers/gpu/drm/amd/amdgpu/athub_v2_0.o
+00:06:38   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_ptp.o
+00:06:38   CC [M]  net/sunrpc/svcauth.o
+00:06:38   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/coex.o
+00:06:38   CC [M]  drivers/usb/misc/iowarrior.o
+00:06:38   CC [M]  drivers/gpu/drm/i915/display/intel_sprite.o
+00:06:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fuse/nv50.o
+00:06:38   CC [M]  drivers/net/wireless/ath/ath11k/core.o
+00:06:38   CC [M]  drivers/usb/storage/isd200.o
+00:06:38   CC [M]  fs/xfs/libxfs/xfs_rmap_btree.o
+00:06:38   CC [M]  drivers/usb/serial/cyberjack.o
+00:06:39   CC [M]  drivers/gpu/drm/amd/amdgpu/athub_v2_1.o
+00:06:39   CC [M]  drivers/usb/misc/isight_firmware.o
+00:06:39   LD [M]  net/kcm/kcm.o
+00:06:39   CC [M]  drivers/usb/storage/jumpshot.o
+00:06:39   CC [M]  drivers/net/wireless/marvell/mwifiex/uap_cmd.o
+00:06:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fuse/gf100.o
+00:06:39   CC [M]  net/sunrpc/svcauth_unix.o
+00:06:39   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_vfr.o
+00:06:39   CC [M]  drivers/usb/serial/cypress_m8.o
+00:06:39   CC [M]  drivers/gpu/drm/amd/amdgpu/smuio_v9_0.o
+00:06:39   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/tt.o
+00:06:39   CC [M]  drivers/usb/misc/usblcd.o
+00:06:39   CC [M]  drivers/net/wireless/ath/ath10k/sdio.o
+00:06:39   CC [M]  drivers/scsi/elx/efct/efct_hw_queues.o
+00:06:39   CC [M]  drivers/usb/storage/karma.o
+00:06:40   CC [M]  drivers/net/wireless/ath/ath11k/hal.o
+00:06:40   CC [M]  drivers/net/ethernet/brocade/bna/bnad.o
+00:06:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/fuse/gm107.o
+00:06:40   CC [M]  drivers/usb/misc/ldusb.o
+00:06:40   CC [M]  drivers/gpu/drm/i915/display/intel_tc.o
+00:06:40   CC [M]  drivers/usb/serial/usb_debug.o
+00:06:40   CC [M]  drivers/net/wireless/marvell/mwifiex/ie.o
+00:06:40   CC [M]  drivers/gpu/drm/amd/amdgpu/smuio_v11_0.o
+00:06:40   CC [M]  drivers/usb/storage/onetouch.o
+00:06:40   CC [M]  fs/xfs/libxfs/xfs_refcount.o
+00:06:40   CC [M]  drivers/scsi/lpfc/lpfc_attr.o
+00:06:40   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_devlink.o
+00:06:40   CC [M]  net/sunrpc/addr.o
+00:06:40   CC [M]  drivers/usb/misc/legousbtower.o
+00:06:40   CC [M]  drivers/usb/serial/digi_acceleport.o
+00:06:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/base.o
+00:06:40   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/offloading.o
+00:06:41   CC [M]  drivers/scsi/elx/efct/efct_lio.o
+00:06:41   CC [M]  drivers/gpu/drm/amd/amdgpu/smuio_v11_0_6.o
+00:06:41   CC [M]  drivers/usb/storage/realtek_cr.o
+00:06:41   CC [M]  drivers/net/wireless/ath/ath11k/hal_tx.o
+00:06:41   CC [M]  drivers/net/wireless/ath/ath10k/usb.o
+00:06:41   CC [M]  drivers/usb/misc/trancevibrator.o
+00:06:41   CC [M]  drivers/gpu/drm/i915/display/intel_vga.o
+00:06:41   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_cmdresp.o
+00:06:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/nv10.o
+00:06:41   CC [M]  net/sunrpc/rpcb_clnt.o
+00:06:41   CC [M]  drivers/usb/serial/io_edgeport.o
+00:06:42   CC [M]  drivers/usb/misc/uss720.o
+00:06:42   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_dim.o
+00:06:42   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/tdls.o
+00:06:42   CC [M]  drivers/usb/storage/sddr09.o
+00:06:42   CC [M]  drivers/gpu/drm/amd/amdgpu/smuio_v13_0.o
+00:06:42   CC [M]  drivers/scsi/elx/efct/efct_unsol.o
+00:06:42   CC [M]  drivers/net/ethernet/brocade/bna/bnad_ethtool.o
+00:06:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/nv50.o
+00:06:42   CC [M]  drivers/net/wireless/ath/ath11k/hal_rx.o
+00:06:42   CC [M]  drivers/usb/misc/usbsevseg.o
+00:06:42   CC [M]  drivers/gpu/drm/i915/display/i9xx_plane.o
+00:06:42   LD [M]  drivers/net/wireless/ath/ath10k/ath10k_core.o
+00:06:42   LD [M]  drivers/net/wireless/ath/ath10k/ath10k_pci.o
+00:06:42   LD [M]  drivers/net/wireless/ath/ath10k/ath10k_sdio.o
+00:06:42   LD [M]  drivers/net/wireless/ath/ath10k/ath10k_usb.o
+00:06:42   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_event.o
+00:06:42   CC [M]  fs/nilfs2/inode.o
+00:06:43   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_coredump.o
+00:06:43   CC [M]  fs/xfs/libxfs/xfs_refcount_btree.o
+00:06:43   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_reset.o
+00:06:43   CC [M]  drivers/scsi/elx/libefc/efc_cmds.o
+00:06:43   CC [M]  net/sunrpc/timer.o
+00:06:43   CC [M]  drivers/usb/serial/io_ti.o
+00:06:43   CC [M]  drivers/usb/storage/sddr55.o
+00:06:43   CC [M]  drivers/usb/misc/yurex.o
+00:06:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/g94.o
+00:06:43   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/ftm-responder.o
+00:06:43   CC [M]  drivers/scsi/lpfc/lpfc_vport.o
+00:06:43   CC [M]  drivers/net/ethernet/brocade/bna/bnad_debugfs.o
+00:06:43   CC [M]  drivers/usb/misc/usb251xb.o
+00:06:44   CC [M]  fs/nilfs2/file.o
+00:06:44   CC [M]  drivers/gpu/drm/amd/amdgpu/mca_v3_0.o
+00:06:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/gf119.o
+00:06:44   CC [M]  drivers/scsi/elx/libefc/efc_domain.o
+00:06:44   CC [M]  net/sunrpc/xdr.o
+00:06:44   CC [M]  drivers/usb/storage/shuttle_usbat.o
+00:06:44   CC [M]  drivers/net/wireless/marvell/mwifiex/uap_event.o
+00:06:44   CC [M]  drivers/net/wireless/ath/ath11k/wmi.o
+00:06:44   CC [M]  drivers/gpu/drm/i915/display/skl_scaler.o
+00:06:44   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_tc.o
+00:06:44   CC [M]  drivers/usb/serial/empeg.o
+00:06:44   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/ftm-initiator.o
+00:06:44   CC [M]  drivers/scsi/lpfc/lpfc_debugfs.o
+00:06:44   CC [M]  drivers/usb/misc/usb3503.o
+00:06:44   CC [M]  fs/nilfs2/dir.o
+00:06:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/gk104.o
+00:06:45   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.o
+00:06:45   CC [M]  drivers/net/ethernet/brocade/bna/bna_enet.o
+00:06:45   CC [M]  fs/xfs/libxfs/xfs_sb.o
+00:06:45   CC [M]  drivers/usb/serial/f81232.o
+00:06:45   LD [M]  drivers/usb/storage/usb-storage.o
+00:06:45   LD [M]  drivers/usb/storage/ums-alauda.o
+00:06:45   LD [M]  drivers/usb/storage/ums-cypress.o
+00:06:45   LD [M]  drivers/usb/storage/ums-datafab.o
+00:06:45   LD [M]  drivers/usb/storage/ums-eneub6250.o
+00:06:45   LD [M]  drivers/usb/storage/ums-freecom.o
+00:06:45   LD [M]  drivers/usb/storage/ums-isd200.o
+00:06:45   LD [M]  drivers/usb/storage/ums-jumpshot.o
+00:06:45   LD [M]  drivers/usb/storage/ums-karma.o
+00:06:45   LD [M]  drivers/usb/storage/ums-onetouch.o
+00:06:45   LD [M]  drivers/usb/storage/ums-realtek.o
+00:06:45   CC [M]  drivers/scsi/elx/libefc/efc_fabric.o
+00:06:45   LD [M]  drivers/usb/storage/ums-sddr09.o
+00:06:45   LD [M]  drivers/usb/storage/ums-sddr55.o
+00:06:45   LD [M]  drivers/usb/storage/ums-usbat.o
+00:06:45   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_tx.o
+00:06:45   CC [M]  net/sunrpc/sunrpc_syms.o
+00:06:45   CC [M]  drivers/usb/misc/usb4604.o
+00:06:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gpio/ga102.o
+00:06:45   CC [M]  drivers/gpu/drm/i915/display/skl_universal_plane.o
+00:06:45   CC [M]  fs/nilfs2/super.o
+00:06:45   CC [M]  drivers/usb/serial/f81534.o
+00:06:46   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_module.o
+00:06:46   CC [M]  fs/xfs/libxfs/xfs_symlink_remote.o
+00:06:46   CC [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_debugfs.o
+00:06:46   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/rfi.o
+00:06:46   CC [M]  drivers/net/ethernet/brocade/bna/bna_tx_rx.o
+00:06:46   CC [M]  drivers/scsi/elx/libefc/efc_node.o
+00:06:46   CC [M]  net/sunrpc/cache.o
+00:06:46   CC [M]  drivers/usb/misc/chaoskey.o
+00:06:46   CC [M]  drivers/net/wireless/marvell/mwifiex/sta_rx.o
+00:06:46   CC [M]  drivers/net/wireless/marvell/mwl8k.o
+00:06:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gsp/base.o
+00:06:46   CC [M]  fs/nilfs2/namei.o
+00:06:46   CC [M]  drivers/usb/serial/ftdi_sio.o
+00:06:46   CC [M]  fs/xfs/libxfs/xfs_trans_inode.o
+00:06:46   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device.o
+00:06:47   CC      drivers/input/keyboard/atkbd.o
+00:06:47   CC [M]  drivers/scsi/lpfc/lpfc_bsg.o
+00:06:47   LD [M]  drivers/net/ethernet/broadcom/bnxt/bnxt_en.o
+00:06:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/gsp/gv100.o
+00:06:47   CC [M]  drivers/net/ethernet/broadcom/b44.o
+00:06:47   CC [M]  drivers/scsi/elx/libefc/efc_nport.o
+00:06:47   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/debugfs.o
+00:06:47   CC [M]  drivers/net/wireless/marvell/mwifiex/uap_txrx.o
+00:06:47   CC [M]  drivers/gpu/drm/i915/display/intel_acpi.o
+00:06:47   CC [M]  drivers/net/wireless/ath/ath11k/mac.o
+00:06:47   CC [M]  fs/nilfs2/page.o
+00:06:47   CC [M]  fs/xfs/libxfs/xfs_trans_resv.o
+00:06:47   CC [M]  drivers/input/keyboard/applespi.o
+00:06:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/base.o
+00:06:48   CC [M]  drivers/usb/serial/garmin_gps.o
+00:06:48   CC [M]  drivers/net/ethernet/brocade/bna/bfa_msgq.o
+00:06:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_chardev.o
+00:06:48   CC [M]  net/sunrpc/rpc_pipe.o
+00:06:48   CC [M]  drivers/scsi/elx/libefc/efc_device.o
+00:06:48   CC [M]  drivers/net/wireless/marvell/mwifiex/cfg80211.o
+00:06:48   CC [M]  drivers/gpu/drm/i915/display/intel_opregion.o
+00:06:48   CC [M]  fs/nilfs2/mdt.o
+00:06:48   CC [M]  fs/xfs/libxfs/xfs_types.o
+00:06:48   CC [M]  drivers/net/ethernet/broadcom/bnx2.o
+00:06:48   CC [M]  drivers/usb/serial/ipaq.o
+00:06:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/nv04.o
+00:06:48   CC [M]  drivers/net/ethernet/brocade/bna/bfa_ioc.o
+00:06:49   CC      drivers/rtc/lib.o
+00:06:49   CC [M]  drivers/input/keyboard/cros_ec_keyb.o
+00:06:49   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/debugfs-vif.o
+00:06:49   CC [M]  drivers/usb/serial/ipw.o
+00:06:49   CC [M]  drivers/scsi/elx/libefc/efclib.o
+00:06:49   CC      drivers/rtc/class.o
+00:06:49   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_topology.o
+00:06:49   CC [M]  fs/nilfs2/btnode.o
+00:06:49   CC [M]  net/sunrpc/sysfs.o
+00:06:49   CC [M]  fs/xfs/libxfs/xfs_rtbitmap.o
+00:06:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/nv4e.o
+00:06:49   CC [M]  drivers/scsi/lpfc/lpfc_nvme.o
+00:06:49   CC [M]  drivers/gpu/drm/i915/display/intel_fbdev.o
+00:06:50   CC [M]  drivers/usb/serial/ir-usb.o
+00:06:50   CC      drivers/rtc/interface.o
+00:06:50   CC [M]  drivers/input/keyboard/gpio_keys.o
+00:06:50   CC [M]  drivers/scsi/elx/libefc/efc_sm.o
+00:06:50   CC [M]  drivers/net/ethernet/brocade/bna/bfa_ioc_ct.o
+00:06:50   CC [M]  fs/nilfs2/bmap.o
+00:06:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/nv50.o
+00:06:50   CC [M]  drivers/net/wireless/ath/ath11k/reg.o
+00:06:50   CC [M]  fs/xfs/xfs_aops.o
+00:06:50   CC [M]  drivers/usb/serial/iuu_phoenix.o
+00:06:50   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/led.o
+00:06:50   CC [M]  net/sunrpc/svc_xprt.o
+00:06:50   CC [M]  drivers/net/wireless/marvell/mwifiex/ethtool.o
+00:06:50   CC [M]  drivers/input/keyboard/gpio_keys_polled.o
+00:06:50   CC [M]  drivers/scsi/elx/libefc/efc_els.o
+00:06:51   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_pasid.o
+00:06:51   CC [M]  drivers/gpu/drm/i915/display/dvo_ch7017.o
+00:06:51   CC [M]  fs/nilfs2/btree.o
+00:06:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/g94.o
+00:06:51   CC [M]  drivers/net/ethernet/brocade/bna/bfa_cee.o
+00:06:51   CC      drivers/rtc/nvmem.o
+00:06:51   CC [M]  drivers/scsi/lpfc/lpfc_nvmet.o
+00:06:51   CC [M]  drivers/input/keyboard/qt1050.o
+00:06:51   CC [M]  drivers/usb/serial/keyspan.o
+00:06:51   CC      drivers/rtc/dev.o
+00:06:51   CC [M]  drivers/net/wireless/ath/ath11k/htc.o
+00:06:51   CC [M]  drivers/net/wireless/intel/iwlwifi/mvm/d3.o
+00:06:51   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_doorbell.o
+00:06:51   CC [M]  drivers/net/wireless/marvell/mwifiex/11h.o
+00:06:52   CC [M]  drivers/scsi/elx/libefc_sli/sli4.o
+00:06:52   CC [M]  drivers/net/ethernet/brocade/bna/cna_fwimg.o
+00:06:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/gf117.o
+00:06:52   CC      drivers/rtc/proc.o
+00:06:52   CC [M]  drivers/gpu/drm/i915/display/dvo_ch7xxx.o
+00:06:52   CC [M]  drivers/input/keyboard/qt1070.o
+00:06:52   CC [M]  net/sunrpc/xprtmultipath.o
+00:06:52   CC      drivers/rtc/sysfs.o
+00:06:52   CC [M]  fs/xfs/xfs_attr_inactive.o
+00:06:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/gf119.o
+00:06:52   CC [M]  fs/nilfs2/direct.o
+00:06:52   CC [M]  drivers/net/ethernet/broadcom/cnic.o
+00:06:52   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_flat_memory.o
+00:06:52   CC [M]  drivers/usb/serial/keyspan_pda.o
+00:06:52   CC [M]  drivers/net/wireless/marvell/mwifiex/tdls.o
+00:06:53   LD [M]  drivers/net/ethernet/brocade/bna/bna.o
+00:06:53   CC [M]  drivers/net/wireless/ath/ath11k/qmi.o
+00:06:53   AR      drivers/net/ethernet/brocade/built-in.a
+00:06:53   CC [M]  drivers/net/wireless/marvell/mwifiex/debugfs.o
+00:06:53   CC      drivers/rtc/rtc-mc146818-lib.o
+00:06:53   CC [M]  drivers/input/keyboard/tm2-touchkey.o
+00:06:53   LD [M]  drivers/scsi/lpfc/lpfc.o
+00:06:53   CC [M]  drivers/net/wireguard/main.o
+00:06:53   CC [M]  drivers/gpu/drm/i915/display/dvo_ivch.o
+00:06:53   CC [M]  fs/xfs/xfs_attr_list.o
+00:06:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/gk104.o
+00:06:53   CC [M]  fs/nilfs2/dat.o
+00:06:53   CC [M]  drivers/usb/serial/kl5kusb105.o
+00:06:53   CC      drivers/rtc/rtc-cmos.o
+00:06:53   CC [M]  net/sunrpc/debugfs.o
+00:06:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_process.o
+00:06:53   LD [M]  drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.o
+00:06:53   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-debug.o
+00:06:53   AR      drivers/input/keyboard/built-in.a
+00:06:53   LD [M]  drivers/scsi/elx/efct.o
+00:06:54   CC [M]  drivers/scsi/bfa/bfad.o
+00:06:54   CC      drivers/input/mouse/psmouse-base.o
+00:06:54   CC [M]  drivers/net/wireguard/noise.o
+00:06:54   CC [M]  drivers/usb/serial/kobil_sct.o
+00:06:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/gk110.o
+00:06:54   CC      drivers/input/mouse/synaptics.o
+00:06:54   CC [M]  fs/nilfs2/recovery.o
+00:06:54   CC [M]  drivers/net/wireless/marvell/mwifiex/sdio.o
+00:06:54   CC [M]  drivers/gpu/drm/i915/display/dvo_ns2501.o
+00:06:54   CC [M]  drivers/net/wireless/ath/ath11k/dp.o
+00:06:54   CC [M]  drivers/rtc/lib_test.o
+00:06:54   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-eeprom-read.o
+00:06:54   CC [M]  net/sunrpc/backchannel_rqst.o
+00:06:54   CC [M]  drivers/usb/serial/mct_u232.o
+00:06:54   CC [M]  drivers/net/wireless/ath/ath11k/dp_tx.o
+00:06:55   CC [M]  drivers/rtc/rtc-ab-eoz9.o
+00:06:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/gm200.o
+00:06:55   CC [M]  drivers/scsi/bfa/bfad_im.o
+00:06:55   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_queue.o
+00:06:55   CC [M]  fs/nilfs2/the_nilfs.o
+00:06:55   CC [M]  fs/xfs/xfs_bmap_util.o
+00:06:55   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-eeprom-parse.o
+00:06:55   CC [M]  drivers/net/wireguard/device.o
+00:06:55   CC [M]  drivers/gpu/drm/i915/display/dvo_sil164.o
+00:06:55   CC      drivers/input/mouse/focaltech.o
+00:06:55   CC [M]  drivers/usb/serial/mos7720.o
+00:06:55   CC [M]  net/sunrpc/stats.o
+00:06:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/pad.o
+00:06:55   CC [M]  drivers/rtc/rtc-abx80x.o
+00:06:55   CC [M]  fs/befs/datastream.o
+00:06:55   CC [M]  drivers/net/ethernet/broadcom/tg3.o
+00:06:56   CC      drivers/input/mouse/alps.o
+00:06:56   CC [M]  drivers/net/wireless/marvell/mwifiex/pcie.o
+00:06:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_mqd_manager.o
+00:06:56   CC [M]  fs/nilfs2/segbuf.o
+00:06:56   CC [M]  drivers/scsi/bfa/bfad_attr.o
+00:06:56   CC [M]  drivers/net/wireless/ath/ath11k/dp_rx.o
+00:06:56   CC [M]  fs/befs/btree.o
+00:06:56   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-phy-db.o
+00:06:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padnv04.o
+00:06:56   CC [M]  drivers/usb/serial/mos7840.o
+00:06:56   CC [M]  drivers/gpu/drm/i915/display/dvo_tfp410.o
+00:06:56   CC [M]  drivers/net/wireguard/peer.o
+00:06:56   CC [M]  drivers/rtc/rtc-bq32k.o
+00:06:57   CC [M]  net/sunrpc/sysctl.o
+00:06:57   CC [M]  fs/befs/super.o
+00:06:57   CC [M]  fs/nilfs2/segment.o
+00:06:57   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_mqd_manager_cik.o
+00:06:57   CC [M]  drivers/scsi/bfa/bfad_debugfs.o
+00:06:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padnv4e.o
+00:06:57   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-nvm-parse.o
+00:06:57   CC      drivers/input/mouse/byd.o
+00:06:57   CC [M]  fs/befs/inode.o
+00:06:57   CC [M]  drivers/rtc/rtc-cros-ec.o
+00:06:57   CC [M]  drivers/usb/serial/navman.o
+00:06:57   LD [M]  net/sunrpc/sunrpc.o
+00:06:57   CC [M]  drivers/gpu/drm/i915/display/g4x_dp.o
+00:06:57   CC [M]  net/atm/addr.o
+00:06:57   CC [M]  drivers/net/wireguard/timers.o
+00:06:57   CC [M]  fs/xfs/xfs_bio_io.o
+00:06:57   CC [M]  fs/befs/debug.o
+00:06:58   CC      drivers/input/mouse/elantech.o
+00:06:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padnv50.o
+00:06:58   CC [M]  drivers/rtc/rtc-ds1286.o
+00:06:58   CC [M]  drivers/net/wireless/marvell/mwifiex/pcie_quirks.o
+00:06:58   CC [M]  drivers/scsi/bfa/bfad_bsg.o
+00:06:58   CC [M]  drivers/usb/serial/omninet.o
+00:06:58   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_mqd_manager_vi.o
+00:06:58   CC [M]  fs/befs/io.o
+00:06:58   CC [M]  fs/xfs/xfs_buf.o
+00:06:58   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/drv.o
+00:06:58   CC [M]  drivers/rtc/rtc-ds1305.o
+00:06:58   CC [M]  drivers/usb/serial/opticon.o
+00:06:58   CC [M]  net/atm/pvc.o
+00:06:58   CC [M]  fs/befs/linuxvfs.o
+00:06:58   CC [M]  drivers/net/wireguard/queueing.o
+00:06:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padg94.o
+00:06:59   CC [M]  drivers/net/wireless/marvell/mwifiex/usb.o
+00:06:59   CC [M]  fs/nilfs2/cpfile.o
+00:06:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_mqd_manager_v9.o
+00:06:59   CC [M]  drivers/gpu/drm/i915/display/g4x_hdmi.o
+00:06:59   CC [M]  drivers/net/wireless/ath/ath11k/debug.o
+00:06:59   CC      drivers/input/mouse/logips2pp.o
+00:06:59   CC [M]  drivers/usb/serial/option.o
+00:06:59   CC [M]  drivers/rtc/rtc-ds1307.o
+00:06:59   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/rx.o
+00:06:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padgf119.o
+00:06:59   CC [M]  net/atm/signaling.o
+00:06:59   LD [M]  fs/befs/befs.o
+00:06:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/padgm200.o
+00:06:59   CC      drivers/input/mouse/lifebook.o
+00:06:59   CC [M]  drivers/scsi/bfa/bfa_ioc.o
+00:06:59   CC [M]  drivers/net/wireguard/send.o
+00:07:00   CC [M]  drivers/usb/serial/oti6858.o
+00:07:00   CC [M]  fs/nilfs2/sufile.o
+00:07:00   CC      drivers/input/mouse/sentelic.o
+00:07:00   CC [M]  drivers/net/wireless/ath/ath11k/ce.o
+00:07:00   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_mqd_manager_v10.o
+00:07:00   CC [M]  net/l2tp/l2tp_core.o
+00:07:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/bus.o
+00:07:00   CC [M]  drivers/gpu/drm/i915/display/icl_dsi.o
+00:07:00   CC [M]  drivers/rtc/rtc-ds1343.o
+00:07:00   CC [M]  net/atm/svc.o
+00:07:00   LD [M]  drivers/net/wireless/marvell/mwifiex/mwifiex.o
+00:07:00   LD [M]  drivers/net/wireless/marvell/mwifiex/mwifiex_sdio.o
+00:07:00   LD [M]  drivers/net/wireless/marvell/mwifiex/mwifiex_pcie.o
+00:07:00   CC [M]  drivers/usb/serial/pl2303.o
+00:07:00   LD [M]  drivers/net/wireless/marvell/mwifiex/mwifiex_usb.o
+00:07:00   CC [M]  net/l2tp/l2tp_ppp.o
+00:07:01   CC      drivers/input/mouse/trackpoint.o
+00:07:01   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/tx.o
+00:07:01   CC [M]  drivers/net/wireguard/receive.o
+00:07:01   CC [M]  fs/xfs/xfs_dir2_readdir.o
+00:07:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/busnv04.o
+00:07:01   CC [M]  fs/nilfs2/ifile.o
+00:07:01   CC [M]  drivers/rtc/rtc-ds1347.o
+00:07:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_kernel_queue.o
+00:07:01   CC [M]  drivers/usb/serial/qcaux.o
+00:07:01   CC      drivers/input/mouse/cypress_ps2.o
+00:07:01   CC [M]  drivers/net/wireless/ath/ath11k/peer.o
+00:07:01   CC [M]  net/atm/ioctl.o
+00:07:02   CC [M]  drivers/rtc/rtc-ds1374.o
+00:07:02   CC [M]  fs/nilfs2/alloc.o
+00:07:02   CC [M]  drivers/usb/serial/qcserial.o
+00:07:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/busnv4e.o
+00:07:02   CC [M]  drivers/rtc/rtc-ds1390.o
+00:07:02   CC      drivers/input/mouse/vmmouse.o
+00:07:02   CC [M]  drivers/scsi/bfa/bfa_ioc_cb.o
+00:07:02   CC [M]  net/l2tp/l2tp_ip.o
+00:07:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_packet_manager.o
+00:07:02   CC [M]  drivers/net/wireguard/socket.o
+00:07:02   CC [M]  drivers/usb/serial/quatech2.o
+00:07:02   CC      drivers/input/mouse/psmouse-smbus.o
+00:07:02   CC [M]  drivers/gpu/drm/i915/display/intel_backlight.o
+00:07:02   CC [M]  drivers/net/wireless/ath/ath11k/dbring.o
+00:07:02   CC [M]  net/atm/common.o
+00:07:02   CC [M]  fs/xfs/xfs_discard.o
+00:07:02   CC [M]  drivers/rtc/rtc-ds1511.o
+00:07:02   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/trans.o
+00:07:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/busnv50.o
+00:07:03   CC [M]  drivers/scsi/bfa/bfa_ioc_ct.o
+00:07:03   CC [M]  fs/nilfs2/gcinode.o
+00:07:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_packet_manager_vi.o
+00:07:03   CC [M]  drivers/net/ethernet/cisco/enic/enic_main.o
+00:07:03   CC [M]  drivers/rtc/rtc-ds1553.o
+00:07:03   CC [M]  drivers/net/ethernet/chelsio/inline_crypto/ch_ipsec/chcr_ipsec.o
+00:07:03   CC [M]  drivers/usb/serial/safe_serial.o
+00:07:03   CC [M]  net/l2tp/l2tp_netlink.o
+00:07:03   CC [M]  drivers/input/mouse/appletouch.o
+00:07:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/busgf119.o
+00:07:03   CC [M]  drivers/net/wireguard/peerlookup.o
+00:07:03   CC [M]  drivers/rtc/rtc-ds1672.o
+00:07:03   CC [M]  fs/nilfs2/ioctl.o
+00:07:03   CC [M]  drivers/net/wireless/ath/ath11k/hw.o
+00:07:04   CC [M]  drivers/usb/serial/sierra.o
+00:07:04   CC [M]  drivers/scsi/bfa/bfa_hw_cb.o
+00:07:04   CC [M]  net/atm/atm_misc.o
+00:07:04   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_packet_manager_v9.o
+00:07:04   CC [M]  drivers/input/mouse/bcm5974.o
+00:07:04   CC [M]  drivers/gpu/drm/i915/display/intel_crt.o
+00:07:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/bit.o
+00:07:04   CC [M]  drivers/rtc/rtc-ds1685.o
+00:07:04   CC [M]  fs/xfs/xfs_error.o
+00:07:04   LD [M]  drivers/net/ethernet/chelsio/inline_crypto/ch_ipsec/ch_ipsec.o
+00:07:04   CC [M]  drivers/net/ethernet/chelsio/inline_crypto/ch_ktls/chcr_ktls.o
+00:07:04   CC [M]  drivers/scsi/bfa/bfa_hw_ct.o
+00:07:04   CC [M]  drivers/net/wireguard/allowedips.o
+00:07:04   CC [M]  net/l2tp/l2tp_eth.o
+00:07:04   CC [M]  drivers/usb/serial/usb-serial-simple.o
+00:07:04   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/ctxt-info.o
+00:07:04   CC [M]  fs/nilfs2/sysfs.o
+00:07:05   CC [M]  drivers/input/mouse/cyapa.o
+00:07:05   CC [M]  net/atm/raw.o
+00:07:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/aux.o
+00:07:05   CC [M]  drivers/net/wireless/ath/ath11k/wow.o
+00:07:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_process_queue_manager.o
+00:07:05   CC [M]  drivers/usb/serial/spcp8x5.o
+00:07:05   CC [M]  drivers/rtc/rtc-ds1742.o
+00:07:05   CC [M]  fs/xfs/xfs_export.o
+00:07:05   CC [M]  drivers/scsi/bfa/bfa_fcs.o
+00:07:05   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/ctxt-info-gen3.o
+00:07:05   CC [M]  drivers/net/ethernet/cisco/enic/vnic_cq.o
+00:07:05   LD [M]  fs/nilfs2/nilfs2.o
+00:07:05   CC      drivers/i2c/algos/i2c-algo-bit.o
+00:07:05   CC [M]  drivers/gpu/drm/i915/display/intel_ddi.o
+00:07:05   CC [M]  drivers/rtc/rtc-ds2404.o
+00:07:05   CC [M]  net/l2tp/l2tp_debugfs.o
+00:07:05   CC [M]  net/atm/resources.o
+00:07:05   CC [M]  drivers/net/wireguard/ratelimiter.o
+00:07:06   CC [M]  drivers/usb/serial/ssu100.o
+00:07:06   CC [M]  drivers/input/mouse/cyapa_gen3.o
+00:07:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/auxg94.o
+00:07:06   CC [M]  fs/xfs/xfs_extent_busy.o
+00:07:06   CC [M]  drivers/net/wireless/ath/ath11k/thermal.o
+00:07:06   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device_queue_manager.o
+00:07:06   CC [M]  drivers/net/ethernet/cisco/enic/vnic_intr.o
+00:07:06   CC [M]  drivers/rtc/rtc-ds3232.o
+00:07:06   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/trans-gen2.o
+00:07:06   LD [M]  drivers/net/ethernet/chelsio/inline_crypto/ch_ktls/ch_ktls.o
+00:07:06   AR      drivers/net/ethernet/chelsio/inline_crypto/built-in.a
+00:07:06   CC [M]  drivers/scsi/bfa/bfa_fcs_lport.o
+00:07:06   CC [M]  drivers/net/ethernet/chelsio/cxgb/cxgb2.o
+00:07:06   CC [M]  drivers/usb/serial/symbolserial.o
+00:07:06   CC [M]  drivers/i2c/algos/i2c-algo-pca.o
+00:07:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/auxgf119.o
+00:07:07   CC [M]  drivers/net/wireguard/cookie.o
+00:07:07   CC [M]  net/atm/atm_sysfs.o
+00:07:07   CC [M]  net/l2tp/l2tp_ip6.o
+00:07:07   CC [M]  drivers/input/mouse/cyapa_gen5.o
+00:07:07   CC [M]  drivers/net/ethernet/cisco/enic/vnic_wq.o
+00:07:07   CC [M]  drivers/usb/serial/usb_wwan.o
+00:07:07   CC [M]  drivers/rtc/rtc-em3027.o
+00:07:07   CC [M]  drivers/net/wireless/ath/ath11k/mhi.o
+00:07:07   CC [M]  drivers/net/wireless/intel/iwlwifi/pcie/tx-gen2.o
+00:07:07   AR      drivers/i2c/algos/built-in.a
+00:07:07   CC      drivers/i2c/busses/i2c-designware-common.o
+00:07:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/auxgm200.o
+00:07:07   CC [M]  drivers/net/ethernet/chelsio/cxgb/espi.o
+00:07:07   CC [M]  drivers/net/ethernet/cisco/enic/enic_res.o
+00:07:07   CC [M]  net/atm/proc.o
+00:07:08   CC [M]  drivers/usb/serial/ti_usb_3410_5052.o
+00:07:08   CC [M]  drivers/net/wireguard/netlink.o
+00:07:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device_queue_manager_cik.o
+00:07:08   CC [M]  fs/xfs/xfs_file.o
+00:07:08   CC [M]  drivers/rtc/rtc-fm3130.o
+00:07:08   CC [M]  drivers/net/team/team.o
+00:07:08   CC [M]  drivers/input/mouse/cyapa_gen6.o
+00:07:08   CC      drivers/i2c/busses/i2c-designware-master.o
+00:07:08   CC [M]  drivers/net/wireless/ath/ath11k/pci.o
+00:07:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/anx9805.o
+00:07:08   CC [M]  drivers/net/ethernet/chelsio/cxgb/tp.o
+00:07:08   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-dbg-tlv.o
+00:07:08   CC [M]  drivers/net/ethernet/cisco/enic/enic_dev.o
+00:07:08   CC [M]  drivers/gpu/drm/i915/display/intel_ddi_buf_trans.o
+00:07:08   CC [M]  drivers/usb/serial/upd78f0730.o
+00:07:08   CC [M]  net/atm/clip.o
+00:07:09   CC [M]  drivers/rtc/rtc-isl12022.o
+00:07:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device_queue_manager_vi.o
+00:07:09   CC [M]  drivers/scsi/bfa/bfa_fcs_rport.o
+00:07:09   LD [M]  drivers/net/wireguard/wireguard.o
+00:07:09   CC [M]  drivers/input/mouse/elan_i2c_core.o
+00:07:09   CC [M]  drivers/scsi/csiostor/csio_attr.o
+00:07:09   CC [M]  drivers/net/ethernet/chelsio/cxgb/pm3393.o
+00:07:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/iccsense/base.o
+00:07:09   CC      drivers/i2c/busses/i2c-designware-slave.o
+00:07:09   CC [M]  drivers/usb/serial/visor.o
+00:07:09   CC [M]  drivers/net/ethernet/cisco/enic/enic_pp.o
+00:07:09   CC [M]  drivers/rtc/rtc-isl1208.o
+00:07:09   CC [M]  drivers/net/wireless/intel/iwlwifi/iwl-trans.o
+00:07:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device_queue_manager_v9.o
+00:07:10   LD [M]  drivers/net/wireless/ath/ath11k/ath11k.o
+00:07:10   LD [M]  drivers/net/wireless/ath/ath11k/ath11k_pci.o
+00:07:10   AR      drivers/net/wireless/ath/built-in.a
+00:07:10   CC [M]  drivers/net/wireless/ath/main.o
+00:07:10   CC [M]  drivers/net/team/team_mode_broadcast.o
+00:07:10   CC [M]  drivers/usb/serial/whiteheat.o
+00:07:10   CC [M]  drivers/gpu/drm/i915/display/intel_dp.o
+00:07:10   CC [M]  net/atm/br2684.o
+00:07:10   CC [M]  drivers/scsi/csiostor/csio_init.o
+00:07:10   CC      drivers/i2c/busses/i2c-designware-platdrv.o
+00:07:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/iccsense/gf100.o
+00:07:10   CC [M]  drivers/input/mouse/elan_i2c_i2c.o
+00:07:10   CC [M]  fs/xfs/xfs_filestream.o
+00:07:10   CC [M]  drivers/net/ethernet/chelsio/cxgb/sge.o
+00:07:10   CC [M]  drivers/net/ethernet/cisco/enic/vnic_dev.o
+00:07:10   CC [M]  drivers/net/wireless/intel/iwlwifi/queue/tx.o
+00:07:10   CC [M]  drivers/scsi/bfa/bfa_fcs_fcpim.o
+00:07:10   CC [M]  drivers/rtc/rtc-m41t80.o
+00:07:10   CC [M]  drivers/net/team/team_mode_roundrobin.o
+00:07:10   CC [M]  drivers/usb/serial/xr_serial.o
+00:07:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_device_queue_manager_v10.o
+00:07:11   CC [M]  drivers/net/wireless/ath/regd.o
+00:07:11   CC      drivers/i2c/busses/i2c-designware-baytrail.o
+00:07:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/instmem/base.o
+00:07:11   CC [M]  drivers/scsi/csiostor/csio_lnode.o
+00:07:11   CC [M]  net/atm/lec.o
+00:07:11   CC [M]  drivers/input/mouse/elan_i2c_smbus.o
+00:07:11   CC [M]  drivers/net/team/team_mode_random.o
+00:07:11   CC [M]  drivers/usb/serial/xsens_mt.o
+00:07:11   CC [M]  drivers/scsi/bfa/bfa_fcbuild.o
+00:07:11   CC [M]  drivers/rtc/rtc-m41t93.o
+00:07:11   CC [M]  drivers/net/ethernet/cisco/enic/vnic_rq.o
+00:07:11   CC      drivers/i2c/busses/i2c-designware-pcidrv.o
+00:07:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_interrupt.o
+00:07:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/instmem/nv04.o
+00:07:12   CC [M]  drivers/net/ethernet/chelsio/cxgb/subr.o
+00:07:12   AR      drivers/usb/serial/built-in.a
+00:07:12   CC [M]  drivers/net/wireless/ath/hw.o
+00:07:12   CC [M]  drivers/input/mouse/sermouse.o
+00:07:12   CC [M]  drivers/net/team/team_mode_activebackup.o
+00:07:12   CC [M]  fs/xfs/xfs_fsmap.o
+00:07:12   CC      drivers/usb/early/ehci-dbgp.o
+00:07:12   CC [M]  drivers/rtc/rtc-m41t94.o
+00:07:12   CC [M]  drivers/scsi/csiostor/csio_scsi.o
+00:07:12   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/img.o
+00:07:12   CC [M]  drivers/net/ethernet/cisco/enic/vnic_vic.o
+00:07:12   CC [M]  drivers/i2c/busses/i2c-scmi.o
+00:07:12   CC [M]  drivers/input/mouse/synaptics_i2c.o
+00:07:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/instmem/nv40.o
+00:07:12   CC [M]  drivers/gpu/drm/i915/display/intel_dp_aux.o
+00:07:12   CC [M]  drivers/scsi/bfa/bfa_port.o
+00:07:12   CC [M]  drivers/net/ethernet/cisco/enic/enic_ethtool.o
+00:07:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_events.o
+00:07:13   CC [M]  net/atm/pppoatm.o
+00:07:13   CC [M]  drivers/net/team/team_mode_loadbalance.o
+00:07:13   CC [M]  drivers/rtc/rtc-m48t35.o
+00:07:13   CC [M]  drivers/net/ethernet/chelsio/cxgb/mv88x201x.o
+00:07:13   CC [M]  drivers/net/wireless/ath/key.o
+00:07:13   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/notif-wait.o
+00:07:13   CC      drivers/usb/early/xhci-dbc.o
+00:07:13   CC [M]  drivers/i2c/busses/i2c-amd756.o
+00:07:13   CC [M]  drivers/input/mouse/synaptics_usb.o
+00:07:13   CC [M]  drivers/rtc/rtc-m48t59.o
+00:07:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/instmem/nv50.o
+00:07:13   CC [M]  drivers/scsi/bfa/bfa_fcpim.o
+00:07:13   CC [M]  drivers/net/ethernet/cisco/enic/enic_api.o
+00:07:13   CC [M]  drivers/scsi/csiostor/csio_hw.o
+00:07:13   CC [M]  drivers/net/ethernet/chelsio/cxgb/my3126.o
+00:07:13   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/dbg.o
+00:07:14   CC [M]  drivers/net/wireless/ath/dfs_pattern_detector.o
+00:07:14   AR      drivers/usb/early/built-in.a
+00:07:14   CC      drivers/usb/roles/class.o
+00:07:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/cik_event_interrupt.o
+00:07:14   LD [M]  net/atm/atm.o
+00:07:14   CC [M]  net/sctp/sm_statetable.o
+00:07:14   CC [M]  drivers/input/mouse/vsxxxaa.o
+00:07:14   CC [M]  drivers/gpu/drm/i915/display/intel_dp_aux_backlight.o
+00:07:14   CC [M]  drivers/rtc/rtc-max6900.o
+00:07:14   CC [M]  drivers/i2c/busses/i2c-amd8111.o
+00:07:14   CC [M]  net/sctp/sm_statefuns.o
+00:07:14   CC [M]  drivers/net/ethernet/cisco/enic/enic_clsf.o
+00:07:14   CC [M]  fs/xfs/xfs_fsops.o
+00:07:14   CC [M]  drivers/usb/roles/intel-xhci-usb-role-switch.o
+00:07:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/instmem/gk20a.o
+00:07:14   LD [M]  drivers/input/mouse/cyapatp.o
+00:07:14   LD [M]  drivers/input/mouse/elan_i2c.o
+00:07:14   AR      drivers/input/mouse/built-in.a
+00:07:14   CC [M]  drivers/net/ethernet/chelsio/cxgb/mv88e1xxx.o
+00:07:14   CC [M]  drivers/input/joystick/iforce/iforce-ff.o
+00:07:14   AR      drivers/usb/roles/built-in.a
+00:07:14   CC [M]  drivers/rtc/rtc-max6902.o
+00:07:14   CC [M]  drivers/usb/dwc3/core.o
+00:07:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_int_process_v9.o
+00:07:15   CC [M]  drivers/net/wireless/ath/dfs_pri_detector.o
+00:07:15   CC [M]  drivers/i2c/busses/i2c-cht-wc.o
+00:07:15   CC [M]  drivers/net/wireless/mediatek/mt7601u/usb.o
+00:07:15   LD [M]  drivers/net/ethernet/cisco/enic/enic.o
+00:07:15   AR      drivers/net/ethernet/cisco/built-in.a
+00:07:15   CC [M]  drivers/net/wireless/mediatek/mt7601u/init.o
+00:07:15   CC [M]  drivers/gpu/drm/i915/display/intel_dp_hdcp.o
+00:07:15   CC [M]  drivers/input/joystick/iforce/iforce-main.o
+00:07:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/base.o
+00:07:15   CC [M]  drivers/net/ethernet/chelsio/cxgb/vsc7326.o
+00:07:15   CC [M]  drivers/rtc/rtc-max6916.o
+00:07:15   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/pnvm.o
+00:07:15   CC [M]  drivers/scsi/csiostor/csio_hw_t5.o
+00:07:15   CC [M]  drivers/input/joystick/iforce/iforce-packets.o
+00:07:15   CC [M]  drivers/scsi/bfa/bfa_core.o
+00:07:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_dbgdev.o
+00:07:16   CC [M]  drivers/i2c/busses/i2c-i801.o
+00:07:16   LD [M]  drivers/net/wireless/ath/ath.o
+00:07:16   CC [M]  fs/cachefiles/bind.o
+00:07:16   CC [M]  drivers/rtc/rtc-mcp795.o
+00:07:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gf100.o
+00:07:16   CC [M]  fs/xfs/xfs_globals.o
+00:07:16   CC [M]  drivers/input/joystick/iforce/iforce-serio.o
+00:07:16   CC [M]  fs/ocfs2/dlmfs/userdlm.o
+00:07:16   CC [M]  drivers/usb/dwc3/trace.o
+00:07:16   CC [M]  drivers/net/wireless/mediatek/mt7601u/main.o
+00:07:16   CC [M]  drivers/scsi/csiostor/csio_isr.o
+00:07:16   LD [M]  drivers/net/ethernet/chelsio/cxgb/cxgb.o
+00:07:16   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/dump.o
+00:07:16   CC [M]  drivers/net/ethernet/chelsio/cxgb3/cxgb3_main.o
+00:07:16   CC [M]  drivers/gpu/drm/i915/display/intel_dp_link_training.o
+00:07:16   CC [M]  fs/cachefiles/daemon.o
+00:07:16   CC [M]  drivers/input/joystick/iforce/iforce-usb.o
+00:07:16   CC [M]  drivers/rtc/rtc-msm6242.o
+00:07:17   CC [M]  fs/ocfs2/dlmfs/dlmfs.o
+00:07:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_dbgmgr.o
+00:07:17   CC [M]  fs/xfs/xfs_health.o
+00:07:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gk104.o
+00:07:17   CC [M]  net/sctp/sm_sideeffect.o
+00:07:17   CC [M]  drivers/i2c/busses/i2c-isch.o
+00:07:17   CC [M]  drivers/scsi/bfa/bfa_svc.o
+00:07:17   CC [M]  drivers/scsi/csiostor/csio_mb.o
+00:07:17   CC [M]  drivers/rtc/rtc-pcf2123.o
+00:07:17   LD [M]  drivers/input/joystick/iforce/iforce.o
+00:07:17   CC [M]  fs/cachefiles/interface.o
+00:07:17   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/1000.o
+00:07:17   AR      drivers/input/joystick/built-in.a
+00:07:17   CC [M]  drivers/input/joystick/a3d.o
+00:07:17   CC [M]  drivers/net/wireless/mediatek/mt7601u/mcu.o
+00:07:17   CC [M]  drivers/usb/dwc3/host.o
+00:07:17   LD [M]  fs/ocfs2/dlmfs/ocfs2_dlmfs.o
+00:07:17   CC [M]  fs/ocfs2/cluster/heartbeat.o
+00:07:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gm107.o
+00:07:17   CC [M]  drivers/gpu/drm/i915/display/intel_dp_mst.o
+00:07:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_smi_events.o
+00:07:18   CC [M]  drivers/i2c/busses/i2c-ismt.o
+00:07:18   CC [M]  drivers/input/joystick/adc-joystick.o
+00:07:18   CC [M]  drivers/rtc/rtc-pcf2127.o
+00:07:18   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/2000.o
+00:07:18   CC [M]  fs/cachefiles/io.o
+00:07:18   CC [M]  drivers/scsi/csiostor/csio_rnode.o
+00:07:18   CC [M]  drivers/usb/dwc3/debugfs.o
+00:07:18   CC [M]  net/sctp/protocol.o
+00:07:18   CC [M]  drivers/input/joystick/adi.o
+00:07:18   CC [M]  drivers/net/ethernet/chelsio/cxgb3/ael1002.o
+00:07:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gm200.o
+00:07:18   CC [M]  fs/cachefiles/key.o
+00:07:18   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/5000.o
+00:07:18   CC [M]  drivers/net/wireless/mediatek/mt7601u/trace.o
+00:07:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_crat.o
+00:07:19   CC [M]  drivers/i2c/busses/i2c-nforce2.o
+00:07:19   CC [M]  fs/xfs/xfs_icache.o
+00:07:19   CC [M]  drivers/rtc/rtc-pcf85063.o
+00:07:19   CC [M]  drivers/input/joystick/analog.o
+00:07:19   CC [M]  drivers/gpu/drm/i915/display/intel_dsi.o
+00:07:19   CC [M]  drivers/scsi/csiostor/csio_wr.o
+00:07:19   CC [M]  fs/cachefiles/main.o
+00:07:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gp100.o
+00:07:19   CC [M]  drivers/usb/dwc3/dwc3-pci.o
+00:07:19   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/6000.o
+00:07:19   CC [M]  drivers/net/ethernet/chelsio/cxgb3/vsc8211.o
+00:07:19   CC [M]  fs/ocfs2/cluster/masklog.o
+00:07:19   CC [M]  drivers/i2c/busses/i2c-nvidia-gpu.o
+00:07:20   CC [M]  fs/ocfs2/cluster/sys.o
+00:07:20   CC [M]  net/sctp/endpointola.o
+00:07:20   CC [M]  drivers/rtc/rtc-pcf8523.o
+00:07:20   CC [M]  drivers/input/joystick/cobra.o
+00:07:20   LD [M]  drivers/usb/dwc3/dwc3.o
+00:07:20   CC [M]  drivers/usb/cdns3/core.o
+00:07:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gp102.o
+00:07:20   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/7000.o
+00:07:20   LD [M]  drivers/scsi/bfa/bfa.o
+00:07:20   CC [M]  drivers/usb/cdns3/drd.o
+00:07:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_iommu.o
+00:07:20   CC [M]  fs/cachefiles/namei.o
+00:07:20   CC [M]  fs/ocfs2/cluster/nodemanager.o
+00:07:20   CC [M]  drivers/net/ethernet/chelsio/cxgb3/t3_hw.o
+00:07:20   CC [M]  drivers/gpu/drm/i915/display/intel_dsi_dcs_backlight.o
+00:07:20   LD [M]  drivers/scsi/csiostor/csiostor.o
+00:07:20   CC [M]  drivers/scsi/smartpqi/smartpqi_init.o
+00:07:20   CC [M]  drivers/input/joystick/db9.o
+00:07:20   CC [M]  drivers/i2c/busses/i2c-piix4.o
+00:07:20   CC [M]  drivers/net/wireless/mediatek/mt7601u/dma.o
+00:07:20   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/8000.o
+00:07:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/ltc/gp10b.o
+00:07:21   CC [M]  drivers/rtc/rtc-pcf8563.o
+00:07:21   CC [M]  drivers/input/joystick/gamecon.o
+00:07:21   CC [M]  drivers/usb/cdns3/cdnsp-pci.o
+00:07:21   CC [M]  net/sctp/associola.o
+00:07:21   CC [M]  fs/cachefiles/rdwr.o
+00:07:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_debugfs.o
+00:07:21   AR      drivers/input/tablet/built-in.a
+00:07:21   CC [M]  drivers/input/tablet/acecad.o
+00:07:21   CC [M]  drivers/gpu/drm/i915/display/intel_dsi_vbt.o
+00:07:21   CC [M]  fs/ocfs2/cluster/quorum.o
+00:07:21   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/9000.o
+00:07:21   CC [M]  fs/xfs/xfs_ioctl.o
+00:07:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/base.o
+00:07:21   CC [M]  drivers/i2c/busses/i2c-sis96x.o
+00:07:21   CC [M]  drivers/input/joystick/gf2k.o
+00:07:21   LD [M]  drivers/usb/cdns3/cdns-usb-common.o
+00:07:21   LD [M]  drivers/usb/cdns3/cdnsp-udc-pci.o
+00:07:21   CC [M]  drivers/rtc/rtc-pcf8583.o
+00:07:21   CC [M]  drivers/usb/class/cdc-acm.o
+00:07:22   CC [M]  fs/ocfs2/cluster/tcp.o
+00:07:22   CC [M]  drivers/input/tablet/aiptek.o
+00:07:22   CC [M]  drivers/net/wireless/mediatek/mt7601u/core.o
+00:07:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_svm.o
+00:07:22   CC [M]  drivers/net/wireless/intel/iwlwifi/cfg/22000.o
+00:07:22   CC [M]  fs/cachefiles/security.o
+00:07:22   CC [M]  drivers/net/ethernet/chelsio/cxgb3/mc5.o
+00:07:22   CC [M]  drivers/input/joystick/grip.o
+00:07:22   CC [M]  drivers/i2c/busses/i2c-via.o
+00:07:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/nv04.o
+00:07:22   CC [M]  net/sctp/transport.o
+00:07:22   CC [M]  drivers/rtc/rtc-r9701.o
+00:07:22   CC [M]  drivers/gpu/drm/i915/display/intel_dvo.o
+00:07:22   CC [M]  drivers/input/tablet/hanwang.o
+00:07:22   CC [M]  fs/cachefiles/xattr.o
+00:07:23   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/paging.o
+00:07:23   CC [M]  drivers/usb/class/usblp.o
+00:07:23   CC [M]  drivers/net/wireless/mediatek/mt7601u/eeprom.o
+00:07:23   CC [M]  drivers/input/joystick/grip_mp.o
+00:07:23   CC [M]  drivers/net/ethernet/chelsio/cxgb3/xgmac.o
+00:07:23   CC [M]  drivers/i2c/busses/i2c-viapro.o
+00:07:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/nv11.o
+00:07:23   CC [M]  drivers/rtc/rtc-rp5c01.o
+00:07:23   CC [M]  drivers/input/tablet/kbtab.o
+00:07:23   LD [M]  fs/cachefiles/cachefiles.o
+00:07:23   CC [M]  net/rds/af_rds.o
+00:07:23   CC [M]  drivers/scsi/smartpqi/smartpqi_sis.o
+00:07:23   CC [M]  fs/ocfs2/cluster/netdebug.o
+00:07:23   CC [M]  drivers/input/joystick/guillemot.o
+00:07:23   CC [M]  drivers/usb/class/cdc-wdm.o
+00:07:23   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/smem.o
+00:07:23   CC [M]  drivers/rtc/rtc-rs5c348.o
+00:07:23   CC [M]  drivers/input/tablet/pegasus_notetaker.o
+00:07:24   CC [M]  net/sctp/chunk.o
+00:07:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/nv17.o
+00:07:24   CC [M]  drivers/gpu/drm/i915/display/intel_gmbus.o
+00:07:24   CC [M]  fs/xfs/xfs_iomap.o
+00:07:24   CC [M]  drivers/i2c/busses/i2c-amd-mp2-pci.o
+00:07:24   CC [M]  drivers/net/ethernet/chelsio/cxgb3/sge.o
+00:07:24   CC [M]  drivers/net/wireless/mediatek/mt7601u/phy.o
+00:07:24   CC [M]  drivers/input/joystick/interact.o
+00:07:24   CC [M]  drivers/scsi/smartpqi/smartpqi_sas_transport.o
+00:07:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../amdkfd/kfd_migrate.o
+00:07:24   CC [M]  drivers/input/tablet/wacom_serial4.o
+00:07:24   CC [M]  drivers/rtc/rtc-rs5c372.o
+00:07:24   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/init.o
+00:07:24   LD [M]  fs/ocfs2/cluster/ocfs2_nodemanager.o
+00:07:24   CC [M]  fs/ocfs2/dlm/dlmdomain.o
+00:07:24   CC [M]  net/rds/bind.o
+00:07:24   CC [M]  drivers/input/joystick/joydump.o
+00:07:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/nv44.o
+00:07:24   CC [M]  drivers/usb/class/usbtmc.o
+00:07:25   CC [M]  drivers/i2c/busses/i2c-amd-mp2-plat.o
+00:07:25   LD [M]  drivers/scsi/smartpqi/smartpqi.o
+00:07:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/nv50.o
+00:07:25   CC [M]  drivers/scsi/sym53c8xx_2/sym_fw.o
+00:07:25   CC [M]  net/sctp/sm_make_chunk.o
+00:07:25   CC [M]  drivers/input/joystick/magellan.o
+00:07:25   CC [M]  drivers/rtc/rtc-rv3028.o
+00:07:25   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/acpi.o
+00:07:25   CC [M]  drivers/gpu/drm/i915/display/intel_hdmi.o
+00:07:25   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_fence.o
+00:07:25   CC [M]  net/mac80211/main.o
+00:07:25   CC [M]  drivers/input/joystick/psxpad-spi.o
+00:07:25   CC [M]  drivers/net/wireless/mediatek/mt7601u/mac.o
+00:07:25   CC [M]  drivers/scsi/sym53c8xx_2/sym_glue.o
+00:07:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/g84.o
+00:07:25   CC [M]  drivers/i2c/busses/i2c-pca-platform.o
+00:07:26   CC [M]  net/rds/cong.o
+00:07:26   CC [M]  drivers/usb/image/mdc800.o
+00:07:26   CC [M]  drivers/net/ethernet/chelsio/cxgb3/l2t.o
+00:07:26   CC [M]  fs/xfs/xfs_iops.o
+00:07:26   CC [M]  drivers/rtc/rtc-rv3029c2.o
+00:07:26   CC [M]  drivers/input/joystick/pxrc.o
+00:07:26   CC [M]  fs/ocfs2/dlm/dlmdebug.o
+00:07:26   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.o
+00:07:26   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/uefi.o
+00:07:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/g98.o
+00:07:26   CC [M]  drivers/i2c/busses/i2c-simtec.o
+00:07:26   CC [M]  drivers/usb/image/microtek.o
+00:07:27   CC [M]  drivers/input/joystick/qwiic-joystick.o
+00:07:27   CC [M]  drivers/scsi/sym53c8xx_2/sym_hipd.o
+00:07:27   CC [M]  drivers/net/wireless/mediatek/mt7601u/util.o
+00:07:27   CC [M]  net/sctp/ulpevent.o
+00:07:27   CC [M]  net/rds/connection.o
+00:07:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gt215.o
+00:07:27   CC [M]  drivers/net/wireless/intel/iwlwifi/fw/debugfs.o
+00:07:27   CC [M]  drivers/i2c/busses/i2c-diolan-u2c.o
+00:07:27   CC [M]  drivers/rtc/rtc-rv3032.o
+00:07:27   CC [M]  net/mac80211/status.o
+00:07:27   CC [M]  drivers/net/ethernet/chelsio/cxgb3/cxgb3_offload.o
+00:07:27   CC [M]  drivers/usb/atm/cxacru.o
+00:07:27   CC [M]  fs/ocfs2/dlm/dlmthread.o
+00:07:27   CC [M]  drivers/input/joystick/sidewinder.o
+00:07:27   CC [M]  drivers/gpu/drm/i915/display/intel_lspcon.o
+00:07:28   CC [M]  drivers/net/wireless/mediatek/mt7601u/debugfs.o
+00:07:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gf100.o
+00:07:28   CC [M]  drivers/i2c/busses/i2c-dln2.o
+00:07:28   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gfx_v8.o
+00:07:28   LD [M]  drivers/net/wireless/intel/iwlwifi/iwlwifi.o
+00:07:28   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/usb.o
+00:07:28   CC [M]  net/sctp/inqueue.o
+00:07:28   CC [M]  drivers/rtc/rtc-rv8803.o
+00:07:28   CC [M]  net/rds/info.o
+00:07:28   CC [M]  fs/xfs/xfs_inode.o
+00:07:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gk104.o
+00:07:28   CC [M]  drivers/input/joystick/spaceball.o
+00:07:28   CC [M]  fs/ocfs2/dlm/dlmrecovery.o
+00:07:29   CC [M]  drivers/net/ethernet/chelsio/cxgb3/aq100x.o
+00:07:29   CC [M]  drivers/scsi/sym53c8xx_2/sym_malloc.o
+00:07:29   CC [M]  drivers/i2c/busses/i2c-cp2615.o
+00:07:29   CC [M]  drivers/gpu/drm/i915/display/intel_lvds.o
+00:07:29   CC [M]  drivers/net/wireless/mediatek/mt7601u/tx.o
+00:07:29   CC [M]  drivers/usb/atm/speedtch.o
+00:07:29   CC [M]  net/mac80211/driver-ops.o
+00:07:29   CC [M]  drivers/rtc/rtc-rx4581.o
+00:07:29   CC [M]  drivers/input/joystick/spaceorb.o
+00:07:29   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gfx_v9.o
+00:07:29   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/usb_mcu.o
+00:07:29   CC [M]  net/sctp/outqueue.o
+00:07:29   CC [M]  net/rds/message.o
+00:07:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gk20a.o
+00:07:29   CC [M]  drivers/scsi/sym53c8xx_2/sym_nvram.o
+00:07:29   LD [M]  drivers/net/ethernet/chelsio/cxgb3/cxgb3.o
+00:07:29   CC [M]  drivers/i2c/busses/i2c-parport.o
+00:07:29   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_main.o
+00:07:29   CC [M]  drivers/input/joystick/stinger.o
+00:07:30   CC [M]  drivers/rtc/rtc-rx8010.o
+00:07:30   LD [M]  drivers/net/wireless/mediatek/mt7601u/mt7601u.o
+00:07:30   AR      drivers/i3c/built-in.a
+00:07:30   AR      drivers/net/ethernet/dec/tulip/built-in.a
+00:07:30   CC [M]  drivers/net/ethernet/dec/tulip/xircom_cb.o
+00:07:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gp100.o
+00:07:30   CC [M]  drivers/usb/atm/ueagle-atm.o
+00:07:30   CC [M]  drivers/input/joystick/tmdc.o
+00:07:30   CC [M]  drivers/gpu/drm/i915/display/intel_panel.o
+00:07:30   LD [M]  drivers/scsi/sym53c8xx_2/sym53c8xx.o
+00:07:30   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/pci.o
+00:07:30   CC [M]  drivers/scsi/mpt3sas/mpt3sas_base.o
+00:07:30   CC [M]  drivers/i2c/busses/i2c-tiny-usb.o
+00:07:30   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_arcturus.o
+00:07:30   CC [M]  net/rds/recv.o
+00:07:30   CC [M]  net/mac80211/sta_info.o
+00:07:30   CC [M]  fs/ocfs2/dlm/dlmmaster.o
+00:07:30   CC [M]  drivers/rtc/rtc-rx8025.o
+00:07:31   CC [M]  drivers/input/joystick/turbografx.o
+00:07:31   CC [M]  net/sctp/ulpqueue.o
+00:07:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/gp10b.o
+00:07:31   CC [M]  drivers/net/ethernet/dec/tulip/dmfe.o
+00:07:31   CC [M]  drivers/i2c/busses/i2c-cros-ec-tunnel.o
+00:07:31   CC [M]  fs/xfs/xfs_itable.o
+00:07:31   CC [M]  drivers/input/joystick/twidjoy.o
+00:07:31   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/pci_mcu.o
+00:07:31   CC [M]  drivers/gpu/drm/i915/display/intel_pps.o
+00:07:31   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_aldebaran.o
+00:07:31   CC [M]  drivers/rtc/rtc-rx8581.o
+00:07:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/tu102.o
+00:07:32   CC [M]  drivers/input/joystick/warrior.o
+00:07:32   CC [M]  net/rds/send.o
+00:07:32   CC [M]  drivers/usb/atm/usbatm.o
+00:07:32   CC [M]  drivers/i2c/busses/i2c-mlxcpld.o
+00:07:32   CC [M]  net/sctp/tsnmap.o
+00:07:32   CC [M]  fs/xfs/xfs_iwalk.o
+00:07:32   CC [M]  drivers/input/joystick/walkera0701.o
+00:07:32   CC [M]  drivers/rtc/rtc-sd3078.o
+00:07:32   CC [M]  drivers/net/ethernet/dec/tulip/winbond-840.o
+00:07:32   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gfx_v10.o
+00:07:32   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/init.o
+00:07:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mc/ga100.o
+00:07:33   CC [M]  fs/ocfs2/dlm/dlmast.o
+00:07:33   CC [M]  drivers/input/joystick/xpad.o
+00:07:33   CC [M]  drivers/i2c/busses/i2c-virtio.o
+00:07:33   CC [M]  drivers/rtc/rtc-stk17ta8.o
+00:07:33   CC [M]  drivers/net/ethernet/chelsio/cxgb4/l2t.o
+00:07:33   CC [M]  net/mac80211/wep.o
+00:07:33   CC [M]  drivers/gpu/drm/i915/display/intel_qp_tables.o
+00:07:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/base.o
+00:07:33   CC [M]  net/sctp/bind_addr.o
+00:07:33   CC [M]  drivers/scsi/mpt3sas/mpt3sas_config.o
+00:07:33   CC [M]  drivers/usb/atm/xusbatm.o
+00:07:33   CC [M]  net/rds/stats.o
+00:07:33   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/main.o
+00:07:33   CC [M]  drivers/input/joystick/zhenhua.o
+00:07:33   CC [M]  drivers/net/ethernet/dec/tulip/de2104x.o
+00:07:33   CC [M]  drivers/rtc/rtc-x1205.o
+00:07:33   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gfx_v10_3.o
+00:07:33   AR      drivers/i2c/busses/built-in.a
+00:07:34   CC [M]  fs/ocfs2/dlm/dlmconvert.o
+00:07:34   AR      drivers/i2c/muxes/built-in.a
+00:07:34   CC [M]  drivers/i2c/muxes/i2c-mux-ltc4306.o
+00:07:34   CC [M]  drivers/gpu/drm/i915/display/intel_sdvo.o
+00:07:34   CC [M]  fs/xfs/xfs_message.o
+00:07:34   AR      drivers/input/touchscreen/built-in.a
+00:07:34   CC [M]  drivers/input/touchscreen/atmel_mxt_ts.o
+00:07:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/nv04.o
+00:07:34   CC [M]  net/mac80211/aead_api.o
+00:07:34   CC [M]  drivers/usb/usbip/usbip_common.o
+00:07:34   CC [M]  net/sctp/socket.o
+00:07:34   CC [M]  net/rds/sysctl.o
+00:07:34   CC [M]  drivers/net/ethernet/chelsio/cxgb4/smt.o
+00:07:34   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/eeprom.o
+00:07:34   AR      drivers/rtc/built-in.a
+00:07:34   CC [M]  drivers/scsi/mpt3sas/mpt3sas_scsih.o
+00:07:34   CC [M]  drivers/i2c/muxes/i2c-mux-mlxcpld.o
+00:07:35   AR      drivers/net/ethernet/dlink/built-in.a
+00:07:35   CC [M]  drivers/net/ethernet/dlink/dl2k.o
+00:07:35   CC [M]  net/mac80211/wpa.o
+00:07:35   CC [M]  fs/xfs/xfs_mount.o
+00:07:35   CC [M]  fs/ocfs2/dlm/dlmlock.o
+00:07:35   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gfx_v7.o
+00:07:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/nv41.o
+00:07:35   CC [M]  drivers/net/ethernet/dec/tulip/eeprom.o
+00:07:35   CC      drivers/i2c/i2c-boardinfo.o
+00:07:35   CC [M]  net/rds/threads.o
+00:07:35   CC [M]  drivers/usb/usbip/usbip_event.o
+00:07:35   CC [M]  drivers/net/ethernet/chelsio/cxgb4/t4_hw.o
+00:07:35   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x0/phy.o
+00:07:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/nv44.o
+00:07:36   CC [M]  drivers/input/touchscreen/auo-pixcir-ts.o
+00:07:36   CC [M]  drivers/net/ethernet/dec/tulip/interrupt.o
+00:07:36   CC [M]  drivers/gpu/drm/i915/display/intel_snps_phy.o
+00:07:36   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_cgs.o
+00:07:36   CC [M]  drivers/usb/usbip/vhci_sysfs.o
+00:07:36   CC [M]  fs/ocfs2/dlm/dlmunlock.o
+00:07:36   CC      drivers/i2c/i2c-core-base.o
+00:07:36   CC [M]  drivers/input/touchscreen/chipone_icn8505.o
+00:07:36   CC [M]  net/mac80211/scan.o
+00:07:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/nv50.o
+00:07:36   CC [M]  net/rds/transport.o
+00:07:37   CC [M]  fs/gfs2/acl.o
+00:07:37   CC [M]  drivers/net/ethernet/dec/tulip/media.o
+00:07:37   CC [M]  drivers/usb/usbip/vhci_tx.o
+00:07:37   CC [M]  fs/xfs/xfs_mru_cache.o
+00:07:37   CC [M]  drivers/input/touchscreen/cy8ctma140.o
+00:07:37   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_job.o
+00:07:37   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x0/mt76x0u.o
+00:07:37   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x0/mt76x0e.o
+00:07:37   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x0/mt76x0-common.o
+00:07:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/g84.o
+00:07:37   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/eeprom.o
+00:07:37   LD [M]  fs/ocfs2/dlm/ocfs2_dlm.o
+00:07:37   CC [M]  fs/gfs2/bmap.o
+00:07:37   CC [M]  fs/ocfs2/alloc.o
+00:07:37   CC [M]  drivers/usb/usbip/vhci_rx.o
+00:07:37   CC [M]  net/rds/loop.o
+00:07:37   CC [M]  drivers/net/ethernet/dec/tulip/timer.o
+00:07:38   CC [M]  drivers/input/touchscreen/dynapro.o
+00:07:38   CC [M]  fs/xfs/xfs_pwork.o
+00:07:38   CC      drivers/i2c/i2c-core-smbus.o
+00:07:38   CC [M]  drivers/usb/usbip/vhci_hcd.o
+00:07:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/mcp77.o
+00:07:38   CC [M]  net/sctp/primitive.o
+00:07:38   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_acp.o
+00:07:38   CC [M]  net/mac80211/offchannel.o
+00:07:38   CC [M]  drivers/input/touchscreen/edt-ft5x06.o
+00:07:38   CC [M]  drivers/net/ethernet/dec/tulip/tulip_core.o
+00:07:38   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/mac.o
+00:07:38   CC [M]  drivers/scsi/mpt3sas/mpt3sas_transport.o
+00:07:39   CC [M]  net/rds/page.o
+00:07:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gf100.o
+00:07:39   CC [M]  drivers/usb/usbip/stub_dev.o
+00:07:39   CC [M]  fs/gfs2/dir.o
+00:07:39   CC      drivers/i2c/i2c-core-acpi.o
+00:07:39   CC [M]  net/sctp/output.o
+00:07:39   CC [M]  drivers/gpu/drm/amd/amdgpu/../acp/acp_hw.o
+00:07:39   CC [M]  drivers/net/ethernet/chelsio/cxgb4/sge.o
+00:07:39   CC [M]  drivers/input/touchscreen/hycon-hy46xx.o
+00:07:39   CC [M]  drivers/gpu/drm/i915/display/intel_tv.o
+00:07:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gk104.o
+00:07:39   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/init.o
+00:07:39   CC [M]  fs/xfs/xfs_reflink.o
+00:07:40   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_ioc32.o
+00:07:40   CC [M]  net/rds/rdma.o
+00:07:40   CC [M]  drivers/usb/usbip/stub_main.o
+00:07:40   CC [M]  drivers/net/ethernet/dec/tulip/21142.o
+00:07:40   CC [M]  net/mac80211/ht.o
+00:07:40   CC [M]  drivers/scsi/mpt3sas/mpt3sas_ctl.o
+00:07:40   CC      drivers/i2c/i2c-core-slave.o
+00:07:40   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_atpx_handler.o
+00:07:40   CC [M]  drivers/input/touchscreen/gunze.o
+00:07:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gk20a.o
+00:07:40   CC [M]  drivers/usb/usbip/stub_rx.o
+00:07:40   CC [M]  net/sctp/input.o
+00:07:40   CC [M]  fs/gfs2/xattr.o
+00:07:40   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/phy.o
+00:07:40   CC [M]  drivers/net/ethernet/dec/tulip/pnic.o
+00:07:40   CC [M]  drivers/input/touchscreen/eeti_ts.o
+00:07:41   CC [M]  drivers/i2c/i2c-smbus.o
+00:07:41   CC [M]  drivers/gpu/drm/i915/display/intel_vdsc.o
+00:07:41   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.o
+00:07:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gm200.o
+00:07:41   CC [M]  net/rds/rdma_transport.o
+00:07:41   CC [M]  drivers/usb/usbip/stub_tx.o
+00:07:41   CC [M]  drivers/net/ethernet/dec/tulip/pnic2.o
+00:07:41   CC [M]  net/mac80211/agg-tx.o
+00:07:41   CC [M]  drivers/input/touchscreen/elants_i2c.o
+00:07:41   CC [M]  fs/gfs2/glock.o
+00:07:41   CC [M]  drivers/i2c/i2c-dev.o
+00:07:42   CC [M]  drivers/scsi/mpt3sas/mpt3sas_trigger_diag.o
+00:07:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gm20b.o
+00:07:42   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/mcu.o
+00:07:42   LD [M]  drivers/usb/usbip/usbip-core.o
+00:07:42   CC [M]  fs/xfs/xfs_stats.o
+00:07:42   LD [M]  drivers/usb/usbip/vhci-hcd.o
+00:07:42   LD [M]  drivers/usb/usbip/usbip-host.o
+00:07:42   CC [M]  drivers/usb/typec/altmodes/displayport.o
+00:07:42   CC [M]  fs/ocfs2/aops.o
+00:07:42   CC [M]  net/sctp/debug.o
+00:07:42   CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_mn.o
+00:07:42   CC [M]  drivers/net/ethernet/chelsio/cxgb4/clip_tbl.o
+00:07:42   CC [M]  net/rds/ib.o
+00:07:42   CC [M]  drivers/net/ethernet/dec/tulip/uli526x.o
+00:07:42   CC [M]  drivers/gpu/drm/i915/display/intel_vrr.o
+00:07:42   CC [M]  drivers/usb/typec/altmodes/nvidia.o
+00:07:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gp100.o
+00:07:42   CC [M]  drivers/scsi/mpt3sas/mpt3sas_warpdrive.o
+00:07:42   CC [M]  drivers/input/touchscreen/elo.o
+00:07:42   CC [M]  drivers/i2c/i2c-mux.o
+00:07:42   CC [M]  fs/xfs/xfs_super.o
+00:07:43   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/pci.o
+00:07:43   LD [M]  drivers/usb/typec/altmodes/typec_displayport.o
+00:07:43   LD [M]  drivers/usb/typec/altmodes/typec_nvidia.o
+00:07:43   CC [M]  drivers/usb/typec/tcpm/tcpm.o
+00:07:43   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/arcturus_ppt.o
+00:07:43   CC [M]  net/sctp/stream.o
+00:07:43   CC [M]  net/mac80211/agg-rx.o
+00:07:43   CC [M]  drivers/input/touchscreen/egalax_ts_serial.o
+00:07:43   CC [M]  drivers/scsi/mpt3sas/mpt3sas_debugfs.o
+00:07:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gp10b.o
+00:07:43   LD [M]  drivers/net/ethernet/dec/tulip/tulip.o
+00:07:43   CC [M]  net/rds/ib_cm.o
+00:07:43   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_ethtool.o
+00:07:43   AR      drivers/net/ethernet/dec/built-in.a
+00:07:43   CC [M]  drivers/usb/typec/tcpm/fusb302.o
+00:07:43   CC [M]  drivers/i2c/i2c-stub.o
+00:07:43   CC [M]  drivers/gpu/drm/i915/display/vlv_dsi.o
+00:07:43   CC [M]  drivers/input/touchscreen/fujitsu_ts.o
+00:07:44   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/pci_main.o
+00:07:44   LD [M]  drivers/scsi/mpt3sas/mpt3sas.o
+00:07:44   CC [M]  drivers/scsi/mpi3mr/mpi3mr_os.o
+00:07:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/gv100.o
+00:07:44   CC [M]  fs/gfs2/glops.o
+00:07:44   CC [M]  drivers/input/touchscreen/goodix.o
+00:07:44   CC [M]  drivers/i2c/i2c-slave-eeprom.o
+00:07:44   CC [M]  fs/ocfs2/blockcheck.o
+00:07:44   CC [M]  net/sctp/auth.o
+00:07:44   CC [M]  drivers/usb/typec/ucsi/ucsi.o
+00:07:44   CC [M]  net/mac80211/vht.o
+00:07:45   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/navi10_ppt.o
+00:07:45   CC [M]  net/rds/ib_recv.o
+00:07:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/tu102.o
+00:07:45   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/pci_init.o
+00:07:45   CC [M]  fs/xfs/xfs_symlink.o
+00:07:45   CC [M]  fs/gfs2/log.o
+00:07:45   AR      drivers/i2c/built-in.a
+00:07:45   CC [M]  drivers/usb/typec/tcpm/wcove.o
+00:07:45   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/sienna_cichlid_ppt.o
+00:07:45   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_uld.o
+00:07:45   CC [M]  fs/ocfs2/buffer_head_io.o
+00:07:45   CC [M]  drivers/input/touchscreen/ili210x.o
+00:07:45   CC [M]  drivers/usb/typec/ucsi/trace.o
+00:07:45   CC [M]  drivers/gpu/drm/i915/display/vlv_dsi_pll.o
+00:07:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/mem.o
+00:07:45   CC [M]  drivers/usb/typec/tcpm/tcpci.o
+00:07:45   CC [M]  drivers/scsi/mpi3mr/mpi3mr_fw.o
+00:07:46   CC [M]  net/sctp/offload.o
+00:07:46   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/pci_mcu.o
+00:07:46   CC [M]  drivers/input/touchscreen/ilitek_ts_i2c.o
+00:07:46   CC [M]  drivers/usb/typec/ucsi/psy.o
+00:07:46   CC [M]  net/mac80211/he.o
+00:07:46   CC [M]  net/rds/ib_ring.o
+00:07:46   CC [M]  fs/gfs2/lops.o
+00:07:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/memnv04.o
+00:07:46   CC [M]  drivers/usb/typec/ucsi/displayport.o
+00:07:46   CC [M]  drivers/usb/typec/tcpm/tcpci_maxim.o
+00:07:46   CC [M]  fs/ocfs2/dcache.o
+00:07:46   CC [M]  drivers/net/ethernet/chelsio/cxgb4/srq.o
+00:07:47   LD [M]  drivers/usb/typec/tcpm/typec_wcove.o
+00:07:47   CC      drivers/gpu/drm/drm_dsc.o
+00:07:47   CC [M]  drivers/gpu/drm/i915/i915_perf.o
+00:07:47   CC [M]  net/sctp/stream_sched.o
+00:07:47   CC [M]  drivers/usb/typec/ucsi/ucsi_acpi.o
+00:07:47   CC [M]  drivers/input/touchscreen/inexio.o
+00:07:47   CC [M]  fs/xfs/xfs_sysfs.o
+00:07:47   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/pci_phy.o
+00:07:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/memnv50.o
+00:07:47   CC [M]  net/rds/ib_send.o
+00:07:47   CC [M]  net/mac80211/s1g.o
+00:07:47   LD [M]  drivers/scsi/mpi3mr/mpi3mr.o
+00:07:47   CC [M]  drivers/scsi/ufs/ufshcd.o
+00:07:47   CC [M]  drivers/usb/typec/ucsi/ucsi_ccg.o
+00:07:47   CC [M]  drivers/input/touchscreen/mms114.o
+00:07:47   CC [M]  fs/gfs2/main.o
+00:07:47   CC [M]  net/rds/ib_stats.o
+00:07:47   CC [M]  net/sctp/stream_sched_prio.o
+00:07:47   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/vangogh_ppt.o
+00:07:48   CC [M]  drivers/net/ethernet/chelsio/cxgb4/sched.o
+00:07:48   CC [M]  fs/xfs/xfs_trans.o
+00:07:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/memgf100.o
+00:07:48   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb.o
+00:07:48   CC [M]  fs/gfs2/meta_io.o
+00:07:48   CC [M]  fs/ocfs2/dir.o
+00:07:48   AR      drivers/input/misc/built-in.a
+00:07:48   CC [M]  drivers/input/misc/apanel.o
+00:07:48   CC [M]  drivers/input/touchscreen/msg2638.o
+00:07:48   LD [M]  drivers/usb/typec/ucsi/typec_ucsi.o
+00:07:48   CC [M]  drivers/net/vxlan/vxlan_core.o
+00:07:48   CC [M]  drivers/usb/typec/tipd/core.o
+00:07:48   CC [M]  net/rds/ib_sysctl.o
+00:07:48   CC [M]  net/sctp/stream_sched_rr.o
+00:07:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmm.o
+00:07:49   CC [M]  net/mac80211/ibss.o
+00:07:49   CC [M]  fs/gfs2/aops.o
+00:07:49   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_filter.o
+00:07:49   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb_init.o
+00:07:49   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/cyan_skillfish_ppt.o
+00:07:49   CC [M]  drivers/gpu/drm/i915/i915_gpu_error.o
+00:07:49   CC [M]  drivers/input/touchscreen/mtouch.o
+00:07:49   CC [M]  drivers/input/misc/ati_remote2.o
+00:07:49   CC [M]  drivers/usb/typec/tipd/trace.o
+00:07:49   CC [M]  drivers/input/touchscreen/usbtouchscreen.o
+00:07:50   CC [M]  net/rds/ib_rdma.o
+00:07:50   CC [M]  net/sctp/stream_interleave.o
+00:07:50   CC [M]  drivers/input/misc/atlas_btns.o
+00:07:50   CC [M]  fs/xfs/xfs_xattr.o
+00:07:50   CC [M]  fs/gfs2/dentry.o
+00:07:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu11/smu_v11_0.o
+00:07:50   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb_main.o
+00:07:50   LD [M]  drivers/usb/typec/tipd/tps6598x.o
+00:07:50   CC [M]  drivers/usb/typec/mux/pi3usb30532.o
+00:07:50   CC [M]  drivers/input/misc/cm109.o
+00:07:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmnv04.o
+00:07:50   CC [M]  drivers/input/touchscreen/penmount.o
+00:07:50   CC [M]  fs/gfs2/export.o
+00:07:51   CC [M]  fs/xfs/kmem.o
+00:07:51   CC [M]  net/mac80211/iface.o
+00:07:51   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_tc_u32.o
+00:07:51   CC [M]  drivers/input/touchscreen/pixcir_i2c_ts.o
+00:07:51   CC [M]  net/rds/ib_frmr.o
+00:07:51   CC [M]  drivers/gpu/drm/i915/i915_vgpu.o
+00:07:51   CC [M]  drivers/input/misc/cma3000_d0x.o
+00:07:51   CC [M]  drivers/usb/typec/mux/intel_pmc_mux.o
+00:07:51   CC [M]  fs/gfs2/file.o
+00:07:51   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb_mac.o
+00:07:51   CC [M]  net/sctp/proc.o
+00:07:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmnv41.o
+00:07:51   CC [M]  fs/ocfs2/dlmglue.o
+00:07:51   CC [M]  drivers/input/misc/cma3000_d0x_i2c.o
+00:07:51   CC [M]  drivers/scsi/ufs/ufs-sysfs.o
+00:07:51   LD [M]  drivers/net/vxlan/vxlan.o
+00:07:51   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu12/renoir_ppt.o
+00:07:51   CC [M]  fs/ocfs2/export.o
+00:07:51   CC [M]  drivers/usb/typec/class.o
+00:07:52   CC [M]  drivers/input/touchscreen/raydium_i2c_ts.o
+00:07:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmnv44.o
+00:07:52   CC [M]  drivers/gpu/drm/i915/intel_gvt.o
+00:07:52   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_ptp.o
+00:07:52   CC [M]  net/rds/tcp.o
+00:07:52   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb_mcu.o
+00:07:52   CC [M]  net/sctp/sysctl.o
+00:07:52   CC [M]  drivers/input/misc/e3x0-button.o
+00:07:52   CC [M]  fs/gfs2/ops_fstype.o
+00:07:52   CC [M]  fs/xfs/xfs_log.o
+00:07:52   CC [M]  drivers/usb/typec/mux.o
+00:07:53   CC [M]  drivers/input/misc/gpio-vibra.o
+00:07:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu12/smu_v12_0.o
+00:07:53   CC [M]  drivers/input/touchscreen/silead.o
+00:07:53   CC [M]  net/mac80211/rate.o
+00:07:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmnv50.o
+00:07:53   CC [M]  drivers/usb/typec/bus.o
+00:07:53   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/pci.o
+00:07:53   CC [M]  drivers/gpu/drm/i915/gvt/gvt.o
+00:07:53   CC [M]  drivers/scsi/ufs/ufs-debugfs.o
+00:07:53   CC [M]  fs/ocfs2/extent_map.o
+00:07:53   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_tc_flower.o
+00:07:53   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x2/usb_phy.o
+00:07:53   CC [M]  net/sctp/ipv6.o
+00:07:53   CC [M]  drivers/usb/typec/port-mapper.o
+00:07:53   CC [M]  net/rds/tcp_connect.o
+00:07:53   CC [M]  drivers/input/misc/iqs269a.o
+00:07:54   CC [M]  fs/gfs2/inode.o
+00:07:54   CC [M]  drivers/input/touchscreen/sis_i2c.o
+00:07:54   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu13/smu_v13_0.o
+00:07:54   CC [M]  drivers/scsi/ufs/ufs_bsg.o
+00:07:54   CC [M]  drivers/usb/typec/hd3ss3220.o
+00:07:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmmcp77.o
+00:07:54   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/soc.o
+00:07:54   CC [M]  drivers/gpu/drm/i915/gvt/aperture_gm.o
+00:07:54   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x2/mt76x2-common.o
+00:07:54   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x2/mt76x2e.o
+00:07:54   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x2/mt76x2u.o
+00:07:54   CC [M]  net/rds/tcp_listen.o
+00:07:54   CC [M]  net/rds/tcp_recv.o
+00:07:54   CC [M]  drivers/input/touchscreen/st1232.o
+00:07:54   CC [M]  drivers/input/misc/iqs626a.o
+00:07:55   CC [M]  net/mac80211/michael.o
+00:07:55   CC [M]  drivers/scsi/ufs/ufshcd-crypto.o
+00:07:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgf100.o
+00:07:55   CC [M]  drivers/usb/typec/stusb160x.o
+00:07:55   CC [M]  net/sctp/diag.o
+00:07:55   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_cudbg.o
+00:07:55   CC [M]  fs/ocfs2/file.o
+00:07:55   CC [M]  fs/gfs2/quota.o
+00:07:55   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/main.o
+00:07:55   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu13/aldebaran_ppt.o
+00:07:55   CC [M]  fs/xfs/xfs_log_cil.o
+00:07:55   CC [M]  drivers/input/touchscreen/surface3_spi.o
+00:07:55   CC [M]  drivers/gpu/drm/i915/gvt/handlers.o
+00:07:55   CC [M]  net/mac80211/tkip.o
+00:07:55   CC [M]  drivers/scsi/ufs/cdns-pltfrm.o
+00:07:55   LD [M]  drivers/usb/typec/typec.o
+00:07:55   CC [M]  drivers/net/ethernet/emulex/benet/be_main.o
+00:07:55   CC [M]  net/rds/tcp_send.o
+00:07:55   AR      drivers/usb/built-in.a
+00:07:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgk104.o
+00:07:56   CC [M]  drivers/net/ethernet/emulex/benet/be_cmds.o
+00:07:56   CC [M]  drivers/input/misc/keyspan_remote.o
+00:07:56   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_mps.o
+00:07:56   LD [M]  net/sctp/sctp.o
+00:07:56   LD [M]  net/sctp/sctp_diag.o
+00:07:56   CC [M]  drivers/net/ethernet/emulex/benet/be_ethtool.o
+00:07:56   CC [M]  drivers/input/touchscreen/touchit213.o
+00:07:56   CC [M]  drivers/scsi/ufs/ufshcd-pci.o
+00:07:56   CC [M]  drivers/input/misc/kxtj9.o
+00:07:56   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/init.o
+00:07:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgk20a.o
+00:07:56   CC [M]  drivers/input/touchscreen/touchright.o
+00:07:56   CC [M]  fs/gfs2/recovery.o
+00:07:57   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu13/yellow_carp_ppt.o
+00:07:57   CC [M]  net/rds/tcp_stats.o
+00:07:57   CC [M]  net/mac80211/aes_cmac.o
+00:07:57   CC [M]  drivers/input/touchscreen/touchwin.o
+00:07:57   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cudbg_common.o
+00:07:57   CC [M]  drivers/scsi/ufs/ufshcd-pltfrm.o
+00:07:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgm200.o
+00:07:57   CC [M]  drivers/input/misc/pcspkr.o
+00:07:57   CC [M]  fs/xfs/xfs_bmap_item.o
+00:07:57   CC [M]  fs/gfs2/rgrp.o
+00:07:57   CC [M]  drivers/input/touchscreen/tsc40.o
+00:07:57   CC [M]  drivers/net/ethernet/chelsio/cxgb4vf/cxgb4vf_main.o
+00:07:57   CC [M]  drivers/input/misc/powermate.o
+00:07:58   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/mcu.o
+00:07:58   CC [M]  fs/ocfs2/heartbeat.o
+00:07:58   LD [M]  net/rds/rds.o
+00:07:58   LD [M]  net/rds/rds_rdma.o
+00:07:58   LD [M]  net/rds/rds_tcp.o
+00:07:58   AR      drivers/net/wireless/microchip/built-in.a
+00:07:58   CC      drivers/gpu/drm/drm_probe_helper.o
+00:07:58   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/amdgpu_smu.o
+00:07:58   CC [M]  net/mac80211/aes_gmac.o
+00:07:58   LD [M]  drivers/scsi/ufs/ufshcd-core.o
+00:07:58   CC [M]  drivers/input/touchscreen/tsc2007_core.o
+00:07:58   CC [M]  drivers/scsi/mvsas/mv_init.o
+00:07:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgm20b.o
+00:07:58   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cudbg_lib.o
+00:07:58   CC [M]  drivers/input/misc/pwm-beeper.o
+00:07:58   CC [M]  fs/xfs/xfs_buf_item.o
+00:07:58   CC [M]  drivers/net/can/dev/bittiming.o
+00:07:59   CC [M]  drivers/input/touchscreen/tsc2007_iio.o
+00:07:59   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/core.o
+00:07:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgp100.o
+00:07:59   AR      drivers/net/wireless/mediatek/built-in.a
+00:07:59   CC [M]  drivers/scsi/mvsas/mv_sas.o
+00:07:59   CC [M]  drivers/net/ethernet/chelsio/cxgb4vf/t4vf_hw.o
+00:07:59   CC [M]  drivers/net/ethernet/emulex/benet/be_roce.o
+00:07:59   CC [M]  net/mac80211/fils_aead.o
+00:07:59   CC [M]  drivers/input/misc/axp20x-pek.o
+00:07:59   CC [M]  fs/ocfs2/inode.o
+00:07:59   CC [M]  fs/gfs2/super.o
+00:07:59   CC [M]  drivers/gpu/drm/i915/gvt/vgpu.o
+00:07:59   CC [M]  drivers/net/can/dev/dev.o
+00:07:59   CC [M]  drivers/input/touchscreen/wacom_w8001.o
+00:07:59   CC [M]  drivers/input/misc/rotary_encoder.o
+00:07:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/swsmu/smu_cmn.o
+00:08:00   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/dma.o
+00:08:00   AR      drivers/net/ethernet/emulex/built-in.a
+00:08:00   CC [M]  drivers/net/ethernet/google/gve/gve_main.o
+00:08:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgp10b.o
+00:08:00   LD [M]  drivers/net/ethernet/emulex/benet/be2net.o
+00:08:00   CC [M]  drivers/net/ethernet/google/gve/gve_tx.o
+00:08:00   CC [M]  drivers/input/misc/soc_button_array.o
+00:08:00   CC [M]  net/mac80211/cfg.o
+00:08:00   CC [M]  drivers/input/touchscreen/wacom_i2c.o
+00:08:00   CC [M]  drivers/scsi/mvsas/mv_64xx.o
+00:08:00   CC [M]  drivers/net/ethernet/chelsio/cxgb4vf/sge.o
+00:08:00   CC [M]  fs/xfs/xfs_buf_item_recover.o
+00:08:00   CC [M]  fs/gfs2/sys.o
+00:08:00   CC [M]  drivers/net/can/dev/length.o
+00:08:00   CC [M]  drivers/gpu/drm/i915/gvt/trace_points.o
+00:08:00   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cudbg_zlib.o
+00:08:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmgv100.o
+00:08:01   CC [M]  drivers/input/misc/uinput.o
+00:08:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/smumgr.o
+00:08:01   CC [M]  drivers/input/touchscreen/zet6223.o
+00:08:01   CC [M]  fs/ocfs2/ioctl.o
+00:08:01   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/mac.o
+00:08:01   CC [M]  fs/gfs2/trans.o
+00:08:01   CC [M]  fs/gfs2/util.o
+00:08:01   CC [M]  drivers/net/ethernet/google/gve/gve_tx_dqo.o
+00:08:01   CC [M]  drivers/scsi/mvsas/mv_94xx.o
+00:08:01   CC [M]  drivers/net/can/dev/netlink.o
+00:08:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/vmmtu102.o
+00:08:01   CC [M]  drivers/input/misc/xen-kbdfront.o
+00:08:01   CC [M]  drivers/gpu/drm/i915/gvt/firmware.o
+00:08:02   CC [M]  drivers/input/touchscreen/zforce_ts.o
+00:08:02   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_tc_mqprio.o
+00:08:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/smu8_smumgr.o
+00:08:02   CC [M]  fs/ocfs2/journal.o
+00:08:02   LD [M]  drivers/net/ethernet/chelsio/cxgb4vf/cxgb4vf.o
+00:08:02   CC [M]  net/tipc/addr.o
+00:08:02   CC [M]  fs/gfs2/lock_dlm.o
+00:08:02   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00dev.o
+00:08:02   CC [M]  drivers/input/misc/yealink.o
+00:08:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/umem.o
+00:08:02   CC [M]  drivers/net/can/dev/rx-offload.o
+00:08:02   CC [M]  fs/xfs/xfs_dquot_item_recover.o
+00:08:02   LD [M]  drivers/scsi/mvsas/mvsas.o
+00:08:02   CC [M]  drivers/net/ethernet/google/gve/gve_rx.o
+00:08:02   CC [M]  drivers/scsi/cxgbi/cxgb3i/cxgb3i.o
+00:08:02   CC [M]  drivers/input/touchscreen/iqs5xx.o
+00:08:03   CC [M]  net/tipc/bcast.o
+00:08:03   CC [M]  drivers/gpu/drm/i915/gvt/interrupt.o
+00:08:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/tonga_smumgr.o
+00:08:03   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/eeprom.o
+00:08:03   CC [M]  drivers/input/misc/ideapad_slidebar.o
+00:08:03   CC [M]  net/mac80211/ethtool.o
+00:08:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/ummu.o
+00:08:03   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_tc_matchall.o
+00:08:03   CC [M]  fs/xfs/xfs_extfree_item.o
+00:08:03   LD [M]  fs/gfs2/gfs2.o
+00:08:03   CC [M]  drivers/net/ppp/ppp_generic.o
+00:08:03   CC [M]  drivers/net/can/dev/skb.o
+00:08:03   CC [M]  drivers/net/ethernet/google/gve/gve_rx_dqo.o
+00:08:03   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00mac.o
+00:08:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/fiji_smumgr.o
+00:08:03   CC [M]  drivers/input/touchscreen/zinitix.o
+00:08:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mmu/uvmm.o
+00:08:04   CC [M]  drivers/gpu/drm/i915/gvt/gtt.o
+00:08:04   CC [M]  net/tipc/bearer.o
+00:08:04   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/beacon.o
+00:08:04   CC [M]  fs/ocfs2/localalloc.o
+00:08:04   CC [M]  drivers/scsi/cxgbi/cxgb4i/cxgb4i.o
+00:08:04   LD [M]  drivers/net/can/dev/can-dev.o
+00:08:04   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_dcb.o
+00:08:04   CC [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd-core.o
+00:08:04   CC [M]  net/mac80211/rx.o
+00:08:04   LD [M]  drivers/input/touchscreen/tsc2007.o
+00:08:05   CC [M]  drivers/input/rmi4/rmi_bus.o
+00:08:05   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00config.o
+00:08:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mxm/base.o
+00:08:05   CC [M]  drivers/net/ethernet/google/gve/gve_ethtool.o
+00:08:05   CC [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd-crc16.o
+00:08:05   CC [M]  drivers/net/wireless/mediatek/mt76/mt7603/debugfs.o
+00:08:05   CC [M]  fs/xfs/xfs_icreate_item.o
+00:08:05   CC [M]  drivers/net/ppp/ppp_async.o
+00:08:05   CC [M]  drivers/input/rmi4/rmi_driver.o
+00:08:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/polaris10_smumgr.o
+00:08:05   CC [M]  net/tipc/core.o
+00:08:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mxm/mxms.o
+00:08:05   CC [M]  drivers/net/ethernet/google/gve/gve_adminq.o
+00:08:06   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00queue.o
+00:08:06   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_debugfs.o
+00:08:06   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/main.o
+00:08:06   CC [M]  fs/ocfs2/locks.o
+00:08:06   LD [M]  drivers/net/wireless/mediatek/mt76/mt7603/mt7603e.o
+00:08:06   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/init.o
+00:08:06   CC [M]  drivers/net/ppp/bsd_comp.o
+00:08:06   CC [M]  drivers/gpu/drm/i915/gvt/cfg_space.o
+00:08:06   CC [M]  drivers/input/rmi4/rmi_f01.o
+00:08:06   CC [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd-regmap.o
+00:08:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/mxm/nv50.o
+00:08:06   CC [M]  drivers/scsi/cxgbi/libcxgbi.o
+00:08:06   CC [M]  net/tipc/link.o
+00:08:06   CC [M]  fs/ocfs2/mmap.o
+00:08:06   CC [M]  drivers/net/ethernet/google/gve/gve_utils.o
+00:08:07   CC [M]  drivers/net/ppp/ppp_deflate.o
+00:08:07   CC [M]  drivers/input/rmi4/rmi_2d_sensor.o
+00:08:07   CC [M]  fs/xfs/xfs_inode_item.o
+00:08:07   CC [M]  drivers/net/ppp/ppp_mppe.o
+00:08:07   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00link.o
+00:08:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/agp.o
+00:08:07   LD [M]  drivers/net/ethernet/google/gve/gve.o
+00:08:07   AR      drivers/net/ethernet/google/built-in.a
+00:08:07   CC [M]  net/tipc/discover.o
+00:08:07   CC [M]  drivers/gpu/drm/i915/gvt/opregion.o
+00:08:07   AR      drivers/net/wireless/ralink/built-in.a
+00:08:07   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/mcu.o
+00:08:07   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/iceland_smumgr.o
+00:08:07   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/smu7_smumgr.o
+00:08:07   CC [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd-timestamp.o
+00:08:07   CC [M]  drivers/input/rmi4/rmi_f03.o
+00:08:07   CC [M]  net/mac80211/spectmgmt.o
+00:08:08   CC [M]  drivers/net/ppp/ppp_synctty.o
+00:08:08   CC [M]  fs/ocfs2/namei.o
+00:08:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/base.o
+00:08:08   CC [M]  drivers/input/rmi4/rmi_f11.o
+00:08:08   CC [M]  fs/f2fs/dir.o
+00:08:08   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00debug.o
+00:08:08 drivers/gpu/drm/i915/gvt/opregion.c: In function ‘intel_vgpu_init_opregion’:
+00:08:08 drivers/gpu/drm/i915/gvt/opregion.c:35:28: warning: initializer-string for array of ‘char’ is too long [-Wunterminated-string-initialization]
+00:08:08    35 | #define OPREGION_SIGNATURE "IntelGraphicsMem"
+00:08:08       |                            ^~~~~~~~~~~~~~~~~~
+00:08:08 drivers/gpu/drm/i915/gvt/opregion.c:225:45: note: in expansion of macro ‘OPREGION_SIGNATURE’
+00:08:08   225 |         const char opregion_signature[16] = OPREGION_SIGNATURE;
+00:08:08       |                                             ^~~~~~~~~~~~~~~~~~
+00:08:08   CC [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd-dump.o
+00:08:08   CC [M]  drivers/gpu/drm/i915/gvt/mmio.o
+00:08:08   CC [M]  fs/ceph/super.o
+00:08:08   CC [M]  drivers/net/ppp/pppox.o
+00:08:09   CC [M]  net/mac80211/tx.o
+00:08:09   CC [M]  drivers/scsi/bnx2i/bnx2i_init.o
+00:08:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/pcie.o
+00:08:09   CC [M]  drivers/input/rmi4/rmi_f12.o
+00:08:09   CC [M]  net/tipc/msg.o
+00:08:09   CC [M]  fs/xfs/xfs_inode_item_recover.o
+00:08:09   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/eeprom.o
+00:08:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/vega10_smumgr.o
+00:08:09   LD [M]  drivers/net/can/spi/mcp251xfd/mcp251xfd.o
+00:08:09   CC [M]  drivers/net/can/spi/hi311x.o
+00:08:09   CC [M]  drivers/input/rmi4/rmi_f30.o
+00:08:09   CC [M]  drivers/net/ppp/pppoe.o
+00:08:09   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00crypto.o
+00:08:09   CC [M]  fs/f2fs/file.o
+00:08:09   CC [M]  drivers/gpu/drm/i915/gvt/display.o
+00:08:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/nv04.o
+00:08:10   CC [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4_thermal.o
+00:08:10   CC [M]  drivers/scsi/bnx2i/bnx2i_hwi.o
+00:08:10   CC [M]  fs/ceph/inode.o
+00:08:10   CC [M]  drivers/input/rmi4/rmi_f34.o
+00:08:10   CC [M]  net/tipc/name_distr.o
+00:08:10   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/mac.o
+00:08:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/nv40.o
+00:08:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/smu10_smumgr.o
+00:08:10   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00firmware.o
+00:08:10   CC [M]  drivers/net/can/spi/mcp251x.o
+00:08:11   CC [M]  drivers/input/rmi4/rmi_f34v7.o
+00:08:11   CC [M]  fs/ocfs2/refcounttree.o
+00:08:11   LD [M]  drivers/net/ethernet/chelsio/cxgb4/cxgb4.o
+00:08:11   CC [M]  drivers/net/ppp/pptp.o
+00:08:11   CC [M]  drivers/gpu/drm/i915/gvt/edid.o
+00:08:11   CC [M]  drivers/net/ethernet/chelsio/libcxgb/libcxgb_ppm.o
+00:08:11   CC [M]  fs/xfs/xfs_refcount_item.o
+00:08:11   CC [M]  net/tipc/subscr.o
+00:08:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/nv46.o
+00:08:11   CC [M]  drivers/scsi/bnx2i/bnx2i_iscsi.o
+00:08:11   CC [M]  fs/ceph/dir.o
+00:08:11   CC [M]  drivers/input/rmi4/rmi_f3a.o
+00:08:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/ci_smumgr.o
+00:08:12   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00leds.o
+00:08:12   CC [M]  drivers/net/ethernet/chelsio/libcxgb/libcxgb_cm.o
+00:08:12   CC [M]  fs/xfs/xfs_rmap_item.o
+00:08:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/nv4c.o
+00:08:12   CC [M]  net/tipc/monitor.o
+00:08:12   CC [M]  drivers/gpu/drm/i915/gvt/execlist.o
+00:08:12   CC [M]  drivers/net/can/usb/kvaser_usb/kvaser_usb_core.o
+00:08:12   CC [M]  drivers/input/rmi4/rmi_f55.o
+00:08:12   CC [M]  drivers/gpu/drm/i915/gvt/scheduler.o
+00:08:12   CC [M]  net/mac80211/key.o
+00:08:12   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/debugfs.o
+00:08:12   CC [M]  drivers/scsi/bnx2i/bnx2i_sysfs.o
+00:08:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/g84.o
+00:08:13   CC [M]  fs/xfs/xfs_log_recover.o
+00:08:13   CC [M]  drivers/input/rmi4/rmi_i2c.o
+00:08:13   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00mmio.o
+00:08:13   CC [M]  fs/f2fs/inode.o
+00:08:13   LD [M]  drivers/net/ethernet/chelsio/libcxgb/libcxgb.o
+00:08:13   CC [M]  net/tipc/name_table.o
+00:08:13   AR      drivers/net/ethernet/chelsio/built-in.a
+00:08:13   CC [M]  drivers/net/ethernet/intel/e1000/e1000_main.o
+00:08:13   CC [M]  fs/ceph/file.o
+00:08:13   CC [M]  drivers/net/can/usb/kvaser_usb/kvaser_usb_leaf.o
+00:08:13   CC [M]  drivers/net/ethernet/intel/e1000e/82571.o
+00:08:13   LD [M]  drivers/scsi/bnx2i/bnx2i.o
+00:08:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/g92.o
+00:08:13   CC [M]  drivers/scsi/qedi/qedi_main.o
+00:08:13   CC [M]  drivers/input/rmi4/rmi_spi.o
+00:08:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/vega12_smumgr.o
+00:08:14   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/trace.o
+00:08:14   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00pci.o
+00:08:14   CC [M]  drivers/gpu/drm/i915/gvt/sched_policy.o
+00:08:14   CC [M]  net/mac80211/util.o
+00:08:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/g94.o
+00:08:14   CC [M]  drivers/input/rmi4/rmi_smbus.o
+00:08:14   CC [M]  fs/f2fs/namei.o
+00:08:14   CC [M]  net/tipc/net.o
+00:08:14   CC [M]  drivers/net/ethernet/intel/e1000e/ich8lan.o
+00:08:14   CC [M]  fs/ocfs2/reservations.o
+00:08:14   CC [M]  drivers/net/can/usb/kvaser_usb/kvaser_usb_hydra.o
+00:08:15   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/pci.o
+00:08:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/vegam_smumgr.o
+00:08:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/gf100.o
+00:08:15   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2x00usb.o
+00:08:15   CC [M]  fs/ceph/locks.o
+00:08:15   LD [M]  drivers/input/rmi4/rmi_core.o
+00:08:15   CC      drivers/input/input.o
+00:08:15   CC [M]  drivers/scsi/qedi/qedi_iscsi.o
+00:08:15   CC [M]  drivers/gpu/drm/i915/gvt/mmio_context.o
+00:08:15   CC [M]  fs/xfs/xfs_trans_ail.o
+00:08:15   CC [M]  net/tipc/netlink.o
+00:08:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/gf106.o
+00:08:16   CC [M]  drivers/net/ethernet/intel/e1000/e1000_hw.o
+00:08:16   CC [M]  fs/f2fs/hash.o
+00:08:16   CC [M]  fs/ceph/addr.o
+00:08:16   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/pci_init.o
+00:08:16   CC [M]  fs/ocfs2/move_extents.o
+00:08:16   LD [M]  drivers/net/can/usb/kvaser_usb/kvaser_usb.o
+00:08:16   CC [M]  drivers/net/can/usb/peak_usb/pcan_usb_core.o
+00:08:16   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2800lib.o
+00:08:16   CC [M]  net/tipc/netlink_compat.o
+00:08:16   CC      drivers/input/input-compat.o
+00:08:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/gk104.o
+00:08:16   CC [M]  fs/f2fs/super.o
+00:08:16   CC [M]  drivers/scsi/qedi/qedi_fw.o
+00:08:16   CC [M]  drivers/net/ethernet/intel/e1000e/80003es2lan.o
+00:08:16   CC [M]  drivers/gpu/drm/i915/gvt/cmd_parser.o
+00:08:16   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/smu9_smumgr.o
+00:08:17   CC      drivers/input/input-mt.o
+00:08:17   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/dma.o
+00:08:17   CC [M]  fs/ocfs2/resize.o
+00:08:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pci/gp100.o
+00:08:17   CC [M]  drivers/net/can/usb/peak_usb/pcan_usb.o
+00:08:17   CC      drivers/input/input-poller.o
+00:08:17   CC [M]  net/mac80211/wme.o
+00:08:17   CC [M]  fs/xfs/xfs_trans_buf.o
+00:08:17   CC [M]  drivers/net/ethernet/intel/e1000e/mac.o
+00:08:17   CC [M]  net/tipc/node.o
+00:08:18   CC [M]  fs/ceph/ioctl.o
+00:08:18   CC      drivers/input/ff-core.o
+00:08:18   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/smumgr/vega20_smumgr.o
+00:08:18   CC [M]  drivers/net/ethernet/intel/e1000/e1000_ethtool.o
+00:08:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/base.o
+00:08:18   CC [M]  drivers/scsi/qedi/qedi_sysfs.o
+00:08:18   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/pci_mac.o
+00:08:18   CC      drivers/input/touchscreen.o
+00:08:18   CC [M]  drivers/net/can/usb/peak_usb/pcan_usb_pro.o
+00:08:18   CC [M]  net/mac80211/chan.o
+00:08:18   CC [M]  fs/ceph/export.o
+00:08:18   CC [M]  drivers/net/ethernet/intel/e1000e/manage.o
+00:08:19   CC [M]  fs/ocfs2/slot_map.o
+00:08:19   CC [M]  drivers/gpu/drm/i915/gvt/debugfs.o
+00:08:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/memx.o
+00:08:19   CC [M]  drivers/scsi/qedi/qedi_dbg.o
+00:08:19   CC      drivers/input/input-leds.o
+00:08:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/hwmgr.o
+00:08:19   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/mmio.o
+00:08:19   CC [M]  fs/xfs/xfs_dquot.o
+00:08:19   CC      drivers/input/mousedev.o
+00:08:19   CC [M]  drivers/net/ethernet/intel/e1000e/nvm.o
+00:08:19   CC [M]  drivers/net/ethernet/intel/e1000/e1000_param.o
+00:08:19   CC [M]  fs/ceph/caps.o
+00:08:19   CC [M]  drivers/net/can/usb/peak_usb/pcan_usb_fd.o
+00:08:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gt215.o
+00:08:20   CC [M]  drivers/scsi/qedi/qedi_fw_api.o
+00:08:20   CC [M]  drivers/gpu/drm/i915/gvt/fb_decoder.o
+00:08:20   CC [M]  net/tipc/socket.o
+00:08:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/processpptables.o
+00:08:20   CC      drivers/input/evdev.o
+00:08:20   CC [M]  fs/ocfs2/suballoc.o
+00:08:20   CC [M]  drivers/net/ethernet/intel/e1000e/phy.o
+00:08:20   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/usb_sdio.o
+00:08:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gf100.o
+00:08:20   LD [M]  drivers/net/ethernet/intel/e1000/e1000.o
+00:08:20   CC [M]  drivers/scsi/qedi/qedi_debugfs.o
+00:08:20   CC [M]  net/mac80211/trace.o
+00:08:20   CC [M]  net/smc/af_smc.o
+00:08:21   LD [M]  drivers/net/can/usb/peak_usb/peak_usb.o
+00:08:21   CC [M]  drivers/net/can/usb/usb_8dev.o
+00:08:21   CC [M]  fs/f2fs/inline.o
+00:08:21   CC [M]  drivers/gpu/drm/i915/gvt/dmabuf.o
+00:08:21   CC [M]  drivers/input/ff-memless.o
+00:08:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gf119.o
+00:08:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/hardwaremanager.o
+00:08:21   LD [M]  drivers/scsi/qedi/qedi.o
+00:08:21   CC [M]  drivers/scsi/be2iscsi/be_iscsi.o
+00:08:21   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/usb.o
+00:08:21   CC [M]  fs/xfs/xfs_dquot_item.o
+00:08:22   CC [M]  drivers/net/ethernet/intel/e1000e/param.o
+00:08:22   CC [M]  drivers/input/sparse-keymap.o
+00:08:22   CC [M]  drivers/net/can/usb/ems_usb.o
+00:08:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gk104.o
+00:08:22   CC [M]  drivers/input/matrix-keymap.o
+00:08:22   CC [M]  fs/ceph/snap.o
+00:08:22   CC [M]  drivers/gpu/drm/i915/gvt/page_track.o
+00:08:22   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2800mmio.o
+00:08:22   CC [M]  fs/xfs/xfs_trans_dquot.o
+00:08:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu8_hwmgr.o
+00:08:22   CC [M]  fs/f2fs/checkpoint.o
+00:08:22   CC [M]  drivers/net/ethernet/intel/e1000e/ethtool.o
+00:08:23   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/usb_mcu.o
+00:08:23   CC [M]  drivers/input/joydev.o
+00:08:23   CC [M]  net/smc/smc_pnet.o
+00:08:23   CC [M]  drivers/scsi/be2iscsi/be_main.o
+00:08:23   CC [M]  fs/ocfs2/super.o
+00:08:23   CC [M]  net/tipc/eth_media.o
+00:08:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gk110.o
+00:08:23   CC [M]  drivers/net/can/usb/gs_usb.o
+00:08:23   CC [M]  drivers/gpu/drm/i915/gvt/kvmgt.o
+00:08:23   CC [M]  fs/ceph/xattr.o
+00:08:23   CC [M]  net/tipc/topsrv.o
+00:08:23   AR      drivers/input/built-in.a
+00:08:23   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2400pci.o
+00:08:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gk208.o
+00:08:24   CC [M]  fs/xfs/xfs_qm_syscalls.o
+00:08:24   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/sdio.o
+00:08:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/pppcielanes.o
+00:08:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/process_pptables_v1_0.o
+00:08:24   CC [M]  drivers/net/ethernet/intel/e1000e/netdev.o
+00:08:24   CC [M]  net/smc/smc_ib.o
+00:08:24   CC [M]  fs/f2fs/gc.o
+00:08:24   CC [M]  drivers/net/can/usb/mcba_usb.o
+00:08:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gk20a.o
+00:08:24   CC [M]  drivers/net/slip/slip.o
+00:08:24   CC [M]  fs/xfs/xfs_qm_bhv.o
+00:08:25   CC [M]  fs/ceph/quota.o
+00:08:25   CC [M]  net/tipc/group.o
+00:08:25   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/sdio_mcu.o
+00:08:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/ppatomctrl.o
+00:08:25   LD [M]  drivers/gpu/drm/i915/i915.o
+00:08:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gm107.o
+00:08:25   CC [M]  fs/xfs/xfs_qm.o
+00:08:25   CC [M]  drivers/net/slip/slhc.o
+00:08:25   CC [M]  drivers/scsi/be2iscsi/be_mgmt.o
+00:08:25   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2500pci.o
+00:08:25   CC [M]  net/smc/smc_clc.o
+00:08:25   CC [M]  drivers/net/can/ifi_canfd/ifi_canfd.o
+00:08:26   CC [M]  fs/ceph/io.o
+00:08:26   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/pci.o
+00:08:26   CC [M]  drivers/net/wireless/mediatek/mt76/mt7615/sdio_txrx.o
+00:08:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gm200.o
+00:08:26   CC [M]  net/tipc/trace.o
+00:08:26   CC [M]  fs/f2fs/data.o
+00:08:26   CC [M]  fs/ceph/mds_client.o
+00:08:27   CC [M]  fs/erofs/super.o
+00:08:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/ppatomfwctrl.o
+00:08:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gm20b.o
+00:08:27   CC [M]  drivers/scsi/be2iscsi/be_cmds.o
+00:08:27   CC [M]  drivers/net/can/m_can/m_can.o
+00:08:27   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/init.o
+00:08:27   CC [M]  net/smc/smc_core.o
+00:08:27   LD [M]  drivers/net/wireless/mediatek/mt76/mt7615/mt7615-common.o
+00:08:27   LD [M]  drivers/net/wireless/mediatek/mt76/mt7615/mt7615e.o
+00:08:27   LD [M]  drivers/net/wireless/mediatek/mt76/mt7615/mt7663-usb-sdio-common.o
+00:08:27   LD [M]  drivers/net/wireless/mediatek/mt76/mt7615/mt7663u.o
+00:08:27   LD [M]  drivers/net/wireless/mediatek/mt76/mt7615/mt7663s.o
+00:08:27   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/dev.o
+00:08:27   CC [M]  drivers/net/wireless/ralink/rt2x00/rt61pci.o
+00:08:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gp102.o
+00:08:28   CC [M]  fs/xfs/xfs_quotaops.o
+00:08:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu7_hwmgr.o
+00:08:28   CC [M]  drivers/net/ethernet/intel/e1000e/ptp.o
+00:08:28   CC [M]  net/tipc/udp_media.o
+00:08:28   CC [M]  fs/erofs/inode.o
+00:08:28   LD [M]  drivers/scsi/be2iscsi/be2iscsi.o
+00:08:28   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/dma.o
+00:08:28   CC [M]  drivers/scsi/esas2r/esas2r_log.o
+00:08:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/pmu/gp10b.o
+00:08:28   CC [M]  drivers/net/can/m_can/m_can_pci.o
+00:08:28   CC [M]  fs/xfs/xfs_rtalloc.o
+00:08:28   LD [M]  drivers/net/ethernet/intel/e1000e/e1000e.o
+00:08:28   CC [M]  net/mac80211/mlme.o
+00:08:29   CC [M]  drivers/net/ethernet/intel/igb/igb_main.o
+00:08:29   CC [M]  fs/erofs/data.o
+00:08:29   CC [M]  drivers/scsi/esas2r/esas2r_disc.o
+00:08:29   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/rtl8225.o
+00:08:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gf100.o
+00:08:29   CC [M]  net/smc/smc_wr.o
+00:08:29   CC [M]  net/tipc/sysctl.o
+00:08:29   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/eeprom.o
+00:08:29   CC [M]  fs/ceph/mdsmap.o
+00:08:29   CC [M]  drivers/net/can/peak_canfd/peak_pciefd_main.o
+00:08:29   CC [M]  fs/erofs/namei.o
+00:08:30   CC [M]  fs/xfs/xfs_acl.o
+00:08:30   CC [M]  fs/f2fs/node.o
+00:08:30   CC [M]  drivers/scsi/esas2r/esas2r_flash.o
+00:08:30   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2800pci.o
+00:08:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gf117.o
+00:08:30   CC [M]  fs/ocfs2/symlink.o
+00:08:30   CC [M]  fs/erofs/dir.o
+00:08:30   CC [M]  net/tipc/crypto.o
+00:08:30   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/sa2400.o
+00:08:30   CC [M]  fs/ceph/strings.o
+00:08:30   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/main.o
+00:08:30   CC [M]  drivers/net/can/peak_canfd/peak_canfd.o
+00:08:30   CC [M]  net/smc/smc_llc.o
+00:08:30   CC [M]  fs/ceph/ceph_frag.o
+00:08:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gk104.o
+00:08:31   CC [M]  drivers/scsi/esas2r/esas2r_init.o
+00:08:31   CC [M]  fs/ocfs2/sysfile.o
+00:08:31   CC [M]  fs/erofs/utils.o
+00:08:31   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu7_powertune.o
+00:08:31   CC [M]  fs/ceph/debugfs.o
+00:08:31   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2500usb.o
+00:08:31   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/max2820.o
+00:08:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gk20a.o
+00:08:31   CC [M]  fs/ocfs2/uptodate.o
+00:08:31   CC [M]  fs/erofs/pcpubuf.o
+00:08:31   CC [M]  fs/xfs/xfs_sysctl.o
+00:08:31   LD [M]  drivers/net/can/peak_canfd/peak_pciefd.o
+00:08:31   CC [M]  drivers/net/can/vcan.o
+00:08:32   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/mcu.o
+00:08:32   CC [M]  fs/ceph/util.o
+00:08:32   CC [M]  net/tipc/diag.o
+00:08:32   CC [M]  drivers/scsi/esas2r/esas2r_int.o
+00:08:32   CC [M]  net/mac80211/tdls.o
+00:08:32   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu7_thermal.o
+00:08:32   CC [M]  fs/ceph/metric.o
+00:08:32   CC [M]  fs/erofs/xattr.o
+00:08:32   CC [M]  net/smc/smc_cdc.o
+00:08:32   CC [M]  fs/xfs/xfs_ioctl32.o
+00:08:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gm200.o
+00:08:32   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/grf5101.o
+00:08:32   CC [M]  drivers/net/can/vxcan.o
+00:08:32   CC [M]  fs/f2fs/segment.o
+00:08:33   CC [M]  drivers/net/wireless/ralink/rt2x00/rt73usb.o
+00:08:33   CC [M]  drivers/scsi/esas2r/esas2r_io.o
+00:08:33   LD [M]  net/tipc/tipc.o
+00:08:33   AR      drivers/net/wireless/rsi/built-in.a
+00:08:33   CC [M]  drivers/net/wireless/rsi/rsi_91x_main.o
+00:08:33   CC [M]  fs/ocfs2/quota_local.o
+00:08:33   CC [M]  drivers/net/ethernet/intel/igb/igb_ethtool.o
+00:08:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/privring/gp10b.o
+00:08:33   CC [M]  fs/ceph/cache.o
+00:08:33   CC [M]  fs/erofs/decompressor.o
+00:08:33   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu7_clockpowergating.o
+00:08:33   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/rtl8225se.o
+00:08:33   CC [M]  net/smc/smc_tx.o
+00:08:33   CC [M]  drivers/net/can/slcan.o
+00:08:34   CC [M]  drivers/scsi/esas2r/esas2r_ioctl.o
+00:08:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/base.o
+00:08:34   CC [M]  fs/erofs/zmap.o
+00:08:34   CC [M]  fs/ceph/acl.o
+00:08:34   CC [M]  net/mac80211/ocb.o
+00:08:34   CC [M]  drivers/net/wireless/rsi/rsi_91x_core.o
+00:08:34   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/mac.o
+00:08:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega10_processpptables.o
+00:08:34   CC [M]  fs/xfs/xfs_pnfs.o
+00:08:34   LD [M]  drivers/net/wireless/realtek/rtl818x/rtl8180/rtl818x_pci.o
+00:08:34   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8187/dev.o
+00:08:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/fan.o
+00:08:35   CC [M]  drivers/media/i2c/ccs/ccs-core.o
+00:08:35   CC [M]  drivers/scsi/esas2r/esas2r_targdb.o
+00:08:35   LD [M]  fs/ceph/ceph.o
+00:08:35   CC [M]  net/smc/smc_rx.o
+00:08:35   CC [M]  fs/erofs/zdata.o
+00:08:35   CC [M]  net/smc/smc_close.o
+00:08:35   CC [M]  drivers/net/wireless/ralink/rt2x00/rt2800usb.o
+00:08:35   CC [M]  fs/ocfs2/quota_global.o
+00:08:35   CC [M]  drivers/net/ethernet/intel/igb/e1000_82575.o
+00:08:35   CC [M]  fs/xfs/scrub/trace.o
+00:08:35   CC [M]  drivers/net/wireless/rsi/rsi_91x_mac80211.o
+00:08:35   CC [M]  net/mac80211/airtime.o
+00:08:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/fannil.o
+00:08:35   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega10_hwmgr.o
+00:08:35   CC [M]  drivers/scsi/esas2r/esas2r_vda.o
+00:08:36   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8187/rtl8225.o
+00:08:36   CC [M]  net/mac80211/led.o
+00:08:36   CC [M]  net/smc/smc_ism.o
+00:08:36   LD [M]  fs/erofs/erofs.o
+00:08:36   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/debugfs.o
+00:08:36   CC [M]  net/mac80211/debugfs.o
+00:08:36   LD [M]  drivers/net/wireless/ralink/rt2x00/rt2x00lib.o
+00:08:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/fanpwm.o
+00:08:36   CC [M]  drivers/scsi/esas2r/esas2r_main.o
+00:08:36   CC [M]  drivers/media/i2c/et8ek8/et8ek8_mode.o
+00:08:36   CC [M]  fs/f2fs/recovery.o
+00:08:36   CC [M]  drivers/net/ethernet/intel/igb/e1000_mac.o
+00:08:36   CC [M]  drivers/net/wireless/rsi/rsi_91x_mgmt.o
+00:08:37   CC [M]  fs/xfs/scrub/agheader.o
+00:08:37   CC [M]  drivers/media/i2c/ccs/ccs-reg-access.o
+00:08:37   CC [M]  fs/ocfs2/xattr.o
+00:08:37   CC [M]  drivers/media/i2c/et8ek8/et8ek8_driver.o
+00:08:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/fantog.o
+00:08:37   CC [M]  drivers/net/ethernet/intel/igc/igc_main.o
+00:08:37   CC [M]  net/smc/smc_netlink.o
+00:08:37   CC [M]  net/smc/smc_stats.o
+00:08:37   LD [M]  drivers/scsi/esas2r/esas2r.o
+00:08:37   CC [M]  drivers/net/wireless/mediatek/mt76/mt7915/mmio.o
+00:08:37   CC      drivers/scsi/scsi.o
+00:08:37   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8187/leds.o
+00:08:37   CC [M]  fs/f2fs/shrinker.o
+00:08:38   CC [M]  fs/xfs/scrub/alloc.o
+00:08:38   CC [M]  drivers/media/i2c/ccs/ccs-quirk.o
+00:08:38   CC [M]  net/mac80211/debugfs_sta.o
+00:08:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/ic.o
+00:08:38   CC [M]  drivers/net/ethernet/intel/igb/e1000_nvm.o
+00:08:38   LD [M]  drivers/media/i2c/et8ek8/et8ek8.o
+00:08:38   CC [M]  drivers/net/wireless/realtek/rtl818x/rtl8187/rfkill.o
+00:08:38   CC [M]  drivers/net/wireless/rsi/rsi_91x_hal.o
+00:08:38   CC [M]  fs/f2fs/extent_cache.o
+00:08:38   CC [M]  net/rfkill/core.o
+00:08:38   LD [M]  drivers/net/wireless/mediatek/mt76/mt7915/mt7915e.o
+00:08:38   CC [M]  fs/xfs/scrub/attr.o
+00:08:38   CC [M]  net/smc/smc_diag.o
+00:08:38   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/pci.o
+00:08:38   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega10_powertune.o
+00:08:38   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/mac.o
+00:08:38   CC      drivers/scsi/hosts.o
+00:08:38   CC [M]  drivers/media/i2c/ccs/ccs-limits.o
+00:08:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/temp.o
+00:08:39   CC [M]  drivers/media/i2c/ccs/ccs-data.o
+00:08:39   CC [M]  drivers/net/ethernet/intel/igb/e1000_phy.o
+00:08:39   LD [M]  drivers/net/wireless/realtek/rtl818x/rtl8187/rtl8187.o
+00:08:39   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192c/main.o
+00:08:39   CC [M]  net/rfkill/input.o
+00:08:39   CC      drivers/scsi/scsi_ioctl.o
+00:08:39   CC [M]  fs/xfs/scrub/bmap.o
+00:08:39   CC [M]  drivers/net/wireless/rsi/rsi_91x_ps.o
+00:08:39   LD [M]  drivers/media/i2c/ccs/ccs.o
+00:08:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/nv40.o
+00:08:39   CC [M]  fs/f2fs/sysfs.o
+00:08:39   CC [M]  drivers/media/i2c/cx25840/cx25840-core.o
+00:08:39   LD [M]  net/smc/smc.o
+00:08:39   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192c/dm_common.o
+00:08:40   AR      drivers/media/tuners/built-in.a
+00:08:40   CC [M]  net/rfkill/rfkill-gpio.o
+00:08:40   CC [M]  drivers/media/tuners/tuner-xc2028.o
+00:08:40   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega10_thermal.o
+00:08:40   CC [M]  net/mac80211/debugfs_netdev.o
+00:08:40   CC [M]  drivers/net/ethernet/intel/igb/e1000_mbx.o
+00:08:40   CC [M]  drivers/media/tuners/tuner-simple.o
+00:08:40   LD [M]  net/rfkill/rfkill.o
+00:08:40   CC      drivers/gpu/drm/drm_plane_helper.o
+00:08:40   CC      drivers/scsi/scsicam.o
+00:08:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/nv50.o
+00:08:40   CC [M]  fs/xfs/scrub/btree.o
+00:08:40   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/mcu.o
+00:08:40   CC [M]  drivers/net/wireless/rsi/rsi_91x_coex.o
+00:08:40   CC [M]  drivers/net/ethernet/intel/igc/igc_mac.o
+00:08:41   CC [M]  fs/f2fs/debug.o
+00:08:41   CC [M]  drivers/net/ethernet/intel/igb/e1000_i210.o
+00:08:41   CC      drivers/scsi/scsi_error.o
+00:08:41   CC [M]  fs/vboxsf/dir.o
+00:08:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/g84.o
+00:08:41   CC [M]  drivers/net/wireless/st/cw1200/fwio.o
+00:08:41   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192c/fw_common.o
+00:08:41   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu10_hwmgr.o
+00:08:41   CC [M]  drivers/media/tuners/tuner-types.o
+00:08:41   CC [M]  fs/xfs/scrub/common.o
+00:08:41   CC [M]  fs/ocfs2/acl.o
+00:08:41   CC [M]  drivers/net/wireless/rsi/rsi_91x_debugfs.o
+00:08:41   CC [M]  drivers/net/ethernet/intel/igc/igc_i225.o
+00:08:42   CC [M]  fs/f2fs/xattr.o
+00:08:42   CC [M]  drivers/net/ethernet/intel/igb/igb_ptp.o
+00:08:42   CC [M]  net/mac80211/debugfs_key.o
+00:08:42   CC [M]  fs/vboxsf/file.o
+00:08:42   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/dma.o
+00:08:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gt215.o
+00:08:42   CC [M]  drivers/media/i2c/cx25840/cx25840-audio.o
+00:08:42   CC [M]  drivers/media/tuners/mt20xx.o
+00:08:42   CC [M]  fs/ocfs2/filecheck.o
+00:08:42   CC [M]  drivers/net/wireless/st/cw1200/txrx.o
+00:08:42   CC      drivers/scsi/scsi_lib.o
+00:08:42   CC [M]  fs/xfs/scrub/dabtree.o
+00:08:42   CC [M]  drivers/net/ethernet/intel/igc/igc_base.o
+00:08:42   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192c/phy_common.o
+00:08:42   CC [M]  drivers/net/wireless/rsi/rsi_91x_sdio.o
+00:08:42   CC [M]  fs/vboxsf/utils.o
+00:08:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gf100.o
+00:08:43   CC [M]  fs/f2fs/acl.o
+00:08:43   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/pp_psm.o
+00:08:43   CC [M]  drivers/net/ethernet/intel/igb/igb_hwmon.o
+00:08:43   CC [M]  drivers/media/i2c/cx25840/cx25840-firmware.o
+00:08:43   CC [M]  net/mac80211/mesh.o
+00:08:43   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/eeprom.o
+00:08:43   CC [M]  fs/ocfs2/stackglue.o
+00:08:43   CC [M]  drivers/media/tuners/tda8290.o
+00:08:43   CC [M]  drivers/net/ethernet/intel/igc/igc_nvm.o
+00:08:43   CC [M]  fs/xfs/scrub/dir.o
+00:08:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gf119.o
+00:08:43   CC [M]  fs/vboxsf/vboxsf_wrappers.o
+00:08:43   CC [M]  fs/f2fs/verity.o
+00:08:43   CC [M]  fs/ocfs2/stack_o2cb.o
+00:08:44   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega12_processpptables.o
+00:08:44   CC [M]  drivers/net/wireless/rsi/rsi_91x_sdio_ops.o
+00:08:44   CC [M]  drivers/media/i2c/cx25840/cx25840-vbi.o
+00:08:44   LD [M]  drivers/net/ethernet/intel/igb/igb.o
+00:08:44   CC      drivers/scsi/constants.o
+00:08:44   CC [M]  drivers/net/ethernet/intel/igc/igc_phy.o
+00:08:44   AR      drivers/net/wireless/st/built-in.a
+00:08:44   CC [M]  drivers/net/wireless/rsi/rsi_91x_usb.o
+00:08:44   CC [M]  drivers/net/wireless/st/cw1200/main.o
+00:08:44   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192c/rtl8192c-common.o
+00:08:44   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/main.o
+00:08:44   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/dm.o
+00:08:44   CC [M]  drivers/media/tuners/tea5767.o
+00:08:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gk104.o
+00:08:44   CC [M]  fs/vboxsf/super.o
+00:08:44   CC [M]  fs/xfs/scrub/fscounters.o
+00:08:44   CC [M]  fs/f2fs/compress.o
+00:08:44   CC      drivers/scsi/scsi_lib_dma.o
+00:08:44   CC [M]  fs/ocfs2/stack_user.o
+00:08:45   CC [M]  drivers/media/i2c/cx25840/cx25840-ir.o
+00:08:45   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega12_hwmgr.o
+00:08:45   CC [M]  drivers/net/ethernet/intel/igc/igc_diag.o
+00:08:45   CC [M]  net/mac80211/mesh_pathtbl.o
+00:08:45   CC [M]  net/9p/mod.o
+00:08:45   LD [M]  fs/vboxsf/vboxsf.o
+00:08:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gm107.o
+00:08:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gm200.o
+00:08:45   CC [M]  drivers/net/wireless/st/cw1200/queue.o
+00:08:45   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/hw.o
+00:08:45   CC [M]  drivers/media/tuners/tea5761.o
+00:08:45   CC [M]  fs/xfs/scrub/health.o
+00:08:45   CC      drivers/scsi/scsi_scan.o
+00:08:45   CC [M]  drivers/net/wireless/rsi/rsi_91x_usb_ops.o
+00:08:45   LD [M]  fs/ocfs2/ocfs2.o
+00:08:45   LD [M]  fs/ocfs2/ocfs2_stackglue.o
+00:08:45   LD [M]  fs/ocfs2/ocfs2_stack_o2cb.o
+00:08:45   LD [M]  fs/ocfs2/ocfs2_stack_user.o
+00:08:45   CC [M]  net/9p/client.o
+00:08:45   CC [M]  drivers/net/ieee802154/fakelb.o
+00:08:45   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/init.o
+00:08:45   CC [M]  drivers/net/ethernet/intel/igc/igc_ethtool.o
+00:08:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/therm/gp100.o
+00:08:46   CC [M]  drivers/media/i2c/s5c73m3/s5c73m3-core.o
+00:08:46   LD [M]  drivers/media/i2c/cx25840/cx25840.o
+00:08:46   CC [M]  drivers/net/ieee802154/at86rf230.o
+00:08:46   CC [M]  fs/xfs/scrub/ialloc.o
+00:08:46   CC [M]  drivers/media/tuners/tda9887.o
+00:08:46   CC [M]  drivers/media/i2c/s5c73m3/s5c73m3-spi.o
+00:08:46   LD [M]  drivers/net/wireless/rsi/rsi_91x.o
+00:08:46   LD [M]  drivers/net/wireless/rsi/rsi_sdio.o
+00:08:46   LD [M]  drivers/net/wireless/rsi/rsi_usb.o
+00:08:46   AR      drivers/pps/clients/built-in.a
+00:08:46   CC [M]  drivers/pps/clients/pps-ldisc.o
+00:08:46   GEN     drivers/scsi/scsi_devinfo_tbl.c
+00:08:46   CC [M]  fs/f2fs/iostat.o
+00:08:46   CC      drivers/scsi/scsi_devinfo.o
+00:08:46   CC [M]  net/mac80211/mesh_plink.o
+00:08:46   CC [M]  drivers/net/wireless/st/cw1200/hwio.o
+00:08:46   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/debugfs.o
+00:08:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/timer/base.o
+00:08:47   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega12_thermal.o
+00:08:47   CC [M]  drivers/pps/clients/pps_parport.o
+00:08:47   CC [M]  net/9p/error.o
+00:08:47   CC [M]  fs/xfs/scrub/inode.o
+00:08:47   CC [M]  drivers/net/ethernet/intel/igc/igc_ptp.o
+00:08:47   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/pp_overdriver.o
+00:08:47   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/led.o
+00:08:47   CC [M]  drivers/media/tuners/tda827x.o
+00:08:47   CC      drivers/scsi/scsi_netlink.o
+00:08:47   CC [M]  drivers/media/i2c/s5c73m3/s5c73m3-ctrls.o
+00:08:47   CC [M]  drivers/net/wireless/mediatek/mt76/mmio.o
+00:08:47   CC [M]  net/9p/protocol.o
+00:08:47   CC [M]  drivers/net/ieee802154/mrf24j40.o
+00:08:47   LD [M]  fs/f2fs/f2fs.o
+00:08:47   CC [M]  drivers/pps/clients/pps-gpio.o
+00:08:47   CC [M]  drivers/net/ethernet/intel/igbvf/vf.o
+00:08:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/timer/nv04.o
+00:08:47   CC [M]  drivers/net/wireless/st/cw1200/bh.o
+00:08:48   AR      drivers/pps/generators/built-in.a
+00:08:48   CC      drivers/pps/pps.o
+00:08:48   CC [M]  fs/xfs/scrub/parent.o
+00:08:48   CC [M]  net/9p/trans_fd.o
+00:08:48   CC [M]  drivers/net/wireless/mediatek/mt76/mt7921/trace.o
+00:08:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu_helper.o
+00:08:48   CC [M]  drivers/net/ethernet/intel/igc/igc_dump.o
+00:08:48   CC [M]  drivers/media/tuners/tda18271-maps.o
+00:08:48   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/phy.o
+00:08:48   CC [M]  net/mac80211/mesh_hwmp.o
+00:08:48   LD [M]  drivers/media/i2c/s5c73m3/s5c73m3.o
+00:08:48   CC      drivers/scsi/scsi_sysctl.o
+00:08:48   AR      drivers/media/i2c/built-in.a
+00:08:48   CC [M]  drivers/media/i2c/msp3400-driver.o
+00:08:48   CC [M]  drivers/net/ethernet/intel/igbvf/mbx.o
+00:08:48   CC [M]  drivers/net/ieee802154/cc2520.o
+00:08:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/timer/nv40.o
+00:08:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/timer/nv41.o
+00:08:48   CC      drivers/pps/kapi.o
+00:08:48   CC [M]  fs/xfs/scrub/refcount.o
+00:08:48   CC [M]  drivers/net/wireless/st/cw1200/wsm.o
+00:08:48   CC      drivers/scsi/scsi_proc.o
+00:08:49   CC [M]  drivers/net/ethernet/intel/igbvf/ethtool.o
+00:08:49   CC [M]  drivers/net/ethernet/intel/igc/igc_tsn.o
+00:08:49   CC      drivers/pps/sysfs.o
+00:08:49   CC [M]  drivers/media/tuners/tda18271-common.o
+00:08:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/timer/gk20a.o
+00:08:49   LD [M]  drivers/net/wireless/mediatek/mt76/mt7921/mt7921e.o
+00:08:49   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/dm.o
+00:08:49   CC [M]  drivers/net/wireless/mediatek/mt76/util.o
+00:08:49   CC [M]  net/9p/trans_common.o
+00:08:49   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega20_processpptables.o
+00:08:49   CC [M]  drivers/media/i2c/msp3400-kthreads.o
+00:08:49   AR      drivers/pps/built-in.a
+00:08:49   CC [M]  drivers/net/ieee802154/atusb.o
+00:08:49   CC [M]  drivers/net/wireless/mediatek/mt76/trace.o
+00:08:49   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/rf.o
+00:08:49   CC      drivers/scsi/scsi_debugfs.o
+00:08:49   CC [M]  fs/xfs/scrub/rmap.o
+00:08:49   CC [M]  net/mac80211/mesh_sync.o
+00:08:49   CC [M]  drivers/net/ethernet/intel/igc/igc_xdp.o
+00:08:49   CC [M]  net/9p/trans_xen.o
+00:08:49   CC [M]  drivers/net/ethernet/intel/igbvf/netdev.o
+00:08:50   CC [M]  drivers/media/tuners/tda18271-fe.o
+00:08:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/top/base.o
+00:08:50   CC      drivers/scsi/scsi_trace.o
+00:08:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega20_hwmgr.o
+00:08:50   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/dm.o
+00:08:50   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/fw.o
+00:08:50   CC [M]  drivers/net/ieee802154/adf7242.o
+00:08:50   CC [M]  fs/xfs/scrub/scrub.o
+00:08:50   CC [M]  drivers/media/i2c/aptina-pll.o
+00:08:50   CC [M]  drivers/net/wireless/mediatek/mt76/dma.o
+00:08:50   CC [M]  drivers/net/wireless/st/cw1200/sta.o
+00:08:50   CC [M]  net/9p/trans_virtio.o
+00:08:50   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/sw.o
+00:08:50   LD [M]  drivers/net/ethernet/intel/igc/igc.o
+00:08:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/top/gk104.o
+00:08:50   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/fw.o
+00:08:51   CC [M]  drivers/media/i2c/tvaudio.o
+00:08:51   CC      drivers/scsi/scsi_logging.o
+00:08:51   CC [M]  net/mac80211/mesh_ps.o
+00:08:51   CC [M]  drivers/media/tuners/xc5000.o
+00:08:51   CC [M]  fs/xfs/scrub/symlink.o
+00:08:51   CC [M]  drivers/net/ieee802154/ca8210.o
+00:08:51   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/hw.o
+00:08:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/top/ga100.o
+00:08:51   LD [M]  drivers/net/ethernet/intel/igbvf/igbvf.o
+00:08:51   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_main.o
+00:08:51   CC      drivers/scsi/scsi_pm.o
+00:08:51   CC [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_core.o
+00:08:51   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/table.o
+00:08:51   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/trx.o
+00:08:51   CC [M]  net/9p/trans_rdma.o
+00:08:52   CC [M]  drivers/net/wireless/mediatek/mt76/mac80211.o
+00:08:52   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/hw.o
+00:08:52   CC [M]  fs/xfs/scrub/rtbitmap.o
+00:08:52   CC [M]  drivers/media/i2c/tda7432.o
+00:08:52   CC [M]  drivers/media/tuners/xc4000.o
+00:08:52   CC [M]  net/mac80211/pm.o
+00:08:52   CC [M]  drivers/net/wireless/st/cw1200/scan.o
+00:08:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/base.o
+00:08:52   CC      drivers/scsi/scsi_dh.o
+00:08:52   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega20_powertune.o
+00:08:52   CC [M]  drivers/net/ieee802154/mcr20a.o
+00:08:52   CC [M]  fs/xfs/scrub/quota.o
+00:08:53   CC [M]  drivers/media/i2c/saa6588.o
+00:08:53   LD [M]  net/9p/9pnet.o
+00:08:53   LD [M]  net/9p/9pnet_xen.o
+00:08:53   LD [M]  net/9p/9pnet_virtio.o
+00:08:53   LD [M]  net/9p/9pnet_rdma.o
+00:08:53   CC      drivers/scsi/scsi_bsg.o
+00:08:53   CC [M]  drivers/net/vmxnet3/vmxnet3_drv.o
+00:08:53   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ce/rtl8192ce.o
+00:08:53   AR      drivers/media/rc/keymaps/built-in.a
+00:08:53   CC [M]  drivers/media/rc/keymaps/rc-adstech-dvb-t-pci.o
+00:08:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gpio.o
+00:08:53   CC [M]  drivers/net/wireless/mediatek/mt76/debugfs.o
+00:08:53   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/led.o
+00:08:53   CC [M]  drivers/net/wireless/st/cw1200/debug.o
+00:08:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega20_thermal.o
+00:08:53   CC [M]  drivers/media/tuners/mt2060.o
+00:08:53   CC [M]  drivers/media/rc/keymaps/rc-alink-dtu-m.o
+00:08:53   LD [M]  fs/xfs/xfs.o
+00:08:53   CC [M]  net/mac80211/rc80211_minstrel_ht.o
+00:08:53   CC [M]  fs/zonefs/super.o
+00:08:53   CC      drivers/scsi/scsi_common.o
+00:08:53   CC [M]  drivers/media/tuners/mt2063.o
+00:08:53   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/led.o
+00:08:54   CC [M]  drivers/media/i2c/tda9840.o
+00:08:54   CC [M]  drivers/media/rc/keymaps/rc-anysee.o
+00:08:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/nv40.o
+00:08:54   CC      drivers/scsi/sd.o
+00:08:54   CC [M]  drivers/media/rc/keymaps/rc-apac-viewcomp.o
+00:08:54   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/phy.o
+00:08:54   CC [M]  drivers/net/wireless/mediatek/mt76/eeprom.o
+00:08:54   CC [M]  drivers/net/wireless/ti/wlcore/main.o
+00:08:54   CC [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_8192e.o
+00:08:54   CC [M]  drivers/net/wireless/st/cw1200/pm.o
+00:08:54   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/common_baco.o
+00:08:54   CC [M]  drivers/media/i2c/tda1997x.o
+00:08:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gf100.o
+00:08:55   CC [M]  drivers/media/rc/keymaps/rc-astrometa-t2hybrid.o
+00:08:55   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/phy.o
+00:08:55   CC [M]  drivers/media/tuners/mt2266.o
+00:08:55   LD [M]  fs/zonefs/zonefs.o
+00:08:55   CC      fs/open.o
+00:08:55   CC [M]  drivers/media/rc/keymaps/rc-asus-pc39.o
+00:08:55   CC [M]  drivers/net/wireless/mediatek/mt76/tx.o
+00:08:55   CC [M]  drivers/net/vmxnet3/vmxnet3_ethtool.o
+00:08:55   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega10_baco.o
+00:08:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gf117.o
+00:08:55   CC [M]  drivers/media/rc/keymaps/rc-asus-ps3-100.o
+00:08:55   CC [M]  drivers/net/wireless/st/cw1200/cw1200_sdio.o
+00:08:56   CC [M]  drivers/media/tuners/qt1010.o
+00:08:56   CC [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_8723b.o
+00:08:56   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/rf.o
+00:08:56   CC [M]  net/mac80211/rc80211_minstrel_ht_debugfs.o
+00:08:56   CC      drivers/scsi/sd_dif.o
+00:08:56   CC [M]  drivers/media/rc/keymaps/rc-ati-tv-wonder-hd-600.o
+00:08:56   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_common.o
+00:08:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gk104.o
+00:08:56   CC [M]  drivers/media/i2c/tea6415c.o
+00:08:56   CC [M]  drivers/media/rc/keymaps/rc-ati-x10.o
+00:08:56   CC      fs/read_write.o
+00:08:56   CC      drivers/scsi/sd_zbc.o
+00:08:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega20_baco.o
+00:08:56   CC [M]  drivers/media/tuners/mt2131.o
+00:08:56   CC [M]  drivers/net/wireless/mediatek/mt76/agg-rx.o
+00:08:56   CC [M]  drivers/net/wireless/st/cw1200/cw1200_spi.o
+00:08:57   LD [M]  drivers/net/vmxnet3/vmxnet3.o
+00:08:57   CC [M]  drivers/media/rc/keymaps/rc-avermedia-a16d.o
+00:08:57   CC      drivers/scsi/sr.o
+00:08:57   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/sw.o
+00:08:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gk20a.o
+00:08:57   CC [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_8723a.o
+00:08:57   LD [M]  net/mac80211/mac80211.o
+00:08:57   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/rf.o
+00:08:57   CC [M]  net/6lowpan/core.o
+00:08:57   CC [M]  drivers/media/i2c/tea6420.o
+00:08:57   CC [M]  drivers/media/rc/keymaps/rc-avermedia.o
+00:08:57   CC      drivers/ptp/ptp_clock.o
+00:08:57   CC [M]  drivers/media/tuners/mxl5005s.o
+00:08:57   CC [M]  drivers/net/wireless/ti/wlcore/cmd.o
+00:08:57   CC [M]  drivers/media/rc/keymaps/rc-avermedia-cardbus.o
+00:08:57   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/vega12_baco.o
+00:08:57   CC      drivers/scsi/sr_ioctl.o
+00:08:58   CC [M]  drivers/net/wireless/mediatek/mt76/mcu.o
+00:08:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/volt/gm20b.o
+00:08:58   LD [M]  drivers/net/wireless/st/cw1200/cw1200_core.o
+00:08:58   LD [M]  drivers/net/wireless/st/cw1200/cw1200_wlan_sdio.o
+00:08:58   LD [M]  drivers/net/wireless/st/cw1200/cw1200_wlan_spi.o
+00:08:58   CC      fs/file_table.o
+00:08:58   AR      drivers/power/reset/built-in.a
+00:08:58   CC [M]  drivers/media/i2c/saa7110.o
+00:08:58   CC      drivers/power/supply/power_supply_core.o
+00:08:58   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/table.o
+00:08:58   CC [M]  drivers/media/rc/keymaps/rc-avermedia-dvbt.o
+00:08:58   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/trx.o
+00:08:58   CC [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_8192c.o
+00:08:58   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_ethtool.o
+00:08:58   CC [M]  net/6lowpan/iphc.o
+00:08:58   CC      drivers/ptp/ptp_chardev.o
+00:08:58   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/sw.o
+00:08:58   CC [M]  drivers/media/rc/keymaps/rc-avermedia-m135a.o
+00:08:58   CC      drivers/scsi/sr_vendor.o
+00:08:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/falcon.o
+00:08:58   CC      drivers/power/supply/power_supply_sysfs.o
+00:08:58   CC      fs/super.o
+00:08:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu9_baco.o
+00:08:59   CC [M]  drivers/net/wireless/mediatek/mt76/pci.o
+00:08:59   CC [M]  drivers/media/rc/keymaps/rc-avermedia-m733a-rm-k6.o
+00:08:59   CC [M]  drivers/media/i2c/saa7115.o
+00:08:59   CC      drivers/ptp/ptp_sysfs.o
+00:08:59   CC      drivers/power/supply/power_supply_leds.o
+00:08:59   LD [M]  drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu.o
+00:08:59   CC [M]  drivers/net/ethernet/intel/ixgbevf/vf.o
+00:08:59   CC      drivers/scsi/sg.o
+00:08:59   CC [M]  drivers/media/rc/keymaps/rc-avermedia-rm-ks.o
+00:08:59   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192se/rtl8192se.o
+00:08:59   CC [M]  drivers/scsi/raid_class.o
+00:08:59   CC [M]  drivers/net/wireless/ti/wlcore/io.o
+00:08:59   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/table.o
+00:08:59   CC      drivers/power/supply/power_supply_hwmon.o
+00:08:59   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/trx.o
+00:08:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/xtensa.o
+00:08:59   CC [M]  net/6lowpan/nhc.o
+00:08:59   CC [M]  drivers/media/rc/keymaps/rc-avertv-303.o
+00:08:59   CC      drivers/ptp/ptp_vclock.o
+00:09:00   CC [M]  drivers/power/supply/cw2015_battery.o
+00:09:00   CC [M]  drivers/net/wireless/mediatek/mt76/usb.o
+00:09:00   CC      fs/char_dev.o
+00:09:00   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/tonga_baco.o
+00:09:00   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_82599.o
+00:09:00   CC      drivers/media/rc/rc-main.o
+00:09:00   CC [M]  drivers/net/ethernet/intel/ixgbevf/mbx.o
+00:09:00   CC [M]  drivers/media/rc/keymaps/rc-azurewave-ad-tu700.o
+00:09:00   CC [M]  drivers/media/i2c/saa717x.o
+00:09:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/bsp/g84.o
+00:09:00   CC [M]  drivers/ptp/ptp_kvm_x86.o
+00:09:00   CC [M]  drivers/media/tuners/mxl5007t.o
+00:09:00   CC [M]  drivers/net/wireless/ti/wlcore/event.o
+00:09:00   CC [M]  drivers/media/rc/keymaps/rc-beelink-gs1.o
+00:09:00   CC [M]  net/6lowpan/ndisc.o
+00:09:00   CC [M]  drivers/power/supply/bq27xxx_battery.o
+00:09:01   CC [M]  drivers/scsi/scsi_transport_spi.o
+00:09:01   CC [M]  drivers/net/ethernet/intel/ixgbevf/ethtool.o
+00:09:01   CC      fs/stat.o
+00:09:01   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192de/rtl8192de.o
+00:09:01   CC [M]  drivers/media/rc/keymaps/rc-behold.o
+00:09:01   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/dm.o
+00:09:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/polaris_baco.o
+00:09:01   CC [M]  drivers/ptp/ptp_kvm_common.o
+00:09:01   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/fw.o
+00:09:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gt215.o
+00:09:01   CC [M]  drivers/media/i2c/saa7127.o
+00:09:01   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_82598.o
+00:09:01   CC [M]  drivers/media/rc/keymaps/rc-behold-columbus.o
+00:09:01   CC [M]  drivers/net/wireless/mediatek/mt76/usb_trace.o
+00:09:01   CC [M]  drivers/media/tuners/mc44s803.o
+00:09:01   CC [M]  drivers/power/supply/bq27xxx_battery_i2c.o
+00:09:01   CC [M]  drivers/ptp/ptp_clockmatrix.o
+00:09:01   CC [M]  net/6lowpan/debugfs.o
+00:09:01   CC [M]  drivers/net/wireless/ti/wlcore/tx.o
+00:09:01   CC      fs/exec.o
+00:09:01   CC [M]  drivers/media/rc/keymaps/rc-budget-ci-old.o
+00:09:02   CC [M]  drivers/net/ethernet/intel/ixgbevf/ixgbevf_main.o
+00:09:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gf100.o
+00:09:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/fiji_baco.o
+00:09:02   CC [M]  drivers/net/ethernet/microsoft/mana/gdma_main.o
+00:09:02   CC [M]  drivers/media/rc/keymaps/rc-cinergy-1400.o
+00:09:02   CC [M]  drivers/scsi/scsi_transport_fc.o
+00:09:02   CC [M]  drivers/media/i2c/saa7185.o
+00:09:02   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/hal_btc.o
+00:09:02   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_phy.o
+00:09:02   CC [M]  drivers/media/tuners/max2165.o
+00:09:02   CC [M]  drivers/power/supply/max17042_battery.o
+00:09:02   CC [M]  drivers/media/rc/keymaps/rc-cinergy.o
+00:09:02   CC [M]  drivers/net/wireless/mediatek/mt76/sdio.o
+00:09:02   CC [M]  net/6lowpan/nhc_dest.o
+00:09:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gk104.o
+00:09:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/ci_baco.o
+00:09:03   CC [M]  drivers/ptp/ptp_idt82p33.o
+00:09:03   CC [M]  drivers/media/rc/keymaps/rc-ct-90405.o
+00:09:03   CC [M]  drivers/media/i2c/saa6752hs.o
+00:09:03   CC [M]  drivers/media/tuners/tda18218.o
+00:09:03   CC [M]  drivers/net/wireless/ti/wlcore/rx.o
+00:09:03   CC [M]  drivers/net/ethernet/microsoft/mana/shm_channel.o
+00:09:03   CC      fs/pipe.o
+00:09:03   CC [M]  drivers/power/supply/rt5033_battery.o
+00:09:03   CC [M]  drivers/media/rc/keymaps/rc-d680-dmb.o
+00:09:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gm107.o
+00:09:03   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/hal_bt_coexist.o
+00:09:03   CC [M]  net/6lowpan/nhc_fragment.o
+00:09:03   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_sriov.o
+00:09:04   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_util.o
+00:09:04   CC [M]  drivers/media/rc/keymaps/rc-delock-61959.o
+00:09:04   CC [M]  drivers/net/ethernet/microsoft/mana/hw_channel.o
+00:09:04   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/hwmgr/smu7_baco.o
+00:09:04   CC [M]  drivers/media/i2c/ad5820.o
+00:09:04   CC [M]  drivers/media/tuners/tda18212.o
+00:09:04   CC [M]  drivers/ptp/ptp_vmw.o
+00:09:04   CC [M]  drivers/power/supply/lt3651-charger.o
+00:09:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gm200.o
+00:09:04   CC [M]  drivers/media/rc/keymaps/rc-dib0700-nec.o
+00:09:04   CC [M]  drivers/net/ethernet/intel/ixgbevf/ipsec.o
+00:09:04   CC [M]  drivers/net/wireless/ti/wlcore/ps.o
+00:09:04   CC [M]  drivers/power/supply/ltc4162-l-charger.o
+00:09:04   CC [M]  drivers/scsi/scsi_transport_iscsi.o
+00:09:04   CC [M]  net/6lowpan/nhc_hop.o
+00:09:04   CC      fs/namei.o
+00:09:04   LD [M]  drivers/ptp/ptp_kvm.o
+00:09:04   AR      drivers/ptp/built-in.a
+00:09:04   CC [M]  drivers/media/rc/keymaps/rc-dib0700-rc5.o
+00:09:04   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/hw.o
+00:09:04   CC [M]  drivers/media/tuners/e4000.o
+00:09:04   CC [M]  drivers/net/ethernet/microsoft/mana/mana_en.o
+00:09:05   CC      drivers/gpu/drm/drm_dp_mst_topology.o
+00:09:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/amd_powerplay.o
+00:09:05   CC [M]  drivers/media/i2c/ak7375.o
+00:09:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gp100.o
+00:09:05   CC [M]  drivers/media/rc/keymaps/rc-digitalnow-tinytwin.o
+00:09:05   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_mac.o
+00:09:05   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_mbx.o
+00:09:05   CC [M]  drivers/power/supply/bq24190_charger.o
+00:09:05   CC [M]  drivers/net/wireless/ti/wlcore/acx.o
+00:09:05   CC [M]  net/6lowpan/nhc_ipv6.o
+00:09:05   CC [M]  drivers/media/rc/keymaps/rc-digittrade.o
+00:09:05   LD [M]  drivers/net/ethernet/intel/ixgbevf/ixgbevf.o
+00:09:05   CC [M]  net/6lowpan/nhc_mobility.o
+00:09:05   CC [M]  drivers/media/tuners/fc2580.o
+00:09:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gp102.o
+00:09:05   CC [M]  drivers/media/i2c/dw9714.o
+00:09:06   CC [M]  drivers/media/rc/keymaps/rc-dm1105-nec.o
+00:09:06   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_x540.o
+00:09:06   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/kv_dpm.o
+00:09:06   CC [M]  drivers/net/ethernet/microsoft/mana/mana_ethtool.o
+00:09:06   CC [M]  drivers/media/rc/keymaps/rc-dntv-live-dvb-t.o
+00:09:06   CC [M]  drivers/net/xen-netback/netback.o
+00:09:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/gv100.o
+00:09:06   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/led.o
+00:09:06   CC [M]  net/6lowpan/nhc_routing.o
+00:09:06   CC [M]  drivers/power/supply/bq2515x_charger.o
+00:09:06   CC [M]  drivers/media/i2c/dw9768.o
+00:09:06   CC [M]  drivers/media/rc/keymaps/rc-dntv-live-dvbt-pro.o
+00:09:06   CC [M]  drivers/media/tuners/tua9001.o
+00:09:06   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_mcu.o
+00:09:07   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_x550.o
+00:09:07   CC [M]  drivers/net/wireless/ti/wlcore/boot.o
+00:09:07   LD [M]  drivers/net/ethernet/microsoft/mana/mana.o
+00:09:07   AR      drivers/net/ethernet/microsoft/built-in.a
+00:09:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/ce/tu102.o
+00:09:07   CC [M]  drivers/media/rc/keymaps/rc-dtt200u.o
+00:09:07   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_chip.o
+00:09:07   CC [M]  drivers/scsi/scsi_transport_sas.o
+00:09:07   CC      fs/fcntl.o
+00:09:07   CC [M]  drivers/power/supply/bq25890_charger.o
+00:09:07   CC [M]  drivers/media/i2c/dw9807-vcm.o
+00:09:07   AR      drivers/net/wireless/zydas/built-in.a
+00:09:07   CC [M]  drivers/media/rc/keymaps/rc-dvbsky.o
+00:09:07   CC [M]  net/6lowpan/nhc_udp.o
+00:09:07   CC [M]  drivers/media/tuners/si2157.o
+00:09:07   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/dm.o
+00:09:07   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/phy.o
+00:09:08   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_eeprom.o
+00:09:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/cipher/g84.o
+00:09:08   CC [M]  drivers/media/rc/keymaps/rc-dvico-mce.o
+00:09:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/kv_smc.o
+00:09:08   CC [M]  drivers/net/wireless/ti/wlcore/init.o
+00:09:08   CC      fs/ioctl.o
+00:09:08   CC [M]  drivers/net/xen-netback/xenbus.o
+00:09:08   CC [M]  drivers/media/rc/keymaps/rc-dvico-portable.o
+00:09:08   CC [M]  drivers/media/i2c/adv7170.o
+00:09:08   CC [M]  drivers/power/supply/bq256xx_charger.o
+00:09:08   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_lib.o
+00:09:08   CC [M]  net/6lowpan/nhc_ghc_ext_hop.o
+00:09:08   CC [M]  drivers/scsi/scsi_transport_srp.o
+00:09:08   CC [M]  drivers/media/tuners/fc0011.o
+00:09:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/acpi.o
+00:09:08   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_mac.o
+00:09:09   CC [M]  drivers/media/rc/keymaps/rc-em-terratec.o
+00:09:09   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_phy.o
+00:09:09   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/fw.o
+00:09:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/si_dpm.o
+00:09:09   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/pwrseq.o
+00:09:09   CC [M]  drivers/media/rc/keymaps/rc-encore-enltv2.o
+00:09:09   CC      fs/readdir.o
+00:09:09   CC [M]  drivers/media/i2c/adv7175.o
+00:09:09   CC [M]  drivers/net/xen-netback/interface.o
+00:09:09   CC [M]  drivers/net/wireless/ti/wlcore/debugfs.o
+00:09:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/base.o
+00:09:09   CC [M]  drivers/power/supply/smb347-charger.o
+00:09:09   CC [M]  drivers/scsi/libiscsi.o
+00:09:09   CC [M]  drivers/media/tuners/fc0012.o
+00:09:09   CC [M]  net/6lowpan/nhc_ghc_udp.o
+00:09:09   CC [M]  drivers/media/rc/keymaps/rc-encore-enltv.o
+00:09:09   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_ptp.o
+00:09:10   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_mmio.o
+00:09:10   CC [M]  drivers/media/rc/keymaps/rc-encore-enltv-fm53.o
+00:09:10   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_rf_al2230.o
+00:09:10   CC      fs/select.o
+00:09:10   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/hw.o
+00:09:10   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/rf.o
+00:09:10   CC [M]  drivers/media/i2c/adv7180.o
+00:09:10   CC [M]  drivers/media/tuners/fc0013.o
+00:09:10   CC [M]  drivers/media/rc/keymaps/rc-evga-indtube.o
+00:09:10   CC [M]  net/6lowpan/nhc_ghc_icmpv6.o
+00:09:10   CC [M]  drivers/net/xen-netback/hash.o
+00:09:10   CC [M]  drivers/power/supply/axp288_fuel_gauge.o
+00:09:10   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_xsk.o
+00:09:11   CC [M]  drivers/media/rc/keymaps/rc-eztv.o
+00:09:11   CC [M]  drivers/net/wireless/ti/wlcore/scan.o
+00:09:11   CC [M]  drivers/power/supply/axp288_charger.o
+00:09:11   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_rf_rf2959.o
+00:09:11   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_txrx.o
+00:09:11   CC [M]  drivers/media/i2c/adv7183.o
+00:09:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/ctrl.o
+00:09:11   CC [M]  drivers/media/rc/keymaps/rc-flydvb.o
+00:09:11   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/sw.o
+00:09:11   CC [M]  drivers/media/tuners/it913x.o
+00:09:11   CC [M]  drivers/net/xen-netback/rx.o
+00:09:11   CC [M]  net/6lowpan/nhc_ghc_ext_dest.o
+00:09:11   CC [M]  drivers/scsi/libiscsi_tcp.o
+00:09:11   CC [M]  drivers/media/rc/keymaps/rc-flyvideo.o
+00:09:11   CC      fs/dcache.o
+00:09:12   CC [M]  drivers/power/supply/cros_usbpd-charger.o
+00:09:12   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_dcb.o
+00:09:12   CC [M]  drivers/net/wireless/ti/wlcore/sysfs.o
+00:09:12   CC [M]  drivers/media/rc/keymaps/rc-fusionhdtv-mce.o
+00:09:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/pci.o
+00:09:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/powerplay/si_smc.o
+00:09:12   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_rf_al7230b.o
+00:09:12   CC [M]  drivers/media/i2c/adv7343.o
+00:09:12   CC [M]  drivers/media/tuners/r820t.o
+00:09:12   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/led.o
+00:09:12   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_trace.o
+00:09:12   CC [M]  net/6lowpan/nhc_ghc_ext_frag.o
+00:09:12   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/table.o
+00:09:12   LD [M]  drivers/net/xen-netback/xen-netback.o
+00:09:12   CC [M]  drivers/media/rc/keymaps/rc-gadmei-rm008z.o
+00:09:12   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/trx.o
+00:09:12   CC [M]  drivers/power/supply/cros_peripheral_charger.o
+00:09:12   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/dm.o
+00:09:13   CC [M]  drivers/media/rc/keymaps/rc-geekbox.o
+00:09:13   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_dcb_82598.o
+00:09:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/tegra.o
+00:09:13   CC [M]  drivers/power/supply/bd99954-charger.o
+00:09:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/amdgpu_dpm.o
+00:09:13   CC [M]  drivers/net/wireless/ti/wlcore/vendor_cmd.o
+00:09:13   CC [M]  drivers/media/i2c/adv7393.o
+00:09:13   CC [M]  drivers/scsi/iscsi_tcp.o
+00:09:13   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_rf_uw2453.o
+00:09:13   CC [M]  drivers/media/rc/keymaps/rc-genius-tvgo-a11mce.o
+00:09:13   CC      fs/inode.o
+00:09:13   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/phy.o
+00:09:13   CC [M]  net/6lowpan/nhc_ghc_ext_route.o
+00:09:13   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_debugfs.o
+00:09:13   CC [M]  drivers/media/tuners/qm1d1c0042.o
+00:09:13   CC [M]  drivers/media/rc/keymaps/rc-gotview7135.o
+00:09:13   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_dcb_82599.o
+00:09:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/device/user.o
+00:09:14   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723ae/rtl8723ae.o
+00:09:14   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/fw.o
+00:09:14   CC [M]  drivers/power/supply/surface_battery.o
+00:09:14   CC [M]  drivers/media/i2c/adv7604.o
+00:09:14   CC      drivers/media/rc/rc-ir-raw.o
+00:09:14   CC [M]  drivers/media/rc/keymaps/rc-hisi-poplar.o
+00:09:14   CC [M]  drivers/net/wireless/ti/wlcore/sdio.o
+00:09:14   LD [M]  net/6lowpan/6lowpan.o
+00:09:14   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_rf.o
+00:09:14   CC [M]  net/ieee802154/6lowpan/core.o
+00:09:14   CC [M]  drivers/scsi/iscsi_boot_sysfs.o
+00:09:14   CC [M]  drivers/power/supply/surface_charger.o
+00:09:14   CC [M]  drivers/media/rc/keymaps/rc-hisi-tv-demo.o
+00:09:14   CC [M]  drivers/media/tuners/qm1d1b0004.o
+00:09:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../pm/amdgpu_pm.o
+00:09:14   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_dfs.o
+00:09:14   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_dcb_nl.o
+00:09:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/base.o
+00:09:15   CC [M]  drivers/scsi/advansys.o
+00:09:15   CC [M]  drivers/hwmon/pmbus/pmbus_core.o
+00:09:15   CC      fs/attr.o
+00:09:15   CC [M]  drivers/media/rc/keymaps/rc-imon-mce.o
+00:09:15   AR      drivers/power/supply/built-in.a
+00:09:15   AR      drivers/power/built-in.a
+00:09:15   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/hw.o
+00:09:15   CC      drivers/hwmon/hwmon.o
+00:09:15   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/pwrseq.o
+00:09:15   LD [M]  drivers/net/wireless/ti/wlcore/wlcore.o
+00:09:15   LD [M]  drivers/net/wireless/ti/wlcore/wlcore_sdio.o
+00:09:15   CC [M]  drivers/net/wireless/ti/wl12xx/main.o
+00:09:15   CC [M]  drivers/media/tuners/m88rs6000t.o
+00:09:15   CC [M]  drivers/net/wireless/zydas/zd1211rw/zd_usb.o
+00:09:15   CC [M]  drivers/media/rc/keymaps/rc-imon-pad.o
+00:09:15   CC [M]  net/ieee802154/6lowpan/rx.o
+00:09:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/nv04.o
+00:09:15   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_sysfs.o
+00:09:15   CC      fs/bad_inode.o
+00:09:15   CC [M]  drivers/media/rc/keymaps/rc-imon-rsc.o
+00:09:16   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_beacon.o
+00:09:16   CC [M]  drivers/media/i2c/adv7842.o
+00:09:16   CC      fs/file.o
+00:09:16   AR      drivers/net/ethernet/litex/built-in.a
+00:09:16   CC [M]  drivers/net/wireless/quantenna/qtnfmac/core.o
+00:09:16   CC [M]  drivers/media/rc/keymaps/rc-iodata-bctv7e.o
+00:09:16   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/rf.o
+00:09:16   CC [M]  drivers/hwmon/pmbus/pmbus.o
+00:09:16   CC [M]  drivers/media/tuners/tda18250.o
+00:09:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/nv50.o
+00:09:16   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_debugfs.o
+00:09:16   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm.o
+00:09:16   CC [M]  net/ieee802154/6lowpan/reassembly.o
+00:09:16   CC [M]  drivers/media/rc/keymaps/rc-it913x-v1.o
+00:09:17   CC [M]  drivers/net/wireless/ti/wl12xx/cmd.o
+00:09:17   LD [M]  drivers/net/wireless/zydas/zd1211rw/zd1211rw.o
+00:09:17   CC [M]  drivers/net/wireless/realtek/rtw88/main.o
+00:09:17   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_usb_mcu.o
+00:09:17   CC [M]  drivers/media/rc/keymaps/rc-it913x-v2.o
+00:09:17   CC [M]  drivers/hwmon/pmbus/adm1266.o
+00:09:17   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/led.o
+00:09:17   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_fcoe.o
+00:09:17   LD [M]  drivers/media/tuners/tda18271.o
+00:09:17   CC [M]  drivers/net/wireless/quantenna/qtnfmac/commands.o
+00:09:17   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/sw.o
+00:09:17   CC      fs/filesystems.o
+00:09:17   CC [M]  drivers/media/rc/keymaps/rc-kaiomy.o
+00:09:17   CC [M]  drivers/net/wireless/mediatek/mt76/mt76x02_usb_core.o
+00:09:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/g84.o
+00:09:17   CC [M]  net/ieee802154/6lowpan/tx.o
+00:09:17   CC [M]  drivers/scsi/BusLogic.o
+00:09:18   CC [M]  drivers/media/rc/keymaps/rc-khadas.o
+00:09:18   CC [M]  drivers/net/wireless/ti/wl12xx/acx.o
+00:09:18   CC [M]  drivers/media/i2c/adv7511-v4l2.o
+00:09:18   CC [M]  drivers/hwmon/pmbus/adm1275.o
+00:09:18   CC      fs/namespace.o
+00:09:18   CC [M]  drivers/net/hyperv/netvsc_drv.o
+00:09:18   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/phy.o
+00:09:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/g94.o
+00:09:18   CC [M]  drivers/media/rc/keymaps/rc-khamsin.o
+00:09:18   CC [M]  drivers/net/ethernet/intel/ixgbe/ixgbe_ipsec.o
+00:09:18   CC [M]  drivers/net/wireless/realtek/rtw88/mac80211.o
+00:09:18   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/table.o
+00:09:18   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/trx.o
+00:09:18   CC [M]  drivers/net/wireless/mediatek/mt76/mt76_connac_mcu.o
+00:09:18   LD [M]  net/ieee802154/6lowpan/ieee802154_6lowpan.o
+00:09:18   CC [M]  net/ieee802154/netlink.o
+00:09:18   CC [M]  drivers/media/rc/keymaps/rc-kworld-315u.o
+00:09:19   CC [M]  drivers/hwmon/pmbus/bel-pfe.o
+00:09:19   CC [M]  drivers/net/wireless/ti/wl12xx/debugfs.o
+00:09:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gt200.o
+00:09:19   CC [M]  drivers/media/rc/keymaps/rc-kworld-pc150u.o
+00:09:19   CC [M]  drivers/net/wireless/quantenna/qtnfmac/trans.o
+00:09:19   CC [M]  net/ieee802154/nl-mac.o
+00:09:19   CC [M]  drivers/media/rc/keymaps/rc-kworld-plus-tv-analog.o
+00:09:19   CC [M]  drivers/media/i2c/vpx3220.o
+00:09:19   CC [M]  drivers/hwmon/pmbus/bpa-rs600.o
+00:09:19   CC [M]  drivers/net/wireless/realtek/rtw88/util.o
+00:09:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/mcp77.o
+00:09:20   LD [M]  drivers/net/ethernet/intel/ixgbe/ixgbe.o
+00:09:20   CC [M]  drivers/net/ethernet/intel/i40e/i40e_main.o
+00:09:20   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723be/rtl8723be.o
+00:09:20   CC [M]  drivers/media/rc/keymaps/rc-leadtek-y04g0051.o
+00:09:20   CC [M]  drivers/hwmon/pmbus/fsp-3y.o
+00:09:20   CC [M]  drivers/net/hyperv/netvsc.o
+00:09:20   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/pwrseq.o
+00:09:20   CC [M]  drivers/net/wireless/ti/wl12xx/scan.o
+00:09:20   CC [M]  drivers/net/wireless/quantenna/qtnfmac/cfg80211.o
+00:09:20   CC [M]  drivers/net/wireless/mediatek/mt76/mt76_connac_mac.o
+00:09:20   CC [M]  drivers/media/rc/keymaps/rc-lme2510.o
+00:09:20   CC [M]  drivers/net/ethernet/intel/i40e/i40e_ethtool.o
+00:09:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gt215.o
+00:09:20   CC [M]  drivers/media/i2c/bt819.o
+00:09:20   CC      fs/seq_file.o
+00:09:20   CC [M]  net/ieee802154/nl-phy.o
+00:09:20   CC [M]  drivers/hwmon/pmbus/dps920ab.o
+00:09:20   CC [M]  drivers/net/wireless/realtek/rtw88/debug.o
+00:09:20   CC [M]  drivers/media/rc/keymaps/rc-manli.o
+00:09:21   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/rf.o
+00:09:21   CC [M]  drivers/media/rc/keymaps/rc-mecool-kii-pro.o
+00:09:21   CC [M]  drivers/net/hyperv/rndis_filter.o
+00:09:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_irq.o
+00:09:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/mcp89.o
+00:09:21   CC [M]  drivers/net/wireless/ti/wl12xx/event.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76-usb.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76-sdio.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x02-lib.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76x02-usb.o
+00:09:21   LD [M]  drivers/net/wireless/mediatek/mt76/mt76-connac-lib.o
+00:09:21   CC [M]  drivers/scsi/ips.o
+00:09:21   CC [M]  drivers/media/i2c/bt856.o
+00:09:21   CC [M]  drivers/hwmon/pmbus/lm25066.o
+00:09:21   CC      fs/xattr.o
+00:09:21   CC [M]  net/ieee802154/nl_policy.o
+00:09:21   CC [M]  drivers/net/wireless/realtek/rtw88/tx.o
+00:09:21   CC [M]  drivers/net/wireless/quantenna/qtnfmac/event.o
+00:09:21   CC [M]  drivers/media/rc/keymaps/rc-mecool-kiii-pro.o
+00:09:21   AR      drivers/thermal/broadcom/built-in.a
+00:09:21   AR      drivers/thermal/samsung/built-in.a
+00:09:22   CC [M]  drivers/thermal/intel/int340x_thermal/int3400_thermal.o
+00:09:22   CC [M]  drivers/media/rc/keymaps/rc-medion-x10.o
+00:09:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gf119.o
+00:09:22   CC [M]  net/ieee802154/core.o
+00:09:22   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/sw.o
+00:09:22   CC [M]  drivers/hwmon/pmbus/ltc2978.o
+00:09:22   CC [M]  drivers/media/i2c/bt866.o
+00:09:22   LD [M]  drivers/net/wireless/ti/wl12xx/wl12xx.o
+00:09:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_mst_types.o
+00:09:22   CC [M]  drivers/net/wireless/ti/wl1251/main.o
+00:09:22   CC [M]  drivers/net/hyperv/netvsc_trace.o
+00:09:22   CC [M]  drivers/thermal/intel/int340x_thermal/int340x_thermal_zone.o
+00:09:22   CC [M]  drivers/media/rc/keymaps/rc-medion-x10-digitainer.o
+00:09:22   CC      fs/libfs.o
+00:09:22   CC [M]  drivers/net/wireless/realtek/rtw88/rx.o
+00:09:23   CC [M]  drivers/net/wireless/quantenna/qtnfmac/util.o
+00:09:23   CC [M]  drivers/media/rc/keymaps/rc-medion-x10-or2x.o
+00:09:23   CC [M]  net/ieee802154/header_ops.o
+00:09:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gk104.o
+00:09:23   CC [M]  drivers/thermal/intel/int340x_thermal/int3402_thermal.o
+00:09:23   CC [M]  drivers/hwmon/pmbus/ltc3815.o
+00:09:23   CC [M]  drivers/media/i2c/ks0127.o
+00:09:23   CC [M]  drivers/media/rc/keymaps/rc-minix-neo.o
+00:09:23   CC [M]  drivers/hwmon/hwmon-vid.o
+00:09:23   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/table.o
+00:09:23   CC [M]  drivers/thermal/intel/int340x_thermal/int3403_thermal.o
+00:09:23   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/trx.o
+00:09:23   CC [M]  drivers/net/hyperv/netvsc_bpf.o
+00:09:23   CC [M]  drivers/scsi/fdomain.o
+00:09:23   AR      drivers/net/ethernet/marvell/octeontx2/built-in.a
+00:09:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_color.o
+00:09:23   CC [M]  drivers/media/rc/keymaps/rc-msi-digivox-ii.o
+00:09:23   CC [M]  net/ieee802154/sysfs.o
+00:09:23   AR      drivers/net/ethernet/marvell/prestera/built-in.a
+00:09:23   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_main.o
+00:09:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gk110.o
+00:09:23   CC [M]  drivers/hwmon/pmbus/max16064.o
+00:09:23   CC      fs/fs-writeback.o
+00:09:23   CC [M]  drivers/net/wireless/ti/wl1251/event.o
+00:09:23   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_device.o
+00:09:23   CC [M]  drivers/net/wireless/realtek/rtw88/mac.o
+00:09:24   CC [M]  drivers/net/wireless/quantenna/qtnfmac/qlink_util.o
+00:09:24   CC [M]  drivers/media/rc/keymaps/rc-msi-digivox-iii.o
+00:09:24   CC [M]  drivers/media/i2c/ths7303.o
+00:09:24   LD [M]  drivers/net/hyperv/hv_netvsc.o
+00:09:24   CC [M]  drivers/net/ethernet/mellanox/mlx4/alloc.o
+00:09:24   CC [M]  drivers/scsi/fdomain_pci.o
+00:09:24   CC [M]  net/ieee802154/nl802154.o
+00:09:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gm107.o
+00:09:24   CC [M]  drivers/hwmon/pmbus/max20751.o
+00:09:24   CC [M]  drivers/media/rc/keymaps/rc-msi-tvanywhere.o
+00:09:24   CC [M]  drivers/thermal/intel/int340x_thermal/int3401_thermal.o
+00:09:24   CC [M]  drivers/net/wireless/quantenna/qtnfmac/shm_ipc.o
+00:09:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/dc_fpu.o
+00:09:24   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_hw.o
+00:09:24   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8188ee/rtl8188ee.o
+00:09:24   CC [M]  drivers/net/wireless/ti/wl1251/tx.o
+00:09:25   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtc8192e2ant.o
+00:09:25   CC [M]  drivers/net/wireless/quantenna/qtnfmac/pcie/pcie.o
+00:09:25   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_device_pci_legacy.o
+00:09:25   CC [M]  drivers/scsi/qla1280.o
+00:09:25   CC [M]  drivers/media/rc/keymaps/rc-msi-tvanywhere-plus.o
+00:09:25   CC [M]  drivers/media/i2c/ths8200.o
+00:09:25   CC [M]  drivers/hwmon/pmbus/max34440.o
+00:09:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gm200.o
+00:09:25   CC [M]  drivers/net/wireless/realtek/rtw88/phy.o
+00:09:25   CC [M]  drivers/media/rc/keymaps/rc-nebula.o
+00:09:25   CC [M]  drivers/net/ethernet/mellanox/mlx4/catas.o
+00:09:25   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_device_pci.o
+00:09:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_services.o
+00:09:25   CC [M]  drivers/media/rc/keymaps/rc-nec-terratec-cinergy-xs.o
+00:09:26   CC [M]  net/ieee802154/trace.o
+00:09:26   CC [M]  drivers/net/wireless/ti/wl1251/rx.o
+00:09:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gp100.o
+00:09:26   CC [M]  drivers/hwmon/pmbus/max8688.o
+00:09:26   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_dsa.o
+00:09:26   CC [M]  drivers/net/wireless/quantenna/qtnfmac/pcie/pearl_pcie.o
+00:09:26   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_rxtx.o
+00:09:26   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_rapl.o
+00:09:26   CC [M]  drivers/media/i2c/tvp5150.o
+00:09:26   CC [M]  drivers/media/rc/keymaps/rc-norwood.o
+00:09:26   CC [M]  drivers/net/ethernet/mellanox/mlx4/cmd.o
+00:09:26   CC [M]  drivers/net/ethernet/intel/i40e/i40e_adminq.o
+00:09:26   CC [M]  drivers/scsi/dmx3191d.o
+00:09:26   CC      fs/pnode.o
+00:09:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_helpers.o
+00:09:26   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtc8723b1ant.o
+00:09:26   CC [M]  drivers/media/rc/keymaps/rc-npgtech.o
+00:09:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gp102.o
+00:09:26   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_rfim.o
+00:09:26   CC [M]  drivers/hwmon/pmbus/mp2888.o
+00:09:27   CC [M]  drivers/net/wireless/ti/wl1251/ps.o
+00:09:27   CC [M]  drivers/media/rc/keymaps/rc-odroid.o
+00:09:27   CC      fs/splice.o
+00:09:27   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_devlink.o
+00:09:27   CC [M]  drivers/net/wireless/realtek/rtw88/coex.o
+00:09:27   CC [M]  drivers/net/wireless/quantenna/qtnfmac/pcie/topaz_pcie.o
+00:09:27   CC [M]  net/ieee802154/socket.o
+00:09:27   CC [M]  drivers/media/rc/keymaps/rc-pctv-sedna.o
+00:09:27   CC [M]  drivers/net/ethernet/intel/i40e/i40e_common.o
+00:09:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/gv100.o
+00:09:27   CC [M]  drivers/media/i2c/tvp514x.o
+00:09:27   CC [M]  drivers/scsi/hpsa.o
+00:09:27   CC [M]  drivers/hwmon/pmbus/mp2975.o
+00:09:27   CC [M]  drivers/thermal/intel/int340x_thermal/processor_thermal_mbox.o
+00:09:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_pp_smu.o
+00:09:27   CC [M]  drivers/media/rc/keymaps/rc-pine64.o
+00:09:28   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_ethtool.o
+00:09:28   CC [M]  drivers/net/wireless/ti/wl1251/cmd.o
+00:09:28   CC [M]  drivers/thermal/intel/int340x_thermal/int3406_thermal.o
+00:09:28   CC [M]  drivers/media/rc/keymaps/rc-pinnacle-color.o
+00:09:28   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtc8723b2ant.o
+00:09:28   CC      fs/sync.o
+00:09:28   CC [M]  drivers/net/ethernet/mellanox/mlx4/cq.o
+00:09:28   CC [M]  drivers/hwmon/pmbus/pm6764tr.o
+00:09:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/tu102.o
+00:09:28   CC [M]  drivers/media/i2c/tvp7002.o
+00:09:28   CC [M]  drivers/media/rc/keymaps/rc-pinnacle-grey.o
+00:09:28   CC [M]  drivers/net/wireless/quantenna/qtnfmac/debug.o
+00:09:28   LD [M]  net/ieee802154/ieee802154.o
+00:09:28   LD [M]  net/ieee802154/ieee802154_socket.o
+00:09:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_psr.o
+00:09:28   CC [M]  net/mac802154/main.o
+00:09:28   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_switchdev.o
+00:09:29   CC [M]  drivers/thermal/intel/int340x_thermal/acpi_thermal_rel.o
+00:09:29   CC [M]  drivers/net/wireless/realtek/rtw88/efuse.o
+00:09:29   CC [M]  drivers/media/rc/keymaps/rc-pinnacle-pctv-hd.o
+00:09:29   CC [M]  drivers/hwmon/pmbus/q54sj108a2.o
+00:09:29   CC [M]  drivers/net/wireless/ti/wl1251/acx.o
+00:09:29   CC      fs/utimes.o
+00:09:29   CC [M]  drivers/net/ethernet/mellanox/mlx4/eq.o
+00:09:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ga102.o
+00:09:29   CC [M]  drivers/media/rc/keymaps/rc-pixelview.o
+00:09:29   CC [M]  drivers/media/i2c/tw2804.o
+00:09:29   LD [M]  drivers/net/wireless/quantenna/qtnfmac/qtnfmac.o
+00:09:29   LD [M]  drivers/net/wireless/quantenna/qtnfmac/qtnfmac_pcie.o
+00:09:29   CC      drivers/thermal/intel/therm_throt.o
+00:09:29   AR      drivers/net/wireless/quantenna/built-in.a
+00:09:29   CC [M]  drivers/net/ethernet/marvell/mvmdio.o
+00:09:29   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_crc.o
+00:09:29   CC [M]  net/mac802154/rx.o
+00:09:29   CC [M]  drivers/net/ethernet/intel/i40e/i40e_hmc.o
+00:09:30   CC [M]  drivers/media/rc/keymaps/rc-pixelview-mk12.o
+00:09:30   CC      fs/d_path.o
+00:09:30   CC [M]  drivers/hwmon/pmbus/tps40422.o
+00:09:30   CC [M]  drivers/net/wireless/realtek/rtw88/fw.o
+00:09:30   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_acl.o
+00:09:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/vga.o
+00:09:30   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtc8821a1ant.o
+00:09:30   CC [M]  drivers/media/rc/keymaps/rc-pixelview-002t.o
+00:09:30   CC [M]  drivers/net/wireless/ti/wl1251/boot.o
+00:09:30   CC [M]  drivers/media/i2c/tw9903.o
+00:09:30   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/amdgpu_dm/amdgpu_dm_debugfs.o
+00:09:30   CC [M]  net/mac802154/tx.o
+00:09:30   CC [M]  drivers/thermal/intel/intel_powerclamp.o
+00:09:30   CC      fs/stack.o
+00:09:30   CC [M]  drivers/hwmon/pmbus/tps53679.o
+00:09:30   CC [M]  drivers/net/ethernet/mellanox/mlx4/fw.o
+00:09:30   CC [M]  drivers/media/rc/keymaps/rc-pixelview-new.o
+00:09:30   CC [M]  drivers/net/fjes/fjes_main.o
+00:09:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/head.o
+00:09:31   CC [M]  drivers/net/ethernet/intel/i40e/i40e_lan_hmc.o
+00:09:31   CC      fs/fs_struct.o
+00:09:31   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_flow.o
+00:09:31   CC [M]  drivers/media/rc/keymaps/rc-powercolor-real-angel.o
+00:09:31   CC [M]  drivers/scsi/dc395x.o
+00:09:31   CC [M]  drivers/media/i2c/tw9906.o
+00:09:31   CC [M]  net/mac802154/mac_cmd.o
+00:09:31   CC [M]  drivers/thermal/intel/x86_pkg_temp_thermal.o
+00:09:31   CC [M]  drivers/hwmon/pmbus/ucd9000.o
+00:09:31   CC [M]  drivers/net/wireless/ti/wl1251/init.o
+00:09:31   CC      fs/statfs.o
+00:09:31   CC [M]  drivers/media/rc/keymaps/rc-proteus-2309.o
+00:09:31   CC [M]  drivers/net/wireless/realtek/rtw88/ps.o
+00:09:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/headnv04.o
+00:09:31   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtc8821a2ant.o
+00:09:31   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_flower.o
+00:09:31   CC [M]  drivers/thermal/intel/intel_soc_dts_iosf.o
+00:09:32   CC [M]  drivers/media/rc/keymaps/rc-purpletv.o
+00:09:32   CC [M]  drivers/net/fjes/fjes_hw.o
+00:09:32   CC [M]  net/mac802154/mib.o
+00:09:32   CC [M]  drivers/media/i2c/tw9910.o
+00:09:32   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/basics/conversion.o
+00:09:32   CC      fs/fs_pin.o
+00:09:32   CC [M]  drivers/hwmon/pmbus/ucd9200.o
+00:09:32   CC [M]  drivers/media/rc/keymaps/rc-pv951.o
+00:09:32   CC [M]  drivers/net/ethernet/intel/i40e/i40e_nvm.o
+00:09:32   CC [M]  drivers/thermal/intel/intel_soc_dts_thermal.o
+00:09:32   CC [M]  drivers/net/ethernet/mellanox/mlx4/fw_qos.o
+00:09:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/headnv50.o
+00:09:32   CC [M]  drivers/net/wireless/ti/wl1251/debugfs.o
+00:09:32   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_span.o
+00:09:32   CC      fs/nsfs.o
+00:09:32   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/basics/fixpt31_32.o
+00:09:32   CC [M]  drivers/media/rc/keymaps/rc-hauppauge.o
+00:09:32   CC [M]  drivers/thermal/intel/intel_bxt_pmic_thermal.o
+00:09:32   CC [M]  net/mac802154/iface.o
+00:09:32   CC [M]  drivers/net/wireless/realtek/rtw88/sec.o
+00:09:33   CC [M]  drivers/scsi/esp_scsi.o
+00:09:33   CC [M]  drivers/media/i2c/cs3308.o
+00:09:33   CC [M]  drivers/hwmon/pmbus/zl6100.o
+00:09:33   CC [M]  drivers/media/rc/keymaps/rc-rc6-mce.o
+00:09:33   CC [M]  drivers/thermal/intel/intel_pch_thermal.o
+00:09:33   CC [M]  drivers/net/fjes/fjes_ethtool.o
+00:09:33   CC      fs/fs_types.o
+00:09:33   CC [M]  drivers/net/ethernet/mellanox/mlx4/icm.o
+00:09:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/headgf119.o
+00:09:33   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/basics/vector.o
+00:09:33   CC [M]  drivers/net/ethernet/marvell/prestera/prestera_pci.o
+00:09:33   CC [M]  drivers/media/rc/keymaps/rc-real-audio-220-32-keys.o
+00:09:33   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/halbtcoutsrc.o
+00:09:33   CC      fs/fs_context.o
+00:09:33   CC [M]  drivers/net/ethernet/intel/i40e/i40e_debugfs.o
+00:09:33   CC [M]  net/mac802154/llsec.o
+00:09:33   CC [M]  drivers/media/i2c/cs5345.o
+00:09:34   CC [M]  drivers/net/wireless/realtek/rtw88/bf.o
+00:09:34   CC [M]  drivers/hwmon/pmbus/pim4328.o
+00:09:34   CC [M]  drivers/media/rc/keymaps/rc-reddo.o
+00:09:34   CC [M]  drivers/net/wireless/ti/wl1251/io.o
+00:09:34   CC [M]  drivers/thermal/intel/intel_tcc_cooling.o
+00:09:34   CC [M]  drivers/net/fjes/fjes_trace.o
+00:09:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/headgv100.o
+00:09:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/basics/dc_common.o
+00:09:34   CC [M]  drivers/net/ethernet/mellanox/mlx4/intf.o
+00:09:34   LD [M]  drivers/net/ethernet/marvell/prestera/prestera.o
+00:09:34   CC [M]  drivers/media/rc/keymaps/rc-snapstream-firefly.o
+00:09:34   CC [M]  drivers/net/ethernet/marvell/skge.o
+00:09:34   CC      fs/fs_parser.o
+00:09:34   AR      drivers/thermal/intel/built-in.a
+00:09:34   CC [M]  drivers/scsi/am53c974.o
+00:09:34   AR      drivers/thermal/st/built-in.a
+00:09:34   AR      drivers/thermal/tegra/built-in.a
+00:09:34   CC      drivers/thermal/thermal_core.o
+00:09:34   CC [M]  drivers/media/i2c/cs53l32a.o
+00:09:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/bios_parser.o
+00:09:34   CC [M]  drivers/media/rc/keymaps/rc-streamzap.o
+00:09:35   CC [M]  drivers/hwmon/acpi_power_meter.o
+00:09:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ior.o
+00:09:35   CC      fs/fsopen.o
+00:09:35   CC [M]  net/mac802154/util.o
+00:09:35   CC [M]  drivers/net/wireless/realtek/rtw88/regd.o
+00:09:35   CC [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/rtl_btc.o
+00:09:35   CC [M]  drivers/net/wireless/ti/wl1251/spi.o
+00:09:35   CC [M]  drivers/net/ethernet/mellanox/mlx4/main.o
+00:09:35   CC [M]  drivers/media/rc/keymaps/rc-tanix-tx3mini.o
+00:09:35   CC [M]  drivers/scsi/megaraid.o
+00:09:35   CC [M]  drivers/net/fjes/fjes_debugfs.o
+00:09:35   CC [M]  drivers/media/i2c/m52790.o
+00:09:35   CC [M]  drivers/hwmon/asus_atk0110.o
+00:09:35   CC [M]  drivers/net/ethernet/intel/i40e/i40e_diag.o
+00:09:35   CC [M]  drivers/media/rc/keymaps/rc-tanix-tx5max.o
+00:09:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dacnv50.o
+00:09:35   CC      fs/init.o
+00:09:35   CC [M]  net/mac802154/cfg.o
+00:09:36   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/bios_parser_interface.o
+00:09:36   CC      drivers/thermal/thermal_sysfs.o
+00:09:36   CC [M]  drivers/media/rc/keymaps/rc-tbs-nec.o
+00:09:36   CC [M]  drivers/net/wireless/realtek/rtw88/wow.o
+00:09:36   CC [M]  drivers/net/wireless/ti/wl1251/sdio.o
+00:09:36   LD [M]  drivers/net/wireless/realtek/rtlwifi/btcoexist/btcoexist.o
+00:09:36   LD [M]  drivers/net/fjes/fjes.o
+00:09:36   AR      drivers/net/wireless/realtek/built-in.a
+00:09:36   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723com/main.o
+00:09:36   CC [M]  drivers/net/ethernet/intel/iavf/iavf_main.o
+00:09:36   CC [M]  drivers/hwmon/asb100.o
+00:09:36   CC      fs/kernel_read_file.o
+00:09:36   CC [M]  drivers/media/i2c/tlv320aic23b.o
+00:09:36   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/bios_parser_helper.o
+00:09:36   CC [M]  drivers/media/rc/keymaps/rc-technisat-ts35.o
+00:09:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dacgf119.o
+00:09:36   CC [M]  drivers/net/ethernet/intel/i40e/i40e_txrx.o
+00:09:36   CC [M]  drivers/net/ethernet/marvell/sky2.o
+00:09:36   CC [M]  net/mac802154/trace.o
+00:09:36   CC      drivers/thermal/thermal_helpers.o
+00:09:36   CC      fs/remap_range.o
+00:09:36   CC [M]  drivers/media/rc/keymaps/rc-technisat-usb2.o
+00:09:37   CC [M]  drivers/scsi/atp870u.o
+00:09:37   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/command_table.o
+00:09:37   CC      drivers/thermal/thermal_netlink.o
+00:09:37   CC [M]  drivers/media/i2c/uda1342.o
+00:09:37   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723com/dm_common.o
+00:09:37   LD [M]  drivers/net/wireless/ti/wl1251/wl1251.o
+00:09:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/piornv50.o
+00:09:37   LD [M]  drivers/net/wireless/ti/wl1251/wl1251_spi.o
+00:09:37   CC [M]  drivers/media/rc/keymaps/rc-terratec-cinergy-c-pci.o
+00:09:37   LD [M]  drivers/net/wireless/ti/wl1251/wl1251_sdio.o
+00:09:37   CC [M]  drivers/net/wireless/ti/wl18xx/main.o
+00:09:37   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822b.o
+00:09:37   CC [M]  drivers/hwmon/w83627hf.o
+00:09:37   CC [M]  drivers/net/ethernet/mellanox/mlx4/mcg.o
+00:09:37   CC      fs/buffer.o
+00:09:37   CC [M]  drivers/media/rc/keymaps/rc-terratec-cinergy-s2-hd.o
+00:09:38   CC      drivers/thermal/thermal_hwmon.o
+00:09:38   CC [M]  drivers/media/i2c/wm8775.o
+00:09:38   LD [M]  net/mac802154/mac802154.o
+00:09:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sornv50.o
+00:09:38   CC [M]  drivers/media/rc/keymaps/rc-terratec-cinergy-xs.o
+00:09:38   CC [M]  net/dns_resolver/dns_key.o
+00:09:38   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723com/fw_common.o
+00:09:38   CC      drivers/thermal/gov_fair_share.o
+00:09:38   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/command_table_helper.o
+00:09:38   CC [M]  drivers/media/rc/keymaps/rc-terratec-slim.o
+00:09:38   CC [M]  drivers/hwmon/w83773g.o
+00:09:38   CC [M]  net/dns_resolver/dns_query.o
+00:09:38   CC [M]  drivers/net/ethernet/intel/i40e/i40e_ptp.o
+00:09:38   CC [M]  drivers/net/wireless/ti/wl18xx/acx.o
+00:09:38   CC      drivers/thermal/gov_bang_bang.o
+00:09:38   CC [M]  drivers/net/ethernet/mellanox/mlx4/mr.o
+00:09:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorg84.o
+00:09:38   CC [M]  drivers/net/ethernet/intel/iavf/iavf_ethtool.o
+00:09:38   CC [M]  drivers/media/i2c/wm8739.o
+00:09:39   CC [M]  drivers/media/rc/keymaps/rc-terratec-slim-2.o
+00:09:39   CC [M]  drivers/scsi/initio.o
+00:09:39   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/bios_parser_common.o
+00:09:39   CC      drivers/thermal/gov_step_wise.o
+00:09:39   LD [M]  net/dns_resolver/dns_resolver.o
+00:09:39   AR      drivers/net/ethernet/marvell/built-in.a
+00:09:39   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822b_table.o
+00:09:39   CC [M]  drivers/hwmon/w83792d.o
+00:09:39   CC [M]  net/ceph/ceph_common.o
+00:09:39   CC [M]  drivers/net/ethernet/intel/iavf/iavf_virtchnl.o
+00:09:39   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723com/phy_common.o
+00:09:39   CC [M]  drivers/media/rc/keymaps/rc-tevii-nec.o
+00:09:39   CC      drivers/thermal/gov_user_space.o
+00:09:39   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/command_table2.o
+00:09:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorg94.o
+00:09:39   CC [M]  drivers/media/i2c/vp27smpx.o
+00:09:39   CC [M]  drivers/media/rc/keymaps/rc-tivo.o
+00:09:39   CC      fs/direct-io.o
+00:09:39   CC [M]  drivers/net/wireless/ti/wl18xx/tx.o
+00:09:40   AR      drivers/thermal/built-in.a
+00:09:40   CC [M]  drivers/net/ethernet/mellanox/mlx4/pd.o
+00:09:40   AR      drivers/media/common/b2c2/built-in.a
+00:09:40   CC [M]  drivers/media/common/b2c2/flexcop.o
+00:09:40   CC [M]  drivers/media/rc/keymaps/rc-total-media-in-hand.o
+00:09:40   CC [M]  drivers/net/ethernet/intel/i40e/i40e_ddp.o
+00:09:40   CC [M]  drivers/net/ethernet/mellanox/mlx4/port.o
+00:09:40   CC [M]  net/ceph/messenger.o
+00:09:40   CC [M]  drivers/scsi/a100u2w.o
+00:09:40   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822be.o
+00:09:40   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8723com/rtl8723-common.o
+00:09:40   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/dm.o
+00:09:40   CC [M]  drivers/hwmon/w83793.o
+00:09:40   CC [M]  drivers/media/i2c/sony-btf-mpx.o
+00:09:40   CC [M]  drivers/media/rc/keymaps/rc-total-media-in-hand-02.o
+00:09:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sormcp77.o
+00:09:40   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/command_table_helper2.o
+00:09:40   CC      drivers/media/rc/lirc_dev.o
+00:09:40   CC [M]  drivers/net/wireless/ti/wl18xx/io.o
+00:09:41   CC      fs/mpage.o
+00:09:41   CC [M]  drivers/media/common/b2c2/flexcop-fe-tuner.o
+00:09:41   CC [M]  drivers/net/ethernet/intel/iavf/iavf_fdir.o
+00:09:41   CC [M]  drivers/media/rc/keymaps/rc-trekstor.o
+00:09:41   CC [M]  drivers/scsi/myrb.o
+00:09:41   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/bios_parser2.o
+00:09:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgt215.o
+00:09:41   CC [M]  drivers/media/rc/keymaps/rc-tt-1500.o
+00:09:41   CC [M]  drivers/media/i2c/upd64031a.o
+00:09:41   CC [M]  drivers/net/ethernet/intel/i40e/i40e_client.o
+00:09:41   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822c.o
+00:09:41   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/main.o
+00:09:41   CC [M]  drivers/media/rc/keymaps/rc-twinhan-dtv-cab-ci.o
+00:09:42   CC [M]  drivers/net/wireless/ti/wl18xx/debugfs.o
+00:09:42   CC      fs/proc_namespace.o
+00:09:42   CC [M]  drivers/media/common/b2c2/flexcop-i2c.o
+00:09:42   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/fw.o
+00:09:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sormcp89.o
+00:09:42   CC [M]  drivers/hwmon/w83795.o
+00:09:42   CC [M]  drivers/net/ethernet/intel/iavf/iavf_adv_rss.o
+00:09:42   CC [M]  drivers/media/rc/keymaps/rc-twinhan1027.o
+00:09:42   CC [M]  drivers/net/ethernet/mellanox/mlx4/profile.o
+00:09:42   CC [M]  drivers/media/i2c/upd64083.o
+00:09:42   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/dce60/command_table_helper_dce60.o
+00:09:42   CC [M]  net/ceph/msgpool.o
+00:09:42   CC      fs/eventpoll.o
+00:09:42   CC [M]  drivers/media/rc/keymaps/rc-vega-s9x.o
+00:09:42   CC [M]  drivers/net/ethernet/intel/i40e/i40e_virtchnl_pf.o
+00:09:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgf119.o
+00:09:43   CC [M]  drivers/scsi/myrs.o
+00:09:43   CC [M]  drivers/media/rc/keymaps/rc-videomate-m1f.o
+00:09:43   CC [M]  drivers/media/common/b2c2/flexcop-sram.o
+00:09:43   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/dce80/command_table_helper_dce80.o
+00:09:43   CC [M]  drivers/media/i2c/ov02a10.o
+00:09:43   CC [M]  net/ceph/buffer.o
+00:09:43   CC [M]  drivers/net/ethernet/intel/iavf/iavf_txrx.o
+00:09:43   CC [M]  drivers/net/ethernet/mellanox/mlx4/qp.o
+00:09:43   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/cmd.o
+00:09:43   CC [M]  drivers/media/rc/keymaps/rc-videomate-s350.o
+00:09:43   CC [M]  drivers/net/wireless/ti/wl18xx/scan.o
+00:09:43   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/hw.o
+00:09:43   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/dce110/command_table_helper_dce110.o
+00:09:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgk104.o
+00:09:43   CC [M]  drivers/hwmon/w83781d.o
+00:09:43   CC [M]  drivers/media/rc/keymaps/rc-videomate-tv-pvr.o
+00:09:44   CC [M]  net/ceph/pagelist.o
+00:09:44   CC [M]  drivers/media/common/b2c2/flexcop-eeprom.o
+00:09:44   CC [M]  drivers/media/i2c/ov2640.o
+00:09:44   CC      fs/anon_inodes.o
+00:09:44   CC [M]  drivers/media/rc/keymaps/rc-videostrong-kii-pro.o
+00:09:44   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/dce112/command_table_helper_dce112.o
+00:09:44   CC [M]  drivers/net/ethernet/mellanox/mlx4/reset.o
+00:09:44   CC [M]  drivers/scsi/3w-xxxx.o
+00:09:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgm107.o
+00:09:44   CC [M]  net/ceph/mon_client.o
+00:09:44   CC [M]  drivers/net/wireless/ti/wl18xx/cmd.o
+00:09:44   CC [M]  drivers/media/rc/keymaps/rc-wetek-hub.o
+00:09:44   CC      fs/signalfd.o
+00:09:44   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822c_table.o
+00:09:44   CC [M]  drivers/media/common/b2c2/flexcop-misc.o
+00:09:44   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/bios/dce112/command_table_helper2_dce112.o
+00:09:44   CC [M]  drivers/net/ethernet/intel/iavf/iavf_common.o
+00:09:45   CC [M]  drivers/media/rc/keymaps/rc-wetek-play2.o
+00:09:45   CC [M]  drivers/hwmon/w83791d.o
+00:09:45   CC [M]  drivers/media/i2c/ov2680.o
+00:09:45   CC [M]  drivers/net/ethernet/mellanox/mlx4/sense.o
+00:09:45   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/debugfs.o
+00:09:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgm200.o
+00:09:45   CC      fs/timerfd.o
+00:09:45   CC [M]  drivers/net/ethernet/intel/i40e/i40e_xsk.o
+00:09:45   CC [M]  drivers/media/rc/keymaps/rc-winfast.o
+00:09:45   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/clk_mgr.o
+00:09:45   CC [M]  drivers/net/wireless/ti/wl18xx/event.o
+00:09:45   CC [M]  drivers/scsi/3w-9xxx.o
+00:09:45   CC [M]  drivers/media/common/b2c2/flexcop-hw-filter.o
+00:09:45   CC [M]  net/ceph/decode.o
+00:09:45   CC [M]  drivers/net/ethernet/mellanox/mlx4/srq.o
+00:09:45   CC [M]  drivers/media/rc/keymaps/rc-winfast-usbii-deluxe.o
+00:09:46   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/led.o
+00:09:46   CC [M]  drivers/net/ethernet/intel/iavf/iavf_adminq.o
+00:09:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgp100.o
+00:09:46   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8822ce.o
+00:09:46   CC [M]  drivers/media/i2c/ov2685.o
+00:09:46   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dce60/dce60_clk_mgr.o
+00:09:46   CC [M]  drivers/hwmon/abituguru.o
+00:09:46   CC [M]  drivers/media/rc/keymaps/rc-su3000.o
+00:09:46   CC      fs/eventfd.o
+00:09:46   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fw.o
+00:09:46   CC [M]  net/ceph/cls_lock_client.o
+00:09:46   CC [M]  drivers/net/ethernet/mellanox/mlx4/resource_tracker.o
+00:09:46   LD [M]  drivers/net/wireless/ti/wl18xx/wl18xx.o
+00:09:46   CC      drivers/net/wireless/ti/wilink_platform_data.o
+00:09:46   CC [M]  drivers/media/rc/keymaps/rc-xbox-360.o
+00:09:46   LD [M]  drivers/media/common/b2c2/b2c2-flexcop.o
+00:09:46   AR      drivers/media/common/saa7146/built-in.a
+00:09:46   CC [M]  drivers/media/common/saa7146/saa7146_i2c.o
+00:09:46   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dce100/dce_clk_mgr.o
+00:09:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorgv100.o
+00:09:46   LD [M]  drivers/net/ethernet/intel/i40e/i40e.o
+00:09:47   CC [M]  drivers/media/common/saa7146/saa7146_core.o
+00:09:47   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/phy.o
+00:09:47   AR      drivers/net/wireless/ti/built-in.a
+00:09:47   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core.o
+00:09:47   CC      fs/userfaultfd.o
+00:09:47   CC [M]  drivers/media/i2c/ov2740.o
+00:09:47   CC [M]  drivers/net/ethernet/intel/iavf/iavf_client.o
+00:09:47   CC [M]  drivers/scsi/3w-sas.o
+00:09:47   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8723d.o
+00:09:47   CC [M]  drivers/media/rc/keymaps/rc-xbox-dvd.o
+00:09:47   CC [M]  drivers/hwmon/abituguru3.o
+00:09:47   CC [M]  net/ceph/osd_client.o
+00:09:47   CC [M]  drivers/media/rc/keymaps/rc-x96max.o
+00:09:47   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dce110/dce110_clk_mgr.o
+00:09:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sortu102.o
+00:09:47   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8723d_table.o
+00:09:47   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/eq.o
+00:09:47   CC [M]  drivers/hwmon/ad7314.o
+00:09:48   CC [M]  drivers/media/rc/keymaps/rc-zx-irdec.o
+00:09:48   CC [M]  drivers/media/common/saa7146/saa7146_fops.o
+00:09:48   CC [M]  drivers/media/i2c/ov5647.o
+00:09:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dce112/dce112_clk_mgr.o
+00:09:48   LD [M]  drivers/net/ethernet/intel/iavf/iavf.o
+00:09:48   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_main.o
+00:09:48   CC [M]  drivers/scsi/ipr.o
+00:09:48   CC      fs/aio.o
+00:09:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/sorga102.o
+00:09:48   CC [M]  drivers/hwmon/ad7414.o
+00:09:48   CC [M]  drivers/net/netdevsim/netdev.o
+00:09:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dce120/dce120_clk_mgr.o
+00:09:49   CC      drivers/media/rc/keymaps/rc-cec.o
+00:09:49   CC [M]  drivers/media/common/saa7146/saa7146_video.o
+00:09:49   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8723de.o
+00:09:49   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core_acl_flex_keys.o
+00:09:49   CC [M]  drivers/media/i2c/ov5648.o
+00:09:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/outp.o
+00:09:49   CC [M]  drivers/hwmon/ad7418.o
+00:09:49   CC      drivers/media/rc/bpf-lirc.o
+00:09:49   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/uar.o
+00:09:49   CC [M]  drivers/net/ethernet/mellanox/mlx4/crdump.o
+00:09:49   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn10/rv1_clk_mgr.o
+00:09:49   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core_acl_flex_actions.o
+00:09:49   CC [M]  drivers/net/netdevsim/dev.o
+00:09:50   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_common.o
+00:09:50   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/pwrseq.o
+00:09:50   CC [M]  drivers/hwmon/adc128d818.o
+00:09:50   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8821c.o
+00:09:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn10/rv1_clk_mgr_vbios_smu.o
+00:09:50   CC [M]  drivers/media/rc/ir-nec-decoder.o
+00:09:50   CC      fs/dax.o
+00:09:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dp.o
+00:09:50   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_main.o
+00:09:50   CC [M]  drivers/media/common/saa7146/saa7146_hlp.o
+00:09:50   CC [M]  drivers/media/i2c/ov5670.o
+00:09:50   CC [M]  net/ceph/osdmap.o
+00:09:50   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/pagealloc.o
+00:09:50   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_pci.o
+00:09:50   CC [M]  drivers/media/rc/ir-rc5-decoder.o
+00:09:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn10/rv2_clk_mgr.o
+00:09:51   CC [M]  drivers/hwmon/adcxx.o
+00:09:51   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core_env.o
+00:09:51   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_tx.o
+00:09:51   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/rf.o
+00:09:51   CC [M]  drivers/media/rc/ir-rc6-decoder.o
+00:09:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdagt215.o
+00:09:51   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn20/dcn20_clk_mgr.o
+00:09:51   CC [M]  drivers/net/netdevsim/ethtool.o
+00:09:51   CC [M]  drivers/media/i2c/ov5675.o
+00:09:51   CC [M]  drivers/media/common/saa7146/saa7146_vbi.o
+00:09:51   CC [M]  drivers/hwmon/adm1025.o
+00:09:51   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8821c_table.o
+00:09:51   CC [M]  drivers/media/rc/ir-jvc-decoder.o
+00:09:52   CC      fs/locks.o
+00:09:52   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/health.o
+00:09:52   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_netdev.o
+00:09:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdagf119.o
+00:09:52   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn21/rn_clk_mgr.o
+00:09:52   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core_hwmon.o
+00:09:52   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/sw.o
+00:09:52   CC [M]  drivers/media/i2c/ov5695.o
+00:09:52   CC [M]  drivers/net/netdevsim/fib.o
+00:09:52   CC [M]  drivers/media/rc/ir-sony-decoder.o
+00:09:52   CC [M]  drivers/hwmon/adm1026.o
+00:09:52   CC [M]  drivers/scsi/hptiop.o
+00:09:52   LD [M]  drivers/media/common/saa7146/saa7146.o
+00:09:52   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_rx.o
+00:09:52   LD [M]  drivers/media/common/saa7146/saa7146_vv.o
+00:09:52   AR      drivers/media/common/siano/built-in.a
+00:09:52   CC [M]  drivers/media/common/siano/smscoreapi.o
+00:09:52   CC [M]  drivers/net/wireless/realtek/rtw88/rtw8821ce.o
+00:09:52   CC [M]  net/ceph/crush/crush.o
+00:09:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdagv100.o
+00:09:53   CC [M]  drivers/media/rc/ir-sanyo-decoder.o
+00:09:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn21/rn_clk_mgr_vbios_smu.o
+00:09:53   CC [M]  net/ceph/crush/mapper.o
+00:09:53   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/mcg.o
+00:09:53   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/table.o
+00:09:53   CC [M]  drivers/media/i2c/ov6650.o
+00:09:53   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/trx.o
+00:09:53   CC [M]  drivers/net/ethernet/mellanox/mlxsw/core_thermal.o
+00:09:53   CC [M]  drivers/media/rc/ir-sharp-decoder.o
+00:09:53   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_ethtool.o
+00:09:53   CC [M]  drivers/scsi/stex.o
+00:09:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmi.o
+00:09:53   CC [M]  drivers/media/common/siano/sms-cards.o
+00:09:53   CC [M]  net/ceph/crush/hash.o
+00:09:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn30/dcn30_clk_mgr.o
+00:09:53   CC      fs/binfmt_script.o
+00:09:53   CC [M]  drivers/net/wireless/realtek/rtw88/pci.o
+00:09:53   CC [M]  net/ceph/striper.o
+00:09:54   CC [M]  drivers/net/netdevsim/bus.o
+00:09:54   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_ethtool.o
+00:09:54   CC [M]  drivers/media/rc/ir-mce_kbd-decoder.o
+00:09:54   CC      fs/binfmt_elf.o
+00:09:54   CC [M]  drivers/media/common/siano/smsendian.o
+00:09:54   CC [M]  net/ceph/debugfs.o
+00:09:54   CC [M]  drivers/hwmon/adm1029.o
+00:09:54   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/cq.o
+00:09:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmig84.o
+00:09:54   CC [M]  drivers/media/i2c/ov7251.o
+00:09:54   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn30/dcn30_clk_mgr_smu_msg.o
+00:09:54   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_pf.o
+00:09:54   CC [M]  drivers/media/common/siano/smsir.o
+00:09:54   CC [M]  drivers/scsi/mvumi.o
+00:09:54   CC [M]  drivers/media/rc/ir-xmp-decoder.o
+00:09:54   CC [M]  drivers/net/ethernet/mellanox/mlxsw/pci.o
+00:09:54   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8821ae/rtl8821ae.o
+00:09:55   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/dm.o
+00:09:55   CC [M]  drivers/hwmon/adm1031.o
+00:09:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmigt215.o
+00:09:55   CC [M]  net/ceph/auth.o
+00:09:55   CC [M]  drivers/net/netdevsim/health.o
+00:09:55   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn301/vg_clk_mgr.o
+00:09:55   CC [M]  drivers/media/common/siano/smsdvb-main.o
+00:09:55   CC      fs/compat_binfmt_elf.o
+00:09:55   CC [M]  drivers/media/rc/ir-imon-decoder.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_core.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8822b.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8822be.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8822c.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8822ce.o
+00:09:55   CC [M]  drivers/media/i2c/ov7640.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8723d.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8723de.o
+00:09:55   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/alloc.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8821c.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_8821ce.o
+00:09:55   LD [M]  drivers/net/wireless/realtek/rtw88/rtw88_pci.o
+00:09:55   LD [M]  drivers/media/common/siano/smsmdtv.o
+00:09:55   CC [M]  net/batman-adv/bat_algo.o
+00:09:56   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_port.o
+00:09:56   CC [M]  drivers/media/rc/ir-rcmm-decoder.o
+00:09:56   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_vf.o
+00:09:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmigf119.o
+00:09:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn301/dcn301_smu.o
+00:09:56   CC [M]  net/ceph/auth_none.o
+00:09:56   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/fw.o
+00:09:56   CC [M]  drivers/scsi/pmcraid.o
+00:09:56   CC [M]  drivers/hwmon/adm9240.o
+00:09:56   CC [M]  drivers/net/netdevsim/udp_tunnels.o
+00:09:56   CC [M]  drivers/media/i2c/ov772x.o
+00:09:56   CC [M]  net/batman-adv/bat_iv_ogm.o
+00:09:56   LD [M]  drivers/media/common/siano/smsdvb.o
+00:09:56   AR      drivers/media/common/v4l2-tpg/built-in.a
+00:09:56   CC      fs/mbcache.o
+00:09:56   CC [M]  drivers/media/common/v4l2-tpg/v4l2-tpg-core.o
+00:09:56   CC [M]  drivers/media/rc/ati_remote.o
+00:09:56   CC [M]  drivers/net/ethernet/mellanox/mlxsw/i2c.o
+00:09:56   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/port.o
+00:09:56   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_mbx.o
+00:09:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn31/dcn31_smu.o
+00:09:56   CC [M]  net/ceph/crypto.o
+00:09:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmigk104.o
+00:09:56   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_cq.o
+00:09:57   CC      fs/posix_acl.o
+00:09:57   CC [M]  drivers/hwmon/ads7828.o
+00:09:57   CC [M]  drivers/media/rc/imon.o
+00:09:57   CC [M]  drivers/media/i2c/ov7740.o
+00:09:57   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/clk_mgr/dcn31/dcn31_clk_mgr.o
+00:09:57   CC [M]  drivers/net/netdevsim/bpf.o
+00:09:57   CC [M]  net/ceph/armor.o
+00:09:57   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/hw.o
+00:09:57   CC [M]  net/ceph/auth_x.o
+00:09:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmigm200.o
+00:09:57   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_resources.o
+00:09:57   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum.o
+00:09:57   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_iov.o
+00:09:57   CC [M]  net/batman-adv/bat_v.o
+00:09:58   CC      fs/coredump.o
+00:09:58   CC [M]  drivers/hwmon/ads7871.o
+00:09:58   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_audio.o
+00:09:58   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/mr.o
+00:09:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/hdmigv100.o
+00:09:58   CC [M]  drivers/media/i2c/ov8856.o
+00:09:58   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_netdev.o
+00:09:58   CC [M]  drivers/media/rc/imon_raw.o
+00:09:58   CC [M]  drivers/media/common/v4l2-tpg/v4l2-tpg-colors.o
+00:09:58   CC [M]  drivers/scsi/virtio_scsi.o
+00:09:58   CC [M]  drivers/net/netdevsim/ipsec.o
+00:09:58   CC [M]  drivers/hwmon/adt7x10.o
+00:09:58   CC [M]  net/ceph/ceph_strings.o
+00:09:58   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_tlv.o
+00:09:58   LD [M]  drivers/media/common/v4l2-tpg/v4l2-tpg.o
+00:09:58   AR      drivers/media/common/videobuf2/built-in.a
+00:09:58   CC [M]  drivers/media/common/videobuf2/videobuf2-core.o
+00:09:58   CC [M]  net/batman-adv/bat_v_elp.o
+00:09:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_stream_encoder.o
+00:09:59   CC [M]  drivers/media/rc/ite-cir.o
+00:09:59   CC [M]  net/ceph/ceph_hash.o
+00:09:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/conn.o
+00:09:59   CC [M]  drivers/hwmon/adt7310.o
+00:09:59   CC      fs/drop_caches.o
+00:09:59   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/pd.o
+00:09:59   CC [M]  net/ceph/pagevec.o
+00:09:59   CC [M]  drivers/scsi/vmw_pvscsi.o
+00:09:59   CC [M]  drivers/media/i2c/ov8865.o
+00:09:59   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/led.o
+00:09:59   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_debugfs.o
+00:09:59   CC [M]  drivers/net/netdevsim/psample.o
+00:09:59   CC [M]  net/batman-adv/bat_v_ogm.o
+00:09:59   CC [M]  drivers/hwmon/adt7410.o
+00:09:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_link_encoder.o
+00:09:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootnv04.o
+00:10:00   CC [M]  drivers/media/rc/mceusb.o
+00:10:00   CC      fs/fhandle.o
+00:10:00   CC [M]  net/ceph/snapshot.o
+00:10:00   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/transobj.o
+00:10:00   CC [M]  drivers/net/ethernet/intel/fm10k/fm10k_dcbnl.o
+00:10:00   CC [M]  drivers/hwmon/adt7411.o
+00:10:00   CC [M]  drivers/scsi/xen-scsifront.o
+00:10:00   CC [M]  fs/binfmt_misc.o
+00:10:00   CC [M]  drivers/media/i2c/ov9640.o
+00:10:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootnv50.o
+00:10:00   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/phy.o
+00:10:00   CC [M]  net/batman-adv/bitarray.o
+00:10:00   CC [M]  drivers/media/common/videobuf2/frame_vector.o
+00:10:00   LD [M]  drivers/net/netdevsim/netdevsim.o
+00:10:00   AR      drivers/net/ethernet/micrel/built-in.a
+00:10:00   CC [M]  drivers/net/ethernet/micrel/ksz884x.o
+00:10:00   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_hwseq.o
+00:10:00   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_selftest.o
+00:10:01   CC [M]  drivers/media/rc/fintek-cir.o
+00:10:01   CC [M]  net/ceph/string_table.o
+00:10:01   LD [M]  drivers/net/ethernet/intel/fm10k/fm10k.o
+00:10:01   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_buffers.o
+00:10:01   CC [M]  drivers/net/ethernet/intel/ice/ice_main.o
+00:10:01   CC [M]  drivers/media/common/videobuf2/vb2-trace.o
+00:10:01   CC [M]  net/ceph/messenger_v1.o
+00:10:01   CC [M]  drivers/hwmon/adt7462.o
+00:10:01   CC [M]  net/batman-adv/bridge_loop_avoidance.o
+00:10:01   AR      fs/built-in.a
+00:10:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_mem_input.o
+00:10:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootg84.o
+00:10:01   CC [M]  drivers/media/i2c/ov9650.o
+00:10:01   CC      drivers/watchdog/watchdog_core.o
+00:10:01   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_clock.o
+00:10:01   CC [M]  drivers/scsi/storvsc_drv.o
+00:10:01   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/vport.o
+00:10:01   CC [M]  drivers/media/rc/nuvoton-cir.o
+00:10:02   CC [M]  drivers/media/common/videobuf2/videobuf2-v4l2.o
+00:10:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootg94.o
+00:10:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_clock_source.o
+00:10:02   CC      drivers/watchdog/watchdog_dev.o
+00:10:02   CC [M]  drivers/net/ethernet/mellanox/mlx4/en_dcb_nl.o
+00:10:02   CC [M]  drivers/media/rc/ene_ir.o
+00:10:02   CC [M]  drivers/hwmon/adt7470.o
+00:10:02   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/pwrseq.o
+00:10:02   CC [M]  net/ceph/messenger_v2.o
+00:10:02   CC [M]  drivers/media/i2c/ov9734.o
+00:10:02   CC [M]  drivers/scsi/wd719x.o
+00:10:03   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_switchdev.o
+00:10:03   CC      drivers/net/loopback.o
+00:10:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgt200.o
+00:10:03   CC [M]  net/batman-adv/distributed-arp-table.o
+00:10:03   CC [M]  drivers/watchdog/pcwd_pci.o
+00:10:03   CC [M]  drivers/media/common/videobuf2/videobuf2-memops.o
+00:10:03   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sriov.o
+00:10:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_scl_filters.o
+00:10:03   LD [M]  drivers/net/ethernet/mellanox/mlx4/mlx4_core.o
+00:10:03   LD [M]  drivers/net/ethernet/mellanox/mlx4/mlx4_en.o
+00:10:03   AR      drivers/net/ethernet/intel/built-in.a
+00:10:03   CC      drivers/gpu/drm/drm_atomic_helper.o
+00:10:03   CC [M]  drivers/media/rc/redrat3.o
+00:10:03   CC [M]  drivers/media/common/videobuf2/videobuf2-vmalloc.o
+00:10:03   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/rf.o
+00:10:03   CC [M]  drivers/hwmon/adt7475.o
+00:10:03   CC [M]  drivers/media/i2c/ov13858.o
+00:10:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgt215.o
+00:10:03   CC [M]  drivers/scsi/st.o
+00:10:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_transform.o
+00:10:03   CC [M]  drivers/watchdog/wdt_pci.o
+00:10:04   AR      drivers/media/platform/ti-vpe/built-in.a
+00:10:04   AR      drivers/media/platform/stm32/built-in.a
+00:10:04   AR      drivers/media/platform/davinci/built-in.a
+00:10:04   AR      drivers/media/platform/omap/built-in.a
+00:10:04   AR      drivers/media/platform/sunxi/sun4i-csi/built-in.a
+00:10:04   AR      drivers/media/platform/sunxi/sun6i-csi/built-in.a
+00:10:04   AR      drivers/media/platform/sunxi/sun8i-di/built-in.a
+00:10:04   AR      drivers/media/platform/sunxi/sun8i-rotate/built-in.a
+00:10:04   AR      drivers/media/platform/sunxi/built-in.a
+00:10:04   AR      drivers/media/platform/built-in.a
+00:10:04   CC [M]  drivers/net/wireless/mac80211_hwsim.o
+00:10:04   CC [M]  drivers/media/common/videobuf2/videobuf2-dma-contig.o
+00:10:04   CC [M]  drivers/media/rc/streamzap.o
+00:10:04   CC [M]  net/batman-adv/fragmentation.o
+00:10:04   CC [M]  drivers/watchdog/pcwd_usb.o
+00:10:04   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fs_cmd.o
+00:10:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgf119.o
+00:10:04   CC [M]  drivers/net/ethernet/intel/ice/ice_controlq.o
+00:10:04   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/sw.o
+00:10:04   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_opp.o
+00:10:04   CC [M]  drivers/media/i2c/mt9m001.o
+00:10:05   CC [M]  drivers/media/common/videobuf2/videobuf2-dma-sg.o
+00:10:05   CC [M]  drivers/media/rc/winbond-cir.o
+00:10:05   CC [M]  drivers/hwmon/applesmc.o
+00:10:05   CC [M]  drivers/watchdog/alim1535_wdt.o
+00:10:05   LD [M]  net/ceph/libceph.o
+00:10:05   CC [M]  drivers/net/wireless/realtek/rtlwifi/base.o
+00:10:05   CC [M]  net/batman-adv/gateway_client.o
+00:10:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgk104.o
+00:10:05   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_router.o
+00:10:05   CC [M]  drivers/net/wireless/realtek/rtlwifi/cam.o
+00:10:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_dmcu.o
+00:10:05   CC [M]  drivers/watchdog/alim7101_wdt.o
+00:10:05   CC [M]  drivers/media/common/videobuf2/videobuf2-dvb.o
+00:10:05   CC [M]  drivers/media/i2c/mt9p031.o
+00:10:05   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/table.o
+00:10:06   CC [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/trx.o
+00:10:06   CC [M]  drivers/net/ethernet/intel/ice/ice_common.o
+00:10:06   CC [M]  drivers/hwmon/aquacomputer_d5next.o
+00:10:06   CC [M]  drivers/media/rc/rc-loopback.o
+00:10:06   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fs_core.o
+00:10:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgk110.o
+00:10:06   CC [M]  drivers/scsi/ch.o
+00:10:06   CC [M]  drivers/watchdog/f71808e_wdt.o
+00:10:06   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_abm.o
+00:10:06   CC [M]  drivers/media/common/cx2341x.o
+00:10:06   CC [M]  drivers/hwmon/asc7621.o
+00:10:06   CC [M]  net/batman-adv/gateway_common.o
+00:10:06   CC [M]  drivers/media/rc/igorplugusb.o
+00:10:06   LD [M]  drivers/media/common/videobuf2/videobuf2-common.o
+00:10:06   CC      drivers/gpu/drm/drm_kms_helper_common.o
+00:10:06   CC [M]  drivers/net/ethernet/intel/e100.o
+00:10:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgm107.o
+00:10:07   CC [M]  drivers/media/i2c/mt9t112.o
+00:10:07   CC [M]  drivers/net/ethernet/mellanox/mlxfw/mlxfw_fsm.o
+00:10:07   CC [M]  drivers/watchdog/sp5100_tco.o
+00:10:07   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_ipp.o
+00:10:07   CC [M]  drivers/media/rc/iguanair.o
+00:10:07   CC [M]  drivers/scsi/ses.o
+00:10:07   CC [M]  net/batman-adv/hard-interface.o
+00:10:07   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl8192ee/rtl8192ee.o
+00:10:07   CC [M]  drivers/net/wireless/realtek/rtlwifi/core.o
+00:10:07   CC [M]  drivers/watchdog/sbc_fitpc2_wdt.o
+00:10:07   CC [M]  net/nfc/nci/core.o
+00:10:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgm200.o
+00:10:07   CC [M]  drivers/hwmon/atxp1.o
+00:10:07   CC [M]  drivers/media/common/tveeprom.o
+00:10:07   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_aux.o
+00:10:07   CC [M]  drivers/net/ethernet/mellanox/mlxfw/mlxfw_mfa2_tlv_multi.o
+00:10:07   CC [M]  drivers/media/rc/ttusbir.o
+00:10:08   CC [M]  drivers/media/i2c/mt9v011.o
+00:10:08   CC [M]  drivers/watchdog/ib700wdt.o
+00:10:08   CC [M]  drivers/net/ethernet/mellanox/mlxfw/mlxfw_mfa2.o
+00:10:08   CC [M]  drivers/scsi/scsi_debug.o
+00:10:08   CC [M]  net/batman-adv/hash.o
+00:10:08   CC [M]  drivers/net/ethernet/intel/ice/ice_nvm.o
+00:10:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgp100.o
+00:10:08   CC [M]  net/nfc/nci/data.o
+00:10:08   CC [M]  drivers/hwmon/axi-fan-control.o
+00:10:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_i2c.o
+00:10:08   CC [M]  drivers/watchdog/ibmasr.o
+00:10:08   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/pci_irq.o
+00:10:08   CC [M]  drivers/media/rc/serial_ir.o
+00:10:08   CC [M]  drivers/media/common/cypress_firmware.o
+00:10:08   CC [M]  drivers/hwmon/coretemp.o
+00:10:09   CC [M]  drivers/media/i2c/mt9v032.o
+00:10:09   CC [M]  drivers/net/wireless/realtek/rtlwifi/debug.o
+00:10:09   LD [M]  drivers/net/ethernet/mellanox/mlxfw/mlxfw.o
+00:10:09   CC [M]  drivers/media/rc/xbox_remote.o
+00:10:09   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fs_counters.o
+00:10:09   CC [M]  net/batman-adv/main.o
+00:10:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_i2c_hw.o
+00:10:09   CC [M]  drivers/media/common/ttpci-eeprom.o
+00:10:09   CC [M]  drivers/watchdog/i6300esb.o
+00:10:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgp102.o
+00:10:09   CC [M]  net/nfc/nci/lib.o
+00:10:09   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_router_xm.o
+00:10:09   CC [M]  drivers/media/rc/ir_toy.o
+00:10:09   CC [M]  drivers/hwmon/corsair-cpro.o
+00:10:09   CC [M]  drivers/net/ethernet/intel/ice/ice_switch.o
+00:10:09   CC [M]  drivers/watchdog/ie6xx_wdt.o
+00:10:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_i2c_sw.o
+00:10:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootgv100.o
+00:10:10   CC [M]  drivers/md/bcache/alloc.o
+00:10:10   CC [M]  drivers/net/wireless/realtek/rtlwifi/efuse.o
+00:10:10   AR      drivers/media/common/built-in.a
+00:10:10   CC [M]  net/nfc/nci/ntf.o
+00:10:10   CC [M]  drivers/media/i2c/mt9v111.o
+00:10:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/roottu102.o
+00:10:10   CC [M]  net/batman-adv/multicast.o
+00:10:10   CC [M]  drivers/watchdog/iTCO_wdt.o
+00:10:10   CC [M]  drivers/hwmon/corsair-psu.o
+00:10:10   CC [M]  drivers/md/bcache/bset.o
+00:10:10   AR      drivers/media/rc/built-in.a
+00:10:10   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fs_ft_pool.o
+00:10:10   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/rl.o
+00:10:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dmub_psr.o
+00:10:10   CC [M]  net/psample/psample.o
+00:10:10   CC [M]  drivers/hwmon/dell-smm-hwmon.o
+00:10:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/rootga102.o
+00:10:10   CC [M]  drivers/watchdog/iTCO_vendor_support.o
+00:10:11   CC [M]  net/nfc/hci/core.o
+00:10:11   CC [M]  drivers/media/i2c/rj54n1cb0c.o
+00:10:11   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum1_kvdl.o
+00:10:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dmub_abm.o
+00:10:11   CC [M]  drivers/watchdog/it8712f_wdt.o
+00:10:11   CC [M]  net/nfc/nci/rsp.o
+00:10:11   CC [M]  drivers/hwmon/dme1737.o
+00:10:11   LD [M]  drivers/scsi/hv_storvsc.o
+00:10:11   CC      drivers/scsi/scsi_sysfs.o
+00:10:11   CC [M]  net/nfc/hci/hcp.o
+00:10:11   CC [M]  drivers/net/wireless/realtek/rtlwifi/ps.o
+00:10:11   CC [M]  drivers/net/ethernet/intel/ice/ice_sched.o
+00:10:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/capsgv100.o
+00:10:11   CC [M]  drivers/md/bcache/btree.o
+00:10:11   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lag.o
+00:10:11   CC [M]  net/batman-adv/netlink.o
+00:10:11   CC [M]  drivers/watchdog/it87_wdt.o
+00:10:11   AR      drivers/net/ethernet/microchip/built-in.a
+00:10:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dce_panel_cntl.o
+00:10:12   CC [M]  drivers/net/ethernet/microchip/lan743x_main.o
+00:10:12   CC [M]  drivers/net/wireless/virt_wifi.o
+00:10:12   CC [M]  net/nfc/hci/command.o
+00:10:12   CC [M]  drivers/watchdog/hpwdt.o
+00:10:12   CC [M]  drivers/media/i2c/s5k6a3.o
+00:10:12   CC [M]  net/nfc/nci/hci.o
+00:10:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/channv50.o
+00:10:12   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum2_kvdl.o
+00:10:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dmub_hw_lock_mgr.o
+00:10:12   CC [M]  net/nfc/hci/llc.o
+00:10:12   CC [M]  drivers/net/wireless/realtek/rtlwifi/rc.o
+00:10:12   AR      drivers/scsi/built-in.a
+00:10:12   CC [M]  drivers/watchdog/nv_tco.o
+00:10:12   AR      drivers/net/ethernet/mellanox/built-in.a
+00:10:12   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_kvdl.o
+00:10:12   CC      drivers/gpu/drm/drm_dp_dual_mode_helper.o
+00:10:12   CC [M]  net/batman-adv/network-coding.o
+00:10:13   CC [M]  drivers/media/i2c/s5k5baf.o
+00:10:13   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/dev.o
+00:10:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce/dmub_outbox.o
+00:10:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/changf119.o
+00:10:13   CC [M]  drivers/hwmon/drivetemp.o
+00:10:13   CC [M]  net/nfc/hci/llc_nop.o
+00:10:13   CC [M]  net/nfc/nci/spi.o
+00:10:13   CC [M]  drivers/watchdog/sch311x_wdt.o
+00:10:13   CC [M]  drivers/net/ethernet/intel/ice/ice_base.o
+00:10:13   CC [M]  drivers/net/ethernet/microchip/lan743x_ethtool.o
+00:10:13   CC [M]  drivers/net/wireless/realtek/rtlwifi/regd.o
+00:10:13   CC [M]  net/nfc/core.o
+00:10:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/dce_calcs.o
+00:10:13   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_tcam.o
+00:10:13   CC [M]  net/nfc/hci/llc_shdlc.o
+00:10:13   CC [M]  drivers/md/bcache/closure.o
+00:10:14   CC [M]  drivers/media/i2c/adp1653.o
+00:10:14   CC [M]  drivers/watchdog/tqmx86_wdt.o
+00:10:14   CC [M]  drivers/hwmon/ds620.o
+00:10:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/changv100.o
+00:10:14   LD [M]  net/nfc/nci/nci.o
+00:10:14   LD [M]  net/nfc/nci/nci_spi.o
+00:10:14   CC      drivers/accessibility/braille/braille_console.o
+00:10:14   CC [M]  drivers/net/ethernet/myricom/myri10ge/myri10ge.o
+00:10:14   CC [M]  net/batman-adv/originator.o
+00:10:14   CC [M]  drivers/watchdog/via_wdt.o
+00:10:14   CC [M]  drivers/md/bcache/debug.o
+00:10:14   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/events.o
+00:10:14   CC [M]  drivers/net/ethernet/microchip/lan743x_ptp.o
+00:10:14   AR      drivers/accessibility/braille/built-in.a
+00:10:14   LD [M]  net/nfc/hci/hci.o
+00:10:14   CC [M]  drivers/accessibility/speakup/speakup_acntsa.o
+00:10:14   CC [M]  drivers/md/persistent-data/dm-array.o
+00:10:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dmacnv50.o
+00:10:14   CC [M]  drivers/net/wireless/realtek/rtlwifi/stats.o
+00:10:14   CC [M]  drivers/hwmon/ds1621.o
+00:10:14   CC [M]  drivers/media/i2c/lm3560.o
+00:10:14   CC [M]  drivers/watchdog/w83627hf_wdt.o
+00:10:15   CC [M]  drivers/net/ethernet/intel/ice/ice_lib.o
+00:10:15   CC [M]  net/nfc/netlink.o
+00:10:15   CC [M]  drivers/md/bcache/extents.o
+00:10:15   CC [M]  drivers/accessibility/speakup/speakup_apollo.o
+00:10:15   CC [M]  drivers/watchdog/w83877f_wdt.o
+00:10:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dmacgf119.o
+00:10:15   CC [M]  drivers/md/persistent-data/dm-bitset.o
+00:10:15   CC [M]  net/batman-adv/routing.o
+00:10:15   CC [M]  drivers/hwmon/emc1403.o
+00:10:15   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/wq.o
+00:10:15   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_ctcam.o
+00:10:15   LD [M]  drivers/net/ethernet/microchip/lan743x.o
+00:10:15   CC [M]  drivers/media/i2c/lm3646.o
+00:10:15   CC [M]  drivers/accessibility/speakup/speakup_audptr.o
+00:10:15   CC      drivers/gpu/drm/drm_simple_kms_helper.o
+00:10:15   CC [M]  drivers/watchdog/w83977f_wdt.o
+00:10:15   CC [M]  drivers/net/wireless/realtek/rtlwifi/pci.o
+00:10:16   CC [M]  drivers/md/bcache/io.o
+00:10:16   CC [M]  drivers/md/persistent-data/dm-block-manager.o
+00:10:16   CC [M]  drivers/accessibility/speakup/speakup_bns.o
+00:10:16   CC [M]  drivers/watchdog/machzwd.o
+00:10:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dmacgp102.o
+00:10:16   CC [M]  drivers/hwmon/emc6w201.o
+00:10:16   CC [M]  net/nfc/af_nfc.o
+00:10:16   AR      drivers/net/ethernet/myricom/built-in.a
+00:10:16   CC [M]  drivers/net/dummy.o
+00:10:16   CC [M]  drivers/net/eql.o
+00:10:16   CC [M]  drivers/media/i2c/ccs-pll.o
+00:10:16   CC [M]  net/batman-adv/send.o
+00:10:16   CC [M]  drivers/md/bcache/journal.o
+00:10:16   CC [M]  drivers/accessibility/speakup/speakup_dectlk.o
+00:10:16   CC [M]  drivers/watchdog/mei_wdt.o
+00:10:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/gid.o
+00:10:17   CC [M]  drivers/md/persistent-data/dm-space-map-common.o
+00:10:17   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_atcam.o
+00:10:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/dmacgv100.o
+00:10:17   CC [M]  drivers/net/ethernet/intel/ice/ice_txrx_lib.o
+00:10:17   CC [M]  drivers/hwmon/f71805f.o
+00:10:17   AR      drivers/accessibility/built-in.a
+00:10:17   CC [M]  net/nfc/rawsock.o
+00:10:17   CC [M]  drivers/net/ifb.o
+00:10:17   CC [M]  drivers/media/i2c/ak881x.o
+00:10:17   CC [M]  drivers/watchdog/nic7018_wdt.o
+00:10:17   CC [M]  drivers/accessibility/speakup/speakup_ltlk.o
+00:10:17   CC [M]  net/ife/ife.o
+00:10:17   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtlwifi.o
+00:10:17   LD [M]  drivers/net/wireless/realtek/rtlwifi/rtl_pci.o
+00:10:17   CC [M]  net/batman-adv/soft-interface.o
+00:10:17   AR      drivers/net/wireless/built-in.a
+00:10:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/custom_float.o
+00:10:17   CC [M]  drivers/watchdog/mlx_wdt.o
+00:10:17   CC [M]  drivers/accessibility/speakup/speakup_soft.o
+00:10:17   CC [M]  drivers/md/bcache/movinggc.o
+00:10:18   CC [M]  drivers/md/persistent-data/dm-space-map-disk.o
+00:10:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/basenv50.o
+00:10:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/devcom.o
+00:10:18   CC      drivers/md/md.o
+00:10:18   CC [M]  drivers/hwmon/f71882fg.o
+00:10:18   CC [M]  drivers/media/i2c/ir-kbd-i2c.o
+00:10:18   CC [M]  drivers/watchdog/xen_wdt.o
+00:10:18   CC [M]  drivers/watchdog/wdat_wdt.o
+00:10:18   CC [M]  drivers/net/ethernet/intel/ice/ice_txrx.o
+00:10:18   CC [M]  drivers/net/macsec.o
+00:10:18   CC [M]  net/nfc/llcp_core.o
+00:10:18   CC [M]  drivers/accessibility/speakup/speakup_spkout.o
+00:10:18   CC [M]  drivers/md/persistent-data/dm-space-map-metadata.o
+00:10:18   CC [M]  net/batman-adv/trace.o
+00:10:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/baseg84.o
+00:10:18   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_erp.o
+00:10:18   CC [M]  drivers/md/bcache/request.o
+00:10:18   CC [M]  drivers/watchdog/softdog.o
+00:10:18   AR      drivers/media/pci/ttpci/built-in.a
+00:10:18   CC [M]  drivers/media/pci/ttpci/budget-core.o
+00:10:19   CC [M]  drivers/accessibility/speakup/speakup_txprt.o
+00:10:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/pci_vsc.o
+00:10:19   AR      drivers/watchdog/built-in.a
+00:10:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/bw_fixed.o
+00:10:19   CC [M]  drivers/media/i2c/video-i2c.o
+00:10:19   CC [M]  drivers/md/persistent-data/dm-transaction-manager.o
+00:10:19   CC [M]  drivers/hwmon/f75375s.o
+00:10:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/dm.o
+00:10:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/basegf119.o
+00:10:19   CC [M]  net/batman-adv/tp_meter.o
+00:10:19   CC [M]  drivers/accessibility/speakup/buffers.o
+00:10:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/display_mode_lib.o
+00:10:20   CC [M]  drivers/media/pci/ttpci/budget.o
+00:10:20   CC [M]  net/nfc/llcp_commands.o
+00:10:20   CC [M]  drivers/accessibility/speakup/devsynth.o
+00:10:20   CC [M]  drivers/md/persistent-data/dm-btree.o
+00:10:20   CC [M]  drivers/net/ethernet/intel/ice/ice_fltr.o
+00:10:20   CC [M]  drivers/md/bcache/stats.o
+00:10:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/basegp102.o
+00:10:20   CC [M]  drivers/net/macvlan.o
+00:10:20   CC [M]  drivers/media/i2c/ml86v7667.o
+00:10:20   CC [M]  drivers/hwmon/fam15h_power.o
+00:10:20   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum1_acl_tcam.o
+00:10:20   CC [M]  net/batman-adv/translation-table.o
+00:10:20   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/fs_ttc.o
+00:10:20   CC [M]  drivers/accessibility/speakup/i18n.o
+00:10:20   CC [M]  drivers/media/pci/ttpci/budget-av.o
+00:10:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/display_rq_dlg_helpers.o
+00:10:20   CC [M]  drivers/md/bcache/super.o
+00:10:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/corenv50.o
+00:10:21   CC [M]  drivers/hwmon/fschmd.o
+00:10:21   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum2_acl_tcam.o
+00:10:21   CC [M]  net/nfc/llcp_sock.o
+00:10:21   CC [M]  drivers/accessibility/speakup/fakekey.o
+00:10:21   CC [M]  drivers/md/persistent-data/dm-btree-remove.o
+00:10:21   CC [M]  drivers/media/i2c/ov2659.o
+00:10:21   CC [M]  drivers/net/ethernet/intel/ice/ice_fdir.o
+00:10:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dml1_display_rq_dlg_calc.o
+00:10:21   CC      drivers/gpu/drm/drm_modeset_helper.o
+00:10:21   CC [M]  drivers/accessibility/speakup/main.o
+00:10:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coreg84.o
+00:10:21   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/diag/fs_tracepoint.o
+00:10:21   CC [M]  net/openvswitch/actions.o
+00:10:22   CC [M]  drivers/media/pci/ttpci/budget-ci.o
+00:10:22   CC [M]  drivers/md/persistent-data/dm-btree-spine.o
+00:10:22   CC [M]  drivers/media/i2c/tc358743.o
+00:10:22   CC [M]  drivers/hwmon/ftsteutates.o
+00:10:22   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_bloom_filter.o
+00:10:22   CC [M]  net/nfc/digital_core.o
+00:10:22   CC [M]  drivers/net/ethernet/intel/ice/ice_ethtool_fdir.o
+00:10:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coreg94.o
+00:10:22   CC [M]  net/vmw_vsock/af_vsock.o
+00:10:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coregf119.o
+00:10:22   CC [M]  drivers/md/bcache/sysfs.o
+00:10:22   LD [M]  drivers/md/persistent-data/dm-persistent-data.o
+00:10:22   CC [M]  net/vmw_vsock/af_vsock_tap.o
+00:10:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn20/dcn20_fpu.o
+00:10:22   CC [M]  net/batman-adv/tvlv.o
+00:10:23   CC [M]  drivers/hwmon/g760a.o
+00:10:23   CC [M]  net/nfc/digital_technology.o
+00:10:23   AR      drivers/media/pci/b2c2/built-in.a
+00:10:23   CC [M]  drivers/media/pci/b2c2/flexcop-dma.o
+00:10:23   CC [M]  net/vmw_vsock/vsock_addr.o
+00:10:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coregk104.o
+00:10:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/display_mode_vba.o
+00:10:23   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.o
+00:10:23   CC [M]  net/openvswitch/datapath.o
+00:10:23   CC [M]  drivers/accessibility/speakup/keyhelp.o
+00:10:23   CC      drivers/edac/edac_mc.o
+00:10:23   LD [M]  net/batman-adv/batman-adv.o
+00:10:23   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl.o
+00:10:23   AR      drivers/net/ethernet/natsemi/built-in.a
+00:10:23   CC [M]  drivers/net/ethernet/natsemi/natsemi.o
+00:10:23   CC [M]  drivers/media/i2c/hi556.o
+00:10:23   CC [M]  drivers/md/bcache/trace.o
+00:10:24   CC [M]  drivers/hwmon/g762.o
+00:10:24   CC [M]  drivers/net/ethernet/intel/ice/ice_flex_pipe.o
+00:10:24   CC [M]  net/nfc/digital_dep.o
+00:10:24   CC [M]  drivers/accessibility/speakup/kobjects.o
+00:10:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coregp102.o
+00:10:24   CC [M]  drivers/net/ethernet/intel/ice/ice_flow.o
+00:10:24   CC [M]  drivers/media/pci/b2c2/flexcop-pci.o
+00:10:24   CC [M]  net/vmw_vsock/diag.o
+00:10:24   CC      drivers/edac/edac_device.o
+00:10:24   CC [M]  drivers/media/i2c/imx208.o
+00:10:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn20/display_rq_dlg_calc_20.o
+00:10:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/coregv100.o
+00:10:24   CC [M]  drivers/hwmon/gl518sm.o
+00:10:25   CC [M]  drivers/accessibility/speakup/selection.o
+00:10:25   LD [M]  net/nfc/nfc.o
+00:10:25   LD [M]  net/nfc/nfc_digital.o
+00:10:25   CC      drivers/gpu/drm/drm_scdc_helper.o
+00:10:25   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/diag/crdump.o
+00:10:25   LD [M]  drivers/media/pci/b2c2/b2c2-flexcop-pci.o
+00:10:25   CC [M]  net/vmw_vsock/vmci_transport.o
+00:10:25   AR      drivers/media/pci/pluto2/built-in.a
+00:10:25   CC [M]  drivers/media/pci/pluto2/pluto2.o
+00:10:25   CC      drivers/edac/edac_mc_sysfs.o
+00:10:25   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_flow.o
+00:10:25   CC [M]  net/openvswitch/dp_notify.o
+00:10:25   CC [M]  drivers/md/bcache/util.o
+00:10:25   CC [M]  drivers/net/ethernet/natsemi/ns83820.o
+00:10:25   CC [M]  drivers/accessibility/speakup/spk_ttyio.o
+00:10:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlynv50.o
+00:10:25   CC [M]  net/openvswitch/flow.o
+00:10:25   CC [M]  drivers/media/i2c/imx214.o
+00:10:25   CC [M]  drivers/accessibility/speakup/synth.o
+00:10:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn20/display_mode_vba_20.o
+00:10:26   CC [M]  drivers/hwmon/gl520sm.o
+00:10:26   CC      drivers/edac/edac_module.o
+00:10:26   CC      drivers/opp/core.o
+00:10:26   CC [M]  drivers/md/bcache/writeback.o
+00:10:26   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/devlink.o
+00:10:26   AR      drivers/media/pci/dm1105/built-in.a
+00:10:26   CC [M]  drivers/media/pci/dm1105/dm1105.o
+00:10:26   AR      drivers/media/usb/ttusb-dec/built-in.a
+00:10:26   CC [M]  drivers/media/usb/ttusb-dec/ttusb_dec.o
+00:10:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlyg84.o
+00:10:26   CC [M]  drivers/accessibility/speakup/thread.o
+00:10:26   CC [M]  net/vmw_vsock/vmci_transport_notify.o
+00:10:26   CC      drivers/edac/edac_device_sysfs.o
+00:10:26   CC [M]  drivers/net/macvtap.o
+00:10:26   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_matchall.o
+00:10:26   CC [M]  drivers/net/ethernet/intel/ice/ice_idc.o
+00:10:26   CC [M]  drivers/media/i2c/imx219.o
+00:10:27   CC [M]  drivers/accessibility/speakup/varhandlers.o
+00:10:27   CC [M]  net/openvswitch/flow_netlink.o
+00:10:27   CC [M]  drivers/hwmon/i5500_temp.o
+00:10:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlygt200.o
+00:10:27   CC [M]  drivers/md/bcache/features.o
+00:10:27   CC      drivers/edac/wq.o
+00:10:27   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/diag/rsc_dump.o
+00:10:27   CC [M]  net/vmw_vsock/vmci_transport_notify_qstate.o
+00:10:27   CC [M]  drivers/media/i2c/imx258.o
+00:10:27   AR      drivers/media/pci/pt1/built-in.a
+00:10:27   CC [M]  drivers/media/pci/pt1/pt1.o
+00:10:27   CC [M]  drivers/hwmon/i5k_amb.o
+00:10:27   LD [M]  drivers/accessibility/speakup/speakup.o
+00:10:27   CC      drivers/opp/cpu.o
+00:10:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlygf119.o
+00:10:27   CC      drivers/edac/edac_pci.o
+00:10:27   CC [M]  drivers/media/usb/ttusb-dec/ttusbdecfe.o
+00:10:27   LD [M]  drivers/md/bcache/bcache.o
+00:10:27   CC [M]  net/nsh/nsh.o
+00:10:27   CC [M]  drivers/net/ethernet/intel/ice/ice_devlink.o
+00:10:28   CC      drivers/md/md-bitmap.o
+00:10:28   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_flower.o
+00:10:28   AR      drivers/media/mmc/siano/built-in.a
+00:10:28   CC [M]  drivers/media/mmc/siano/smssdio.o
+00:10:28   CC      drivers/opp/debugfs.o
+00:10:28   CC [M]  drivers/hwmon/ibmaem.o
+00:10:28   CC      drivers/edac/edac_pci_sysfs.o
+00:10:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlygk104.o
+00:10:28   CC [M]  net/vmw_vsock/virtio_transport.o
+00:10:28   CC [M]  drivers/media/i2c/imx274.o
+00:10:28   AR      drivers/opp/built-in.a
+00:10:28   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_cnt.o
+00:10:28   AR      drivers/media/mmc/built-in.a
+00:10:28   AR      drivers/media/usb/ttusb-budget/built-in.a
+00:10:28   CC [M]  drivers/media/usb/ttusb-budget/dvb-ttusb-budget.o
+00:10:28   AR      drivers/media/pci/pt3/built-in.a
+00:10:28   AR      drivers/media/pci/mantis/built-in.a
+00:10:28   CC [M]  drivers/media/pci/mantis/mantis_ioc.o
+00:10:28   CC      drivers/gpu/drm/drm_gem_atomic_helper.o
+00:10:28   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fw_reset.o
+00:10:28   LD [M]  drivers/media/pci/pt1/earth-pt1.o
+00:10:28   CC [M]  drivers/media/i2c/imx290.o
+00:10:29   CC [M]  drivers/hwmon/ibmpex.o
+00:10:29   CC      drivers/edac/ghes_edac.o
+00:10:29   CC [M]  drivers/net/ethernet/intel/ice/ice_fw_update.o
+00:10:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/ovlygp102.o
+00:10:29   CC [M]  drivers/media/pci/mantis/mantis_uart.o
+00:10:29   CC [M]  drivers/net/mii.o
+00:10:29   CC [M]  net/openvswitch/flow_table.o
+00:10:29   CC [M]  net/vmw_vsock/virtio_transport_common.o
+00:10:29   CC [M]  drivers/hwmon/ina209.o
+00:10:29   CC      drivers/md/md-autodetect.o
+00:10:29   AR      drivers/net/ethernet/neterion/built-in.a
+00:10:29   CC [M]  drivers/net/ethernet/neterion/s2io.o
+00:10:29   CC [M]  drivers/edac/mce_amd.o
+00:10:29   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_fid.o
+00:10:29   CC [M]  drivers/media/i2c/imx319.o
+00:10:30   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/qos.o
+00:10:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/wimmgv100.o
+00:10:30   CC      drivers/cpufreq/cpufreq.o
+00:10:30   AR      drivers/media/usb/dvb-usb/built-in.a
+00:10:30   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-firmware.o
+00:10:30   CC [M]  drivers/media/pci/mantis/mantis_dma.o
+00:10:30   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-init.o
+00:10:30   CC [M]  drivers/net/ethernet/intel/ice/ice_lag.o
+00:10:30   CC [M]  drivers/hwmon/ina2xx.o
+00:10:30   CC [M]  drivers/edac/i5100_edac.o
+00:10:30   CC      drivers/md/dm-init.o
+00:10:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/wndwgv100.o
+00:10:31   CC [M]  drivers/media/i2c/imx355.o
+00:10:31   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rqt.o
+00:10:31   CC [M]  drivers/net/ethernet/intel/ice/ice_ethtool.o
+00:10:31   CC [M]  net/vmw_vsock/hyperv_transport.o
+00:10:31   CC [M]  net/openvswitch/meter.o
+00:10:31   CC      drivers/md/dm-uevent.o
+00:10:31   CC [M]  drivers/edac/i5400_edac.o
+00:10:31   CC [M]  drivers/media/pci/mantis/mantis_pci.o
+00:10:31   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-urb.o
+00:10:31   CC [M]  drivers/hwmon/ina3221.o
+00:10:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/piocnv50.o
+00:10:31   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_ipip.o
+00:10:31   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tir.o
+00:10:31   CC      drivers/cpufreq/freq_table.o
+00:10:31   CC      drivers/md/dm-zone.o
+00:10:32   CC [M]  drivers/media/i2c/max9271.o
+00:10:32   CC [M]  drivers/edac/i7300_edac.o
+00:10:32   CC      drivers/cpufreq/cpufreq_stats.o
+00:10:32   AR      drivers/media/pci/ngene/built-in.a
+00:10:32   CC [M]  drivers/media/pci/ngene/ngene-core.o
+00:10:32   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-i2c.o
+00:10:32   CC [M]  net/vmw_vsock/vsock_loopback.o
+00:10:32   CC [M]  drivers/media/pci/mantis/mantis_i2c.o
+00:10:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/piocgf119.o
+00:10:32   CC [M]  net/openvswitch/openvswitch_trace.o
+00:10:32   CC [M]  drivers/hwmon/it87.o
+00:10:32   CC      drivers/cpufreq/cpufreq_performance.o
+00:10:32   CC [M]  drivers/edac/i7core_edac.o
+00:10:32   CC [M]  drivers/media/i2c/rdacm20.o
+00:10:32   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rss.o
+00:10:32   CC      drivers/md/dm-ima.o
+00:10:33   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_flex_actions.o
+00:10:33   CC      drivers/cpufreq/cpufreq_powersave.o
+00:10:33   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-dvb.o
+00:10:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/cursnv50.o
+00:10:33   LD [M]  net/vmw_vsock/vsock.o
+00:10:33   LD [M]  net/vmw_vsock/vsock_diag.o
+00:10:33   LD [M]  net/vmw_vsock/vmw_vsock_vmci_transport.o
+00:10:33   LD [M]  net/vmw_vsock/vmw_vsock_virtio_transport.o
+00:10:33   LD [M]  net/vmw_vsock/vmw_vsock_virtio_transport_common.o
+00:10:33   LD [M]  net/vmw_vsock/hv_sock.o
+00:10:33   CC [M]  drivers/media/pci/mantis/mantis_dvb.o
+00:10:33   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rx_res.o
+00:10:33   CC      drivers/gpu/drm/drm_gem_framebuffer_helper.o
+00:10:33   CC      drivers/cpufreq/cpufreq_userspace.o
+00:10:33   CC [M]  drivers/media/pci/ngene/ngene-i2c.o
+00:10:33   CC [M]  drivers/net/ethernet/intel/ice/ice_virtchnl_allowlist.o
+00:10:33   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn20/display_rq_dlg_calc_20v2.o
+00:10:33   CC [M]  net/openvswitch/vport.o
+00:10:33   CC [M]  drivers/media/i2c/st-mipid02.o
+00:10:33   CC      drivers/cpufreq/cpufreq_ondemand.o
+00:10:33   CC [M]  drivers/edac/sb_edac.o
+00:10:33   CC [M]  drivers/hwmon/jc42.o
+00:10:33   CC      drivers/md/dm.o
+00:10:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/cursgf119.o
+00:10:34   CC [M]  drivers/media/usb/dvb-usb/dvb-usb-remote.o
+00:10:34   CC      drivers/cpuidle/governors/menu.o
+00:10:34   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_acl_flex_keys.o
+00:10:34   CC [M]  drivers/media/pci/mantis/mantis_evm.o
+00:10:34   CC [M]  drivers/media/usb/dvb-usb/usb-urb.o
+00:10:34   CC [M]  drivers/media/pci/ngene/ngene-cards.o
+00:10:34   CC      drivers/cpufreq/cpufreq_conservative.o
+00:10:34   CC [M]  drivers/net/ethernet/intel/ice/ice_virtchnl_pf.o
+00:10:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn20/display_mode_vba_20v2.o
+00:10:34   CC      drivers/cpuidle/governors/haltpoll.o
+00:10:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/cursgp102.o
+00:10:34   LD [M]  drivers/media/i2c/msp3400.o
+00:10:34   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/channels.o
+00:10:34   CC [M]  drivers/hwmon/k8temp.o
+00:10:34   CC [M]  net/openvswitch/vport-internal_dev.o
+00:10:35   CC      drivers/cpufreq/cpufreq_governor.o
+00:10:35   AR      drivers/cpuidle/governors/built-in.a
+00:10:35   CC      drivers/cpuidle/cpuidle.o
+00:10:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/cursgv100.o
+00:10:35   CC [M]  drivers/hwmon/k10temp.o
+00:10:35   CC [M]  drivers/media/pci/mantis/mantis_hif.o
+00:10:35   CC [M]  drivers/edac/pnd2_edac.o
+00:10:35   CC [M]  drivers/media/usb/dvb-usb/vp7045.o
+00:10:35   AR      drivers/media/pci/ddbridge/built-in.a
+00:10:35   CC [M]  drivers/media/pci/ddbridge/ddbridge-main.o
+00:10:35   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp6000_pcie.o
+00:10:35   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum1_mr_tcam.o
+00:10:35   CC      drivers/md/dm-table.o
+00:10:35   CC      drivers/cpufreq/cpufreq_governor_attr_set.o
+00:10:35   CC [M]  drivers/media/pci/ngene/ngene-dvb.o
+00:10:35   CC [M]  drivers/hwmon/lineage-pem.o
+00:10:35   CC [M]  net/openvswitch/vport-netdev.o
+00:10:35   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_main.o
+00:10:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/oimmnv50.o
+00:10:36   CC      drivers/cpufreq/intel_pstate.o
+00:10:36   CC      drivers/cpuidle/driver.o
+00:10:36   CC [M]  drivers/media/pci/mantis/mantis_ca.o
+00:10:36   CC [M]  drivers/media/usb/dvb-usb/vp7045-fe.o
+00:10:36   CC [M]  drivers/media/pci/ddbridge/ddbridge-core.o
+00:10:36   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_cppcore.o
+00:10:36   CC [M]  drivers/edac/igen6_edac.o
+00:10:36   CC      drivers/cpuidle/governor.o
+00:10:36   CC [M]  drivers/hwmon/lm63.o
+00:10:36   LD [M]  drivers/media/pci/ngene/ngene.o
+00:10:36   CC      drivers/mmc/host/sdhci-pci-data.o
+00:10:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/oimmgf119.o
+00:10:36   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum2_mr_tcam.o
+00:10:36   CC [M]  net/openvswitch/conntrack.o
+00:10:36   CC [M]  drivers/net/ethernet/intel/ice/ice_sriov.o
+00:10:36   CC      drivers/cpuidle/sysfs.o
+00:10:36   CC      drivers/md/dm-target.o
+00:10:36   CC [M]  drivers/mmc/host/sdhci.o
+00:10:37   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_cpplib.o
+00:10:37   CC [M]  drivers/media/pci/mantis/mantis_pcmcia.o
+00:10:37   CC [M]  drivers/media/usb/dvb-usb/vp702x.o
+00:10:37   CC [M]  drivers/edac/e752x_edac.o
+00:10:37   CC      drivers/cpuidle/poll_state.o
+00:10:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/disp/oimmgp102.o
+00:10:37   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_hwinfo.o
+00:10:37   CC [M]  drivers/cpufreq/acpi-cpufreq.o
+00:10:37   CC [M]  drivers/hwmon/lm70.o
+00:10:37   CC      drivers/cpuidle/cpuidle-haltpoll.o
+00:10:37   CC      drivers/md/dm-linear.o
+00:10:37   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_mip.o
+00:10:38   CC [M]  drivers/net/ethernet/intel/ice/ice_virtchnl_fdir.o
+00:10:38   CC [M]  drivers/media/pci/mantis/mantis_input.o
+00:10:38   CC [M]  drivers/edac/i82975x_edac.o
+00:10:38   AR      drivers/cpuidle/built-in.a
+00:10:38   CC [M]  drivers/net/mdio.o
+00:10:38   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_mr_tcam.o
+00:10:38   CC [M]  drivers/media/usb/dvb-usb/vp702x-fe.o
+00:10:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/base.o
+00:10:38   CC [M]  drivers/hwmon/lm73.o
+00:10:38   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_mutex.o
+00:10:38   CC [M]  drivers/cpufreq/powernow-k8.o
+00:10:38   CC      drivers/md/dm-stripe.o
+00:10:38   CC [M]  net/openvswitch/vport-vxlan.o
+00:10:38   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_nffw.o
+00:10:38   CC [M]  drivers/media/pci/ddbridge/ddbridge-ci.o
+00:10:38   CC [M]  drivers/edac/i3000_edac.o
+00:10:38   CC [M]  drivers/mmc/core/core.o
+00:10:39   CC [M]  drivers/media/pci/mantis/mantis_cards.o
+00:10:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/nv04.o
+00:10:39   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_common.o
+00:10:39   CC [M]  drivers/hwmon/lm75.o
+00:10:39   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_nsp.o
+00:10:39   CC [M]  drivers/media/usb/dvb-usb/gp8psk.o
+00:10:39   CC [M]  drivers/cpufreq/pcc-cpufreq.o
+00:10:39   CC      drivers/md/dm-ioctl.o
+00:10:39   CC [M]  drivers/edac/i3200_edac.o
+00:10:39   CC [M]  drivers/mmc/host/sdhci-pci-core.o
+00:10:39   CC [M]  net/openvswitch/vport-geneve.o
+00:10:39   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_mr.o
+00:10:39   CC [M]  drivers/net/ethernet/intel/ice/ice_ptp.o
+00:10:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/nv50.o
+00:10:39   CC [M]  drivers/media/pci/ddbridge/ddbridge-hw.o
+00:10:39   CC [M]  drivers/cpufreq/speedstep-lib.o
+00:10:39   CC [M]  drivers/hwmon/lm77.o
+00:10:40   CC [M]  drivers/media/pci/mantis/mantis_vp1033.o
+00:10:40   CC [M]  drivers/edac/ie31200_edac.o
+00:10:40   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_nsp_cmds.o
+00:10:40   CC [M]  drivers/media/usb/dvb-usb/dtt200u.o
+00:10:40   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_fs.o
+00:10:40   CC [M]  drivers/cpufreq/p4-clockmod.o
+00:10:40   CC [M]  net/openvswitch/vport-gre.o
+00:10:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/gf100.o
+00:10:40   CC [M]  drivers/mmc/core/bus.o
+00:10:40   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_nsp_eth.o
+00:10:40   CC [M]  drivers/edac/x38_edac.o
+00:10:40   CC [M]  drivers/mmc/host/sdhci-pci-o2micro.o
+00:10:40   CC [M]  drivers/media/pci/ddbridge/ddbridge-i2c.o
+00:10:40   CC [M]  drivers/hwmon/lm78.o
+00:10:40   CC [M]  drivers/cpufreq/amd_freq_sensitivity.o
+00:10:40   CC      drivers/md/dm-io.o
+00:10:40   CC [M]  drivers/media/pci/mantis/mantis_vp1034.o
+00:10:41   CC [M]  drivers/media/usb/dvb-usb/dtt200u-fe.o
+00:10:41   CC [M]  drivers/net/ethernet/intel/ice/ice_ptp_hw.o
+00:10:41   CC [M]  drivers/mmc/core/host.o
+00:10:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/gf119.o
+00:10:41   CC [M]  drivers/edac/amd64_edac.o
+00:10:41   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_qdisc.o
+00:10:41   LD [M]  net/openvswitch/openvswitch.o
+00:10:41   AR      drivers/cpufreq/built-in.a
+00:10:41   CC [M]  net/hsr/hsr_main.o
+00:10:41   AR      drivers/net/ethernet/netronome/built-in.a
+00:10:41   CC [M]  drivers/edac/skx_base.o
+00:10:41   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_resource.o
+00:10:41   CC [M]  drivers/mmc/host/sdhci-pci-arasan.o
+00:10:41   CC [M]  drivers/hwmon/lm80.o
+00:10:41   CC      drivers/md/dm-kcopyd.o
+00:10:41   CC [M]  drivers/media/pci/ddbridge/ddbridge-max.o
+00:10:41   CC [M]  drivers/media/pci/mantis/mantis_vp1041.o
+00:10:41   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_rtsym.o
+00:10:41   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.o
+00:10:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/gv100.o
+00:10:42   CC [M]  drivers/media/usb/dvb-usb/dibusb-common.o
+00:10:42   CC [M]  drivers/mmc/core/mmc.o
+00:10:42   CC [M]  net/hsr/hsr_framereg.o
+00:10:42   CC [M]  drivers/mmc/host/sdhci-pci-dwc-mshc.o
+00:10:42   AR      drivers/media/firewire/built-in.a
+00:10:42   CC [M]  drivers/media/firewire/firedtv-avc.o
+00:10:42   CC [M]  drivers/net/ethernet/intel/ice/ice_dcb.o
+00:10:42   CC [M]  drivers/net/ethernet/netronome/nfp/nfpcore/nfp_target.o
+00:10:42   CC [M]  drivers/hwmon/lm83.o
+00:10:42   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn21/display_rq_dlg_calc_21.o
+00:10:42   CC [M]  drivers/net/ethernet/netronome/nfp/ccm.o
+00:10:42   CC [M]  drivers/media/pci/mantis/mantis_vp2033.o
+00:10:42   CC      drivers/md/dm-sysfs.o
+00:10:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/user.o
+00:10:42   CC [M]  drivers/mmc/host/sdhci-pci-gli.o
+00:10:42   CC [M]  drivers/media/pci/ddbridge/ddbridge-mci.o
+00:10:43   CC [M]  drivers/edac/skx_common.o
+00:10:43   CC [M]  drivers/media/usb/dvb-usb/dibusb-mc-common.o
+00:10:43   CC [M]  net/hsr/hsr_device.o
+00:10:43   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_span.o
+00:10:43   CC [M]  drivers/mmc/core/mmc_ops.o
+00:10:43   CC [M]  drivers/hwmon/lm85.o
+00:10:43   CC      drivers/md/dm-stats.o
+00:10:43   CC [M]  drivers/media/firewire/firedtv-ci.o
+00:10:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/usernv04.o
+00:10:43   CC [M]  drivers/net/ethernet/intel/ice/ice_dcb_nl.o
+00:10:43   CC [M]  drivers/media/pci/mantis/mantis_vp2040.o
+00:10:43   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn21/display_mode_vba_21.o
+00:10:43   CC [M]  drivers/net/ethernet/netronome/nfp/ccm_mbox.o
+00:10:43   CC [M]  drivers/mmc/host/sdhci-acpi.o
+00:10:43   CC [M]  drivers/media/pci/ddbridge/ddbridge-sx8.o
+00:10:43   CC [M]  drivers/edac/i10nm_base.o
+00:10:43   CC [M]  net/hsr/hsr_netlink.o
+00:10:43   CC [M]  drivers/media/usb/dvb-usb/a800.o
+00:10:44   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_tx.o
+00:10:44   CC [M]  drivers/mmc/core/sd.o
+00:10:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/usernv50.o
+00:10:44   CC [M]  drivers/media/firewire/firedtv-dvb.o
+00:10:44   CC [M]  drivers/media/pci/mantis/mantis_vp3030.o
+00:10:44   LD [M]  drivers/edac/skx_edac_common.o
+00:10:44   LD [M]  drivers/edac/edac_mce_amd.o
+00:10:44   LD [M]  drivers/edac/skx_edac.o
+00:10:44   LD [M]  drivers/edac/i10nm_edac.o
+00:10:44   AR      drivers/edac/built-in.a
+00:10:44   CC [M]  drivers/hwmon/lm87.o
+00:10:44   CC      drivers/md/dm-rq.o
+00:10:44   AR      drivers/media/usb/dvb-usb-v2/built-in.a
+00:10:44   CC [M]  net/hsr/hsr_slave.o
+00:10:44   CC [M]  drivers/media/usb/dvb-usb-v2/dvb_usb_core.o
+00:10:44   CC [M]  drivers/mmc/host/wbsd.o
+00:10:44   CC [M]  drivers/net/ethernet/netronome/nfp/devlink_param.o
+00:10:44   CC [M]  drivers/media/pci/ddbridge/ddbridge-dummy-fe.o
+00:10:44   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dibusb-common.o
+00:10:44   CC [M]  drivers/media/usb/dvb-usb/dibusb-mb.o
+00:10:44   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_nve.o
+00:10:44   CC [M]  drivers/net/ethernet/intel/ice/ice_dcb_lib.o
+00:10:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/usergf100.o
+00:10:45   CC [M]  drivers/media/firewire/firedtv-fe.o
+00:10:45   CC [M]  drivers/mmc/core/sd_ops.o
+00:10:45   CC [M]  drivers/media/pci/mantis/hopper_cards.o
+00:10:45   CC [M]  net/hsr/hsr_forward.o
+00:10:45   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_asm.o
+00:10:45   LD [M]  drivers/media/pci/ddbridge/ddbridge.o
+00:10:45   CC      drivers/md/dm-builtin.o
+00:10:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/usergf119.o
+00:10:45   CC [M]  drivers/hwmon/lm90.o
+00:10:45   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_app.o
+00:10:45   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_rx.o
+00:10:45   CC [M]  drivers/media/usb/dvb-usb/dibusb-mc.o
+00:10:45   CC [M]  drivers/mmc/host/alcor.o
+00:10:45   CC [M]  drivers/net/netconsole.o
+00:10:46   CC [M]  drivers/media/usb/dvb-usb-v2/dvb_usb_urb.o
+00:10:46   CC [M]  drivers/mmc/core/sdio.o
+00:10:46   CC [M]  drivers/media/firewire/firedtv-fw.o
+00:10:46   CC [M]  drivers/net/ethernet/intel/ice/ice_arfs.o
+00:10:46   CC      drivers/md/dm-bufio.o
+00:10:46   CC [M]  net/hsr/hsr_debugfs.o
+00:10:46   CC [M]  drivers/media/pci/mantis/hopper_vp3028.o
+00:10:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/dma/usergv100.o
+00:10:46   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_nve_vxlan.o
+00:10:46   CC [M]  drivers/media/usb/dvb-usb/nova-t-usb2.o
+00:10:46   CC [M]  drivers/mmc/host/tifm_sd.o
+00:10:46   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_app_nic.o
+00:10:46   CC [M]  drivers/hwmon/lm92.o
+00:10:46   CC [M]  drivers/media/usb/dvb-usb-v2/usb_urb.o
+00:10:47   CC [M]  net/qrtr/af_qrtr.o
+00:10:47   LD [M]  net/hsr/hsr.o
+00:10:47   CC [M]  drivers/mmc/core/sdio_ops.o
+00:10:47   CC      drivers/gpu/drm/drm_atomic_state_helper.o
+00:10:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/base.o
+00:10:47   CC [M]  drivers/media/firewire/firedtv-rc.o
+00:10:47   LD [M]  drivers/media/pci/mantis/mantis_core.o
+00:10:47   LD [M]  drivers/media/pci/mantis/mantis.o
+00:10:47   LD [M]  drivers/media/pci/mantis/hopper.o
+00:10:47   AR      drivers/media/pci/saa7146/built-in.a
+00:10:47   CC [M]  drivers/media/pci/saa7146/mxb.o
+00:10:47   CC [M]  drivers/net/ethernet/intel/ice/ice_xsk.o
+00:10:47   CC      drivers/md/dm-snap.o
+00:10:47   CC [M]  drivers/media/usb/dvb-usb/umt-010.o
+00:10:47   CC [M]  drivers/mmc/host/sdricoh_cs.o
+00:10:47   CC [M]  drivers/mmc/core/sdio_bus.o
+00:10:47   CC [M]  drivers/hwmon/lm93.o
+00:10:47   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_dim.o
+00:10:47   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_dpipe.o
+00:10:47   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_devlink.o
+00:10:48   AR      drivers/media/spi/built-in.a
+00:10:48   CC [M]  drivers/media/spi/gs1662.o
+00:10:48   CC [M]  drivers/media/usb/dvb-usb-v2/af9015.o
+00:10:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/nv04.o
+00:10:48   LD [M]  drivers/media/firewire/firedtv.o
+00:10:48   CC [M]  drivers/media/usb/dvb-usb/m920x.o
+00:10:48   CC [M]  net/qrtr/ns.o
+00:10:48   CC [M]  drivers/mmc/host/cb710-mmc.o
+00:10:48   CC [M]  drivers/mmc/core/sdio_cis.o
+00:10:48   CC [M]  drivers/media/pci/saa7146/hexium_orion.o
+00:10:48   CC [M]  drivers/media/pci/saa7146/hexium_gemini.o
+00:10:48   LD [M]  drivers/net/ethernet/intel/ice/ice.o
+00:10:48   AR      drivers/media/usb/siano/built-in.a
+00:10:48   CC [M]  drivers/media/usb/siano/smsusb.o
+00:10:48   CC [M]  drivers/media/spi/cxd2880-spi.o
+00:10:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/nv10.o
+00:10:49   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_txrx.o
+00:10:49   CC      drivers/md/dm-exception-store.o
+00:10:49   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_hwmon.o
+00:10:49   CC [M]  drivers/mmc/core/sdio_io.o
+00:10:49   CC [M]  drivers/hwmon/lm95234.o
+00:10:49   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_trap.o
+00:10:49   CC [M]  drivers/media/usb/dvb-usb/digitv.o
+00:10:49   CC [M]  drivers/mmc/host/via-sdmmc.o
+00:10:49   CC [M]  drivers/media/usb/dvb-usb-v2/af9035.o
+00:10:49   AR      drivers/net/ethernet/nvidia/built-in.a
+00:10:49   CC [M]  drivers/net/ethernet/nvidia/forcedeth.o
+00:10:49   AR      drivers/media/pci/smipcie/built-in.a
+00:10:49   CC [M]  drivers/media/pci/smipcie/smipcie-main.o
+00:10:49   CC [M]  drivers/mmc/core/sdio_irq.o
+00:10:49   CC [M]  net/qrtr/mhi.o
+00:10:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/nv17.o
+00:10:49   CC      drivers/md/dm-snap-transient.o
+00:10:49   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_main.o
+00:10:49   CC [M]  drivers/media/pci/smipcie/smipcie-ir.o
+00:10:50   CC      drivers/gpu/drm/drm_damage_helper.o
+00:10:50   CC [M]  drivers/mmc/core/slot-gpio.o
+00:10:50   CC [M]  drivers/hwmon/lm95241.o
+00:10:50   CC [M]  drivers/mmc/host/vub300.o
+00:10:50   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/xdp.o
+00:10:50   CC [M]  drivers/media/usb/dvb-usb/cxusb.o
+00:10:50   CC      drivers/md/dm-snap-persistent.o
+00:10:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/nv40.o
+00:10:50   LD [M]  net/qrtr/qrtr.o
+00:10:50   LD [M]  net/qrtr/qrtr-mhi.o
+00:10:50   CC      net/devres.o
+00:10:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn30/display_mode_vba_30.o
+00:10:50   CC [M]  drivers/mmc/core/regulator.o
+00:10:50   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_ethtool.o
+00:10:50   LD [M]  drivers/media/pci/smipcie/smipcie.o
+00:10:50   AR      drivers/media/pci/netup_unidvb/built-in.a
+00:10:50   CC [M]  drivers/media/pci/netup_unidvb/netup_unidvb_core.o
+00:10:51   CC [M]  drivers/media/usb/dvb-usb-v2/anysee.o
+00:10:51   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_common.o
+00:10:51   CC [M]  drivers/hwmon/lm95245.o
+00:10:51   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_stats.o
+00:10:51   CC      drivers/leds/trigger/ledtrig-disk.o
+00:10:51   CC      drivers/md/dm-raid1.o
+00:10:51   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/nv50.o
+00:10:51   CC      net/socket.o
+00:10:51   CC [M]  drivers/mmc/core/debugfs.o
+00:10:51   CC      drivers/leds/trigger/ledtrig-mtd.o
+00:10:51   CC [M]  drivers/mmc/host/ushc.o
+00:10:51   CC [M]  drivers/media/usb/dvb-usb/cxusb-analog.o
+00:10:51   CC [M]  drivers/media/test-drivers/vimc/vimc-core.o
+00:10:51   CC      drivers/leds/trigger/ledtrig-panic.o
+00:10:51   CC [M]  drivers/hwmon/ltc2945.o
+00:10:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/g84.o
+00:10:52   CC [M]  drivers/mmc/core/block.o
+00:10:52   CC [M]  drivers/media/pci/netup_unidvb/netup_unidvb_i2c.o
+00:10:52   CC [M]  drivers/leds/trigger/ledtrig-timer.o
+00:10:52   CC [M]  drivers/media/test-drivers/vimc/vimc-common.o
+00:10:52   CC [M]  drivers/media/usb/dvb-usb-v2/au6610.o
+00:10:52   CC      drivers/md/dm-log.o
+00:10:52   CC [M]  drivers/mmc/host/toshsd.o
+00:10:52   CC [M]  drivers/leds/trigger/ledtrig-oneshot.o
+00:10:52   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_policer.o
+00:10:52   CC [M]  drivers/hwmon/ltc2947-core.o
+00:10:52   CC [M]  drivers/net/tun.o
+00:10:52   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gf100.o
+00:10:53   CC [M]  drivers/leds/trigger/ledtrig-heartbeat.o
+00:10:53   CC [M]  drivers/media/test-drivers/vimc/vimc-streamer.o
+00:10:53   CC      drivers/md/dm-region-hash.o
+00:10:53   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_selftest.o
+00:10:53   CC [M]  drivers/media/pci/netup_unidvb/netup_unidvb_ci.o
+00:10:53   CC [M]  drivers/media/usb/dvb-usb-v2/az6007.o
+00:10:53   CC [M]  drivers/mmc/host/rtsx_pci_sdmmc.o
+00:10:53   CC [M]  drivers/hwmon/ltc2947-i2c.o
+00:10:53   CC [M]  drivers/leds/trigger/ledtrig-backlight.o
+00:10:53   CC      net/compat.o
+00:10:53   CC [M]  drivers/media/usb/dvb-usb/ttusb2.o
+00:10:53   CC [M]  drivers/mmc/core/queue.o
+00:10:53   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_ctrl.o
+00:10:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gk104.o
+00:10:53   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_dcb.o
+00:10:53   CC [M]  drivers/media/test-drivers/vimc/vimc-capture.o
+00:10:54   CC [M]  drivers/hwmon/ltc2947-spi.o
+00:10:54   CC      drivers/md/dm-zero.o
+00:10:54   CC [M]  drivers/leds/trigger/ledtrig-gpio.o
+00:10:54   CC [M]  drivers/media/pci/netup_unidvb/netup_unidvb_spi.o
+00:10:54   CC [M]  drivers/mmc/host/rtsx_usb_sdmmc.o
+00:10:54   CC [M]  drivers/media/usb/dvb-usb-v2/ce6230.o
+00:10:54   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/port.o
+00:10:54   CC [M]  drivers/mmc/core/sdio_uart.o
+00:10:54   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_debugdump.o
+00:10:54   CC [M]  drivers/media/usb/dvb-usb/dib0700_core.o
+00:10:54   CC      net/sysctl_net.o
+00:10:54   CC [M]  drivers/hwmon/ltc2990.o
+00:10:54   CC [M]  drivers/leds/trigger/ledtrig-activity.o
+00:10:54   CC [M]  drivers/md/md-linear.o
+00:10:54   CC [M]  drivers/media/test-drivers/vimc/vimc-debayer.o
+00:10:55   CC [M]  drivers/leds/trigger/ledtrig-default-on.o
+00:10:55   LD [M]  drivers/media/pci/netup_unidvb/netup-unidvb.o
+00:10:55   AR      drivers/media/pci/intel/ipu3/built-in.a
+00:10:55   CC [M]  drivers/media/pci/intel/ipu3/ipu3-cio2-main.o
+00:10:55   CC [M]  drivers/media/usb/dvb-usb-v2/ec168.o
+00:10:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gk110.o
+00:10:55   CC [M]  drivers/mmc/host/sdhci-pltfm.o
+00:10:55   CC [M]  drivers/net/ethernet/mellanox/mlxsw/spectrum_ptp.o
+00:10:55   LD [M]  drivers/mmc/core/mmc_core.o
+00:10:55   CC [M]  drivers/hwmon/ltc4151.o
+00:10:55   LD [M]  drivers/mmc/core/mmc_block.o
+00:10:55   CC [M]  drivers/media/dvb-frontends/drx39xyj/drxj.o
+00:10:55   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_ethtool.o
+00:10:55   CC [M]  drivers/leds/trigger/ledtrig-transient.o
+00:10:55   CC [M]  drivers/net/ethernet/mellanox/mlxsw/minimal.o
+00:10:55   CC [M]  drivers/md/raid0.o
+00:10:55   AR      net/built-in.a
+00:10:55   CC [M]  drivers/media/usb/dvb-usb-v2/lmedm04.o
+00:10:55   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/monitor_stats.o
+00:10:55   CC [M]  drivers/media/usb/dvb-usb/dib0700_devices.o
+00:10:55   CC [M]  drivers/media/test-drivers/vimc/vimc-scaler.o
+00:10:55   CC [M]  drivers/leds/trigger/ledtrig-camera.o
+00:10:56   CC [M]  drivers/mmc/host/cqhci-core.o
+00:10:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gk208.o
+00:10:56   CC [M]  drivers/hwmon/ltc4215.o
+00:10:56   CC [M]  drivers/leds/trigger/ledtrig-netdev.o
+00:10:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn30/display_rq_dlg_calc_30.o
+00:10:56   CC [M]  drivers/md/raid1.o
+00:10:56   LD [M]  drivers/media/pci/intel/ipu3/ipu3-cio2.o
+00:10:56   AR      drivers/firmware/arm_ffa/built-in.a
+00:10:56   AR      drivers/media/pci/intel/built-in.a
+00:10:56   AR      drivers/firmware/arm_scmi/built-in.a
+00:10:56   CC [M]  drivers/media/pci/ivtv/ivtv-routing.o
+00:10:56   AR      drivers/firmware/broadcom/built-in.a
+00:10:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gk20a.o
+00:10:56   AR      drivers/firmware/meson/built-in.a
+00:10:56   CC [M]  drivers/media/test-drivers/vimc/vimc-sensor.o
+00:10:56   CC [M]  drivers/firmware/efi/test/efi_test.o
+00:10:56   CC [M]  drivers/hwmon/ltc4222.o
+00:10:57   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/health.o
+00:10:57   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_main.o
+00:10:57   CC [M]  drivers/mmc/host/mmc_hsq.o
+00:10:57   CC [M]  drivers/media/usb/dvb-usb-v2/gl861.o
+00:10:57   CC [M]  drivers/leds/trigger/ledtrig-pattern.o
+00:10:57   LD [M]  drivers/net/ethernet/mellanox/mlxsw/mlxsw_core.o
+00:10:57   LD [M]  drivers/net/ethernet/mellanox/mlxsw/mlxsw_pci.o
+00:10:57   LD [M]  drivers/net/ethernet/mellanox/mlxsw/mlxsw_i2c.o
+00:10:57   LD [M]  drivers/net/ethernet/mellanox/mlxsw/mlxsw_spectrum.o
+00:10:57   LD [M]  drivers/net/ethernet/mellanox/mlxsw/mlxsw_minimal.o
+00:10:57   AR      drivers/leds/blink/built-in.a
+00:10:57   AR      drivers/net/ethernet/oki-semi/built-in.a
+00:10:57   CC [M]  drivers/net/tap.o
+00:10:57   CC [M]  drivers/media/usb/dvb-usb/opera1.o
+00:10:57   CC [M]  drivers/leds/trigger/ledtrig-audio.o
+00:10:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gm107.o
+00:10:57   CC [M]  drivers/leds/trigger/ledtrig-tty.o
+00:10:57   CC [M]  drivers/media/pci/ivtv/ivtv-cards.o
+00:10:57   CC [M]  drivers/mmc/host/sdhci-xenon.o
+00:10:57   CC [M]  drivers/hwmon/ltc4245.o
+00:10:57   CC      drivers/firmware/efi/libstub/efi-stub-helper.o
+00:10:57 In file included from ./include/uapi/linux/posix_types.h:5,
+00:10:57                  from ./include/uapi/linux/types.h:14,
+00:10:57                  from ./include/linux/types.h:6,
+00:10:57                  from ./include/linux/kasan-checks.h:5,
+00:10:57                  from ./include/asm-generic/rwonce.h:26,
+00:10:57                  from ./arch/x86/include/generated/asm/rwonce.h:1,
+00:10:57                  from ./include/linux/compiler.h:275,
+00:10:57                  from ./include/linux/ctype.h:5,
+00:10:57                  from drivers/firmware/efi/libstub/efi-stub-helper.c:12:
+00:10:57 ./include/linux/stddef.h:11:9: error: cannot use keyword ‘false’ as enumeration constant
+00:10:57    11 |         false   = 0,
+00:10:57       |         ^~~~~
+00:10:57 ./include/linux/stddef.h:11:9: note: ‘false’ is a keyword with ‘-std=c23’ onwards
+00:10:57 ./include/linux/types.h:30:33: error: ‘bool’ cannot be defined via ‘typedef’
+00:10:57    30 | typedef _Bool                   bool;
+00:10:57       |                                 ^~~~
+00:10:57 ./include/linux/types.h:30:33: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
+00:10:57 ./include/linux/types.h:30:1: warning: useless type name in empty declaration
+00:10:57    30 | typedef _Bool                   bool;
+00:10:57       | ^~~~~~~
+00:10:57   LD [M]  drivers/media/test-drivers/vimc/vimc.o
+00:10:57   CC [M]  drivers/media/test-drivers/vivid/vivid-core.o
+00:10:57   CC [M]  drivers/media/mc/mc-device.o
+00:10:58   AR      drivers/leds/trigger/built-in.a
+00:10:58   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf.o
+00:10:58   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.o
+00:10:58   CC [M]  drivers/leds/flash/leds-as3645a.o
+00:10:58   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_repr.o
+00:10:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gm200.o
+00:10:58 make[6]: *** [scripts/Makefile.build:289: drivers/firmware/efi/libstub/efi-stub-helper.o] Error 1
+00:10:58 make[5]: *** [scripts/Makefile.build:552: drivers/firmware/efi/libstub] Error 2
+00:10:58 make[4]: *** [scripts/Makefile.build:552: drivers/firmware/efi] Error 2
+00:10:58 make[3]: *** [scripts/Makefile.build:552: drivers/firmware] Error 2
+00:10:58 make[3]: *** Waiting for unfinished jobs....
+00:10:58   CC [M]  drivers/leds/flash/leds-lm3601x.o
+00:10:58   CC [M]  drivers/hwmon/ltc4260.o
+00:10:58   CC [M]  drivers/media/pci/ivtv/ivtv-controls.o
+00:10:58   CC [M]  drivers/media/usb/dvb-usb/af9005.o
+00:10:58   CC [M]  drivers/mmc/host/sdhci-xenon-phy.o
+00:10:58   LD [M]  drivers/media/dvb-frontends/drx39xyj/drx39xyj.o
+00:10:58   CC [M]  drivers/media/dvb-frontends/dvb-pll.o
+00:10:58   CC [M]  drivers/media/mc/mc-devnode.o
+00:10:58   LD [M]  drivers/mmc/host/sdhci-pci.o
+00:10:58   AR      drivers/media/usb/b2c2/built-in.a
+00:10:58   CC [M]  drivers/media/usb/b2c2/flexcop-usb.o
+00:10:58   CC [M]  drivers/md/raid10.o
+00:10:58   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/reporter_rx.o
+00:10:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gm20b.o
+00:10:59   CC      drivers/leds/led-core.o
+00:10:59   CC [M]  drivers/hwmon/ltc4261.o
+00:10:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn31/display_mode_vba_31.o
+00:10:59   LD [M]  drivers/mmc/host/cqhci.o
+00:10:59   LD [M]  drivers/mmc/host/sdhci-xenon-driver.o
+00:10:59   AR      drivers/mmc/host/built-in.a
+00:10:59   CC [M]  drivers/media/test-drivers/vivid/vivid-ctrls.o
+00:10:59   CC [M]  drivers/media/mc/mc-entity.o
+00:10:59   CC [M]  drivers/hwmon/max1111.o
+00:10:59   CC [M]  drivers/media/pci/ivtv/ivtv-driver.o
+00:10:59   AR      drivers/mmc/built-in.a
+00:10:59   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_net_sriov.o
+00:10:59   CC [M]  drivers/media/pci/cx18/cx18-driver.o
+00:10:59   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf-phy.o
+00:10:59   CC [M]  drivers/media/dvb-frontends/stv0299.o
+00:10:59   CC      drivers/leds/led-class.o
+00:10:59   CC [M]  drivers/media/usb/dvb-usb/af9005-fe.o
+00:10:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gp100.o
+00:10:59   LD [M]  drivers/media/usb/b2c2/b2c2-flexcop-usb.o
+00:11:00   CC [M]  drivers/media/test-drivers/vivid/vivid-vid-common.o
+00:11:00   CC [M]  drivers/media/pci/ivtv/ivtv-fileops.o
+00:11:00   CC [M]  drivers/hwmon/max16065.o
+00:11:00   CC [M]  drivers/media/mc/mc-request.o
+00:11:00   CC      drivers/leds/led-triggers.o
+00:11:00   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/params.o
+00:11:00   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf-i2c.o
+00:11:00   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_netvf_main.o
+00:11:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gp10b.o
+00:11:00   CC [M]  drivers/media/dvb-frontends/stb0899_drv.o
+00:11:00   CC [M]  drivers/media/v4l2-core/v4l2-dev.o
+00:11:00   AR      drivers/media/usb/zr364xx/built-in.a
+00:11:00   CC [M]  drivers/md/raid5.o
+00:11:00   CC [M]  drivers/media/mc/mc-dev-allocator.o
+00:11:00   CC [M]  drivers/leds/led-class-flash.o
+00:11:00   CC [M]  drivers/hwmon/max1619.o
+00:11:00   CC [M]  drivers/media/pci/cx18/cx18-cards.o
+00:11:00   CC [M]  drivers/media/usb/dvb-usb/af9005-remote.o
+00:11:01   CC [M]  drivers/media/test-drivers/vivid/vivid-vbi-gen.o
+00:11:01   LD [M]  drivers/media/mc/mc.o
+00:11:01   CC [M]  drivers/leds/led-class-multicolor.o
+00:11:01   AR      drivers/net/ethernet/packetengines/built-in.a
+00:11:01   CC [M]  drivers/net/ethernet/packetengines/hamachi.o
+00:11:01   CC [M]  drivers/media/pci/ivtv/ivtv-firmware.o
+00:11:01   CC [M]  drivers/media/test-drivers/vivid/vivid-vid-cap.o
+00:11:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gv100.o
+00:11:01   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_port.o
+00:11:01   CC [M]  drivers/hwmon/max1668.o
+00:11:01   CC [M]  drivers/leds/leds-apu.o
+00:11:01   CC [M]  drivers/media/pci/ivtv/ivtv-gpio.o
+00:11:01   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf-gpio.o
+00:11:01   CC [M]  drivers/media/pci/cx18/cx18-i2c.o
+00:11:01   CC [M]  drivers/media/v4l2-core/v4l2-ioctl.o
+00:11:01   CC [M]  drivers/media/usb/dvb-usb/pctv452e.o
+00:11:01   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/xsk/pool.o
+00:11:01   CC [M]  drivers/media/dvb-frontends/stb0899_algo.o
+00:11:02   CC [M]  drivers/leds/leds-blinkm.o
+00:11:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/tu102.o
+00:11:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dcn31/display_rq_dlg_calc_31.o
+00:11:02   CC [M]  drivers/hwmon/max197.o
+00:11:02   CC [M]  drivers/net/ethernet/packetengines/yellowfin.o
+00:11:02   CC [M]  drivers/net/ethernet/netronome/nfp/nfp_shared_buf.o
+00:11:02   CC [M]  drivers/media/pci/ivtv/ivtv-i2c.o
+00:11:02   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf-demod.o
+00:11:02   CC [M]  drivers/media/pci/cx18/cx18-firmware.o
+00:11:02   CC [M]  drivers/hwmon/max31722.o
+00:11:02   CC [M]  drivers/media/usb/dvb-usb/dw2102.o
+00:11:03   CC [M]  drivers/leds/leds-gpio.o
+00:11:03   CC [M]  drivers/media/dvb-frontends/stb6100.o
+00:11:03   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/xsk/setup.o
+00:11:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/ga102.o
+00:11:03   CC [M]  drivers/media/test-drivers/vivid/vivid-vid-out.o
+00:11:03   CC [M]  drivers/hwmon/max6639.o
+00:11:03   CC [M]  drivers/leds/leds-ss4200.o
+00:11:03   CC [M]  drivers/md/raid5-cache.o
+00:11:03   CC [M]  drivers/net/ethernet/netronome/nfp/nic/main.o
+00:11:03   CC      drivers/gpu/drm/drm_format_helper.o
+00:11:03   CC [M]  drivers/media/pci/ivtv/ivtv-ioctl.o
+00:11:03   CC [M]  drivers/media/v4l2-core/v4l2-device.o
+00:11:03   CC [M]  drivers/media/dvb-frontends/cx22700.o
+00:11:03   CC [M]  drivers/media/usb/dvb-usb-v2/mxl111sf-tuner.o
+00:11:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/chan.o
+00:11:04   CC [M]  drivers/media/pci/cx18/cx18-gpio.o
+00:11:04   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/dsc/rc_calc_fpu.o
+00:11:04   CC [M]  drivers/leds/leds-lm3530.o
+00:11:04   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/xsk/rx.o
+00:11:04   CC [M]  drivers/hwmon/max6650.o
+00:11:04   CC [M]  drivers/media/usb/dvb-usb/dtv5100.o
+00:11:04   CC [M]  drivers/net/ethernet/netronome/nfp/crypto/tls.o
+00:11:04   CC [M]  drivers/media/dvb-frontends/cx24110.o
+00:11:04   CC [M]  drivers/media/v4l2-core/v4l2-fh.o
+00:11:04   CC [M]  drivers/media/test-drivers/vivid/vivid-kthread-cap.o
+00:11:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/channv50.o
+00:11:04   CC [M]  drivers/media/usb/dvb-usb-v2/rtl28xxu.o
+00:11:05   CC [M]  drivers/leds/leds-lm3532.o
+00:11:05   CC [M]  drivers/media/pci/cx18/cx18-queue.o
+00:11:05   CC [M]  drivers/media/test-drivers/vicodec/vicodec-core.o
+00:11:05   CC [M]  drivers/hwmon/max6697.o
+00:11:05   CC [M]  drivers/media/test-drivers/vicodec/codec-fwht.o
+00:11:05   CC [M]  drivers/media/pci/ivtv/ivtv-irq.o
+00:11:05   CC [M]  drivers/md/raid5-ppl.o
+00:11:05   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/xsk/tx.o
+00:11:05   CC [M]  drivers/media/usb/dvb-usb/cinergyT2-core.o
+00:11:05   CC [M]  drivers/media/v4l2-core/v4l2-event.o
+00:11:05   CC [M]  drivers/media/dvb-frontends/tda8083.o
+00:11:05   CC [M]  drivers/net/ethernet/netronome/nfp/flower/action.o
+00:11:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/chang84.o
+00:11:05   CC [M]  drivers/leds/leds-lp3944.o
+00:11:05   CC [M]  drivers/hwmon/max31790.o
+00:11:06   CC [M]  drivers/media/pci/cx18/cx18-streams.o
+00:11:06   CC [M]  drivers/net/veth.o
+00:11:06   CC [M]  drivers/media/v4l2-core/v4l2-subdev.o
+00:11:06   CC [M]  drivers/media/test-drivers/vivid/vivid-kthread-out.o
+00:11:06   CC [M]  drivers/media/usb/dvb-usb-v2/dvbsky.o
+00:11:06   CC [M]  drivers/media/usb/dvb-usb/cinergyT2-fe.o
+00:11:06   CC [M]  drivers/media/dvb-frontends/l64781.o
+00:11:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/dmanv04.o
+00:11:06   CC [M]  drivers/media/test-drivers/vicodec/codec-v4l2-fwht.o
+00:11:06   CC [M]  drivers/md/dm-unstripe.o
+00:11:06   CC [M]  drivers/media/pci/ivtv/ivtv-mailbox.o
+00:11:06   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/devlink.o
+00:11:06   CC [M]  drivers/leds/leds-lp3952.o
+00:11:06   CC [M]  drivers/hwmon/mcp3021.o
+00:11:06   LD [M]  drivers/media/test-drivers/vicodec/vicodec.o
+00:11:06   AR      drivers/media/usb/stkwebcam/built-in.a
+00:11:06   CC [M]  drivers/media/dvb-core/dvbdev.o
+00:11:07   CC [M]  drivers/net/ethernet/netronome/nfp/flower/cmsg.o
+00:11:07   CC [M]  drivers/media/test-drivers/vivid/vivid-radio-rx.o
+00:11:07   CC [M]  drivers/md/dm-bio-prison-v1.o
+00:11:07   CC [M]  drivers/media/dvb-frontends/dib3000mb.o
+00:11:07   CC [M]  drivers/media/pci/cx18/cx18-fileops.o
+00:11:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/dmanv10.o
+00:11:07   CC [M]  drivers/media/v4l2-core/v4l2-common.o
+00:11:07   CC [M]  drivers/media/usb/dvb-usb/az6027.o
+00:11:07   CC [M]  drivers/leds/leds-lp50xx.o
+00:11:07   CC [M]  drivers/media/usb/dvb-usb-v2/zd1301.o
+00:11:07   CC [M]  drivers/hwmon/tc654.o
+00:11:07   CC [M]  drivers/media/pci/ivtv/ivtv-queue.o
+00:11:07   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/ptp.o
+00:11:07   CC [M]  drivers/media/dvb-core/dmxdev.o
+00:11:08   CC [M]  drivers/md/dm-bio-prison-v2.o
+00:11:08   CC      drivers/gpu/drm/drm_self_refresh_helper.o
+00:11:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/dmanv17.o
+00:11:08   CC [M]  drivers/net/ethernet/netronome/nfp/flower/lag_conf.o
+00:11:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/dcn_calcs.o
+00:11:08   CC [M]  drivers/media/test-drivers/vivid/vivid-radio-tx.o
+00:11:08   CC [M]  drivers/leds/leds-lt3593.o
+00:11:08   CC [M]  drivers/media/v4l2-core/v4l2-ctrls-core.o
+00:11:08   CC [M]  drivers/hwmon/mlxreg-fan.o
+00:11:08   CC [M]  drivers/media/usb/dvb-usb/technisat-usb2.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb_usb_v2.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-af9015.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-af9035.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-anysee.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-au6610.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-az6007.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-ce6230.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-ec168.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-lmedm04.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-gl861.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-mxl111sf.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-rtl28xxu.o
+00:11:08   LD [M]  drivers/media/usb/dvb-usb-v2/dvb-usb-dvbsky.o
+00:11:08   CC [M]  drivers/media/dvb-frontends/dib3000mc.o
+00:11:08   CC [M]  drivers/media/pci/ivtv/ivtv-streams.o
+00:11:08   CC [M]  drivers/media/pci/cx18/cx18-ioctl.o
+00:11:08   CC [M]  drivers/leds/leds-mlxcpld.o
+00:11:08   CC [M]  drivers/media/test-drivers/vivid/vivid-radio-common.o
+00:11:08   CC [M]  drivers/media/dvb-core/dvb_demux.o
+00:11:08   CC [M]  drivers/md/dm-crypt.o
+00:11:08   CC [M]  drivers/hwmon/mr75203.o
+00:11:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/dmanv40.o
+00:11:09   CC [M]  drivers/md/dm-delay.o
+00:11:09   CC [M]  drivers/leds/leds-mlxreg.o
+00:11:09   AR      drivers/media/test-drivers/built-in.a
+00:11:09   CC [M]  drivers/media/cec/core/cec-core.o
+00:11:09   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/qos.o
+00:11:09   CC [M]  drivers/hwmon/nct6683.o
+00:11:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/dcn_calc_math.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb.o
+00:11:09   CC [M]  drivers/net/ethernet/netronome/nfp/flower/main.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-vp7045.o
+00:11:09   CC [M]  drivers/leds/leds-nic78bx.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-vp702x.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-gp8psk.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dtt200u.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dibusb-mc-common.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-a800.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dibusb-mb.o
+00:11:09   CC [M]  drivers/media/dvb-frontends/dibx000_common.o
+00:11:09   CC [M]  drivers/media/v4l2-core/v4l2-ctrls-api.o
+00:11:09   CC [M]  drivers/media/test-drivers/vivid/vivid-rds-gen.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dibusb-mc.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-nova-t-usb2.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-umt-010.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-m920x.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-digitv.o
+00:11:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/calcs/dcn_calc_auto.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-cxusb.o
+00:11:09   CC [M]  drivers/media/dvb-core/dvb_ca_en50221.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-ttusb2.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dib0700.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-opera.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-af9005.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-af9005-remote.o
+00:11:09   CC [M]  drivers/media/cec/core/cec-adap.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-pctv452e.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dw2102.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-dtv5100.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-cinergyT2.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-az6027.o
+00:11:09   LD [M]  drivers/media/usb/dvb-usb/dvb-usb-technisat-usb2.o
+00:11:09   CC [M]  drivers/media/pci/ivtv/ivtv-udma.o
+00:11:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifonv50.o
+00:11:09   CC [M]  drivers/media/test-drivers/vim2m.o
+00:11:09   CC [M]  drivers/media/test-drivers/vivid/vivid-sdr-cap.o
+00:11:09   AR      drivers/media/usb/s2255/built-in.a
+00:11:09   CC [M]  drivers/media/usb/s2255/s2255drv.o
+00:11:10   CC [M]  drivers/leds/leds-pca9532.o
+00:11:10   CC [M]  drivers/media/pci/cx18/cx18-controls.o
+00:11:10   CC [M]  drivers/hwmon/nct6775.o
+00:11:10   CC [M]  drivers/media/dvb-frontends/dib7000m.o
+00:11:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifog84.o
+00:11:10   CC [M]  drivers/media/dvb-core/dvb_frontend.o
+00:11:10   CC [M]  drivers/media/pci/ivtv/ivtv-vbi.o
+00:11:10   CC [M]  drivers/media/v4l2-core/v4l2-ctrls-request.o
+00:11:10   CC [M]  drivers/leds/uleds.o
+00:11:11   CC [M]  drivers/media/test-drivers/vivid/vivid-vbi-cap.o
+00:11:11   CC [M]  drivers/media/pci/cx18/cx18-mailbox.o
+00:11:11   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/trap.o
+00:11:11   CC [M]  drivers/net/ethernet/netronome/nfp/flower/match.o
+00:11:11   AR      drivers/leds/built-in.a
+00:11:11   CC [M]  drivers/media/pci/ivtv/ivtv-yuv.o
+00:11:11   CC [M]  drivers/media/cec/core/cec-api.o
+00:11:11   CC [M]  drivers/md/dm-dust.o
+00:11:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifogf100.o
+00:11:11   CC [M]  drivers/md/dm-flakey.o
+00:11:11   CC [M]  drivers/media/v4l2-core/v4l2-ctrls-defs.o
+00:11:11   CC [M]  drivers/media/usb/uvc/uvc_driver.o
+00:11:11   CC [M]  drivers/media/dvb-frontends/dib7000p.o
+00:11:11   CC [M]  drivers/media/usb/uvc/uvc_queue.o
+00:11:11   CC [M]  drivers/media/cec/core/cec-notifier.o
+00:11:12   CC [M]  drivers/media/test-drivers/vivid/vivid-vbi-out.o
+00:11:12   CC [M]  drivers/media/cec/i2c/ch7322.o
+00:11:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifogk104.o
+00:11:12   CC [M]  drivers/media/dvb-core/dvb_net.o
+00:11:12   CC [M]  drivers/media/v4l2-core/v4l2-compat-ioctl32.o
+00:11:12   CC [M]  drivers/media/pci/cx18/cx18-vbi.o
+00:11:12   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/fs_tt_redirect.o
+00:11:12   CC [M]  drivers/hwmon/nct7802.o
+00:11:12   CC [M]  drivers/md/dm-path-selector.o
+00:11:12   CC [M]  drivers/media/pci/ivtv/ivtvfb.o
+00:11:12   CC [M]  drivers/net/ethernet/netronome/nfp/flower/metadata.o
+00:11:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/gpio_base.o
+00:11:12   LD [M]  drivers/media/cec/core/cec.o
+00:11:12   CC [M]  drivers/net/virtio_net.o
+00:11:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifogv100.o
+00:11:12   CC [M]  drivers/media/v4l2-core/v4l2-trace.o
+00:11:12   CC [M]  drivers/media/test-drivers/vivid/vivid-osd.o
+00:11:12   CC [M]  drivers/media/cec/platform/seco/seco-cec.o
+00:11:13   CC [M]  drivers/md/dm-mpath.o
+00:11:13   CC [M]  drivers/media/dvb-frontends/dib8000.o
+00:11:13   CC [M]  drivers/media/pci/cx18/cx18-audio.o
+00:11:13   CC [M]  drivers/media/usb/uvc/uvc_v4l2.o
+00:11:13   CC [M]  drivers/media/dvb-core/dvb_ringbuffer.o
+00:11:13   CC [M]  drivers/hwmon/nct7904.o
+00:11:13   CC [M]  drivers/media/test-drivers/vivid/vivid-meta-cap.o
+00:11:13   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_arfs.o
+00:11:13   LD [M]  drivers/media/pci/ivtv/ivtv.o
+00:11:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/gpfifotu102.o
+00:11:13   CC [M]  drivers/hwmon/npcm750-pwm-fan.o
+00:11:13   CC [M]  drivers/media/dvb-core/dvb_math.o
+00:11:13   CC [M]  drivers/media/cec/usb/pulse8/pulse8-cec.o
+00:11:13   CC [M]  drivers/media/v4l2-core/v4l2-mc.o
+00:11:13   CC [M]  drivers/media/cec/usb/rainshadow/rainshadow-cec.o
+00:11:14   CC [M]  drivers/net/ethernet/netronome/nfp/flower/offload.o
+00:11:14   LD [M]  drivers/media/dvb-core/dvb-core.o
+00:11:14   CC      drivers/gpu/drm/bridge/panel.o
+00:11:14   CC [M]  drivers/media/pci/cx18/cx18-video.o
+00:11:14   CC [M]  drivers/net/geneve.o
+00:11:14   CC [M]  drivers/media/test-drivers/vivid/vivid-meta-out.o
+00:11:14   CC [M]  drivers/hwmon/ntc_thermistor.o
+00:11:14   CC [M]  drivers/md/dm-ps-round-robin.o
+00:11:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/usergv100.o
+00:11:14   CC [M]  drivers/media/usb/uvc/uvc_video.o
+00:11:14   CC [M]  drivers/media/usb/gspca/m5602/m5602_core.o
+00:11:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/gpio_service.o
+00:11:14   CC [M]  drivers/hwmon/nzxt-kraken2.o
+00:11:14   CC [M]  drivers/net/ethernet/netronome/nfp/flower/tunnel_conf.o
+00:11:14   CC [M]  drivers/media/v4l2-core/v4l2-spi.o
+00:11:14   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_hw.o
+00:11:15   CC [M]  drivers/md/dm-ps-queue-length.o
+00:11:15   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_fs_ethtool.o
+00:11:15   CC [M]  drivers/media/pci/cx18/cx18-irq.o
+00:11:15   CC [M]  drivers/hwmon/pc87360.o
+00:11:15   CC [M]  drivers/media/test-drivers/vivid/vivid-kthread-touch.o
+00:11:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/fifo/usertu102.o
+00:11:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_factory.o
+00:11:15   CC [M]  drivers/media/pci/cx23885/cx23885-cards.o
+00:11:15   CC [M]  drivers/media/usb/gspca/m5602/m5602_ov9650.o
+00:11:15   CC [M]  drivers/media/v4l2-core/v4l2-i2c.o
+00:11:15   CC [M]  drivers/md/dm-ps-service-time.o
+00:11:15   CC [M]  drivers/media/dvb-frontends/mt312.o
+00:11:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_gpio.o
+00:11:16   CC [M]  drivers/media/usb/uvc/uvc_ctrl.o
+00:11:16   CC [M]  drivers/media/pci/cx18/cx18-av-core.o
+00:11:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/base.o
+00:11:16   CC [M]  drivers/media/pci/cx23885/cx23885-video.o
+00:11:16   CC [M]  drivers/media/test-drivers/vivid/vivid-touch-cap.o
+00:11:16   CC [M]  drivers/media/usb/gspca/stv06xx/stv06xx.o
+00:11:16   CC [M]  drivers/hwmon/pc87427.o
+00:11:16   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_main.o
+00:11:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_dcbnl.o
+00:11:16   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_hpd.o
+00:11:16   CC [M]  drivers/md/dm-ps-historical-service-time.o
+00:11:16   CC [M]  drivers/media/v4l2-core/v4l2-fwnode.o
+00:11:16   CC [M]  drivers/media/usb/gspca/m5602/m5602_ov7660.o
+00:11:16   CC [M]  drivers/net/ethernet/netronome/nfp/flower/qos_conf.o
+00:11:16   CC [M]  drivers/media/usb/gspca/stv06xx/stv06xx_vv6410.o
+00:11:16   CC [M]  drivers/media/dvb-frontends/ves1820.o
+00:11:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv04.o
+00:11:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_ddc.o
+00:11:17   CC [M]  drivers/hwmon/pcf8591.o
+00:11:17   CC [M]  drivers/media/test-drivers/vivid/vivid-cec.o
+00:11:17   CC [M]  drivers/md/dm-ps-io-affinity.o
+00:11:17   CC [M]  drivers/media/radio/si470x/radio-si470x-common.o
+00:11:17   CC [M]  drivers/media/pci/cx18/cx18-av-audio.o
+00:11:17   CC [M]  drivers/media/usb/uvc/uvc_status.o
+00:11:17   CC [M]  drivers/media/pci/cx23885/cx23885-vbi.o
+00:11:17   CC [M]  drivers/media/usb/gspca/m5602/m5602_mt9m111.o
+00:11:17   CC [M]  drivers/media/usb/gspca/stv06xx/stv06xx_hdcs.o
+00:11:17   CC [M]  drivers/media/dvb-frontends/ves1x93.o
+00:11:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_generic.o
+00:11:17   CC [M]  drivers/media/v4l2-core/v4l2-async.o
+00:11:17   CC [M]  drivers/net/ethernet/netronome/nfp/flower/conntrack.o
+00:11:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv10.o
+00:11:17   CC [M]  drivers/hwmon/powr1220.o
+00:11:18   CC [M]  drivers/md/dm-switch.o
+00:11:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/port_buffer.o
+00:11:18   LD [M]  drivers/media/test-drivers/vivid/vivid.o
+00:11:18   CC      drivers/gpu/drm/drm_fb_helper.o
+00:11:18   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/hw_translate.o
+00:11:18   CC [M]  drivers/media/radio/si470x/radio-si470x-usb.o
+00:11:18   CC [M]  drivers/media/usb/uvc/uvc_isight.o
+00:11:18   CC [M]  drivers/media/pci/cx18/cx18-av-firmware.o
+00:11:18   CC [M]  drivers/media/pci/cx23885/cx23885-core.o
+00:11:18   CC [M]  drivers/media/usb/gspca/m5602/m5602_po1030.o
+00:11:18   CC [M]  drivers/media/dvb-frontends/tda1004x.o
+00:11:18   CC [M]  drivers/media/usb/gspca/stv06xx/stv06xx_pb0100.o
+00:11:18   CC [M]  drivers/hwmon/sbtsi_temp.o
+00:11:18   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce60/hw_translate_dce60.o
+00:11:18   CC [M]  drivers/media/v4l2-core/v4l2-dv-timings.o
+00:11:18   CC [M]  drivers/md/dm-log-userspace-base.o
+00:11:19   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_init.o
+00:11:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv15.o
+00:11:19   CC [M]  drivers/media/usb/uvc/uvc_debugfs.o
+00:11:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lag_mp.o
+00:11:19   CC [M]  drivers/media/radio/si470x/radio-si470x-i2c.o
+00:11:19   CC [M]  drivers/media/pci/cx18/cx18-av-vbi.o
+00:11:19   CC [M]  drivers/hwmon/sch56xx-common.o
+00:11:19   CC [M]  drivers/media/usb/gspca/m5602/m5602_s5k83a.o
+00:11:19   CC [M]  drivers/media/usb/gspca/stv06xx/stv06xx_st6422.o
+00:11:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce60/hw_factory_dce60.o
+00:11:19   CC [M]  drivers/media/dvb-frontends/sp887x.o
+00:11:19   CC [M]  drivers/md/dm-log-userspace-transfer.o
+00:11:19   CC [M]  drivers/media/v4l2-core/tuner-core.o
+00:11:19   AR      drivers/net/ethernet/qualcomm/emac/built-in.a
+00:11:19   CC [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet_config.o
+00:11:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv17.o
+00:11:19   CC [M]  drivers/net/ethernet/netronome/nfp/bpf/cmsg.o
+00:11:20   CC [M]  drivers/hwmon/sch5627.o
+00:11:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce80/hw_translate_dce80.o
+00:11:20   CC [M]  drivers/media/usb/uvc/uvc_metadata.o
+00:11:20   CC [M]  drivers/media/pci/cx23885/cx23885-i2c.o
+00:11:20   LD [M]  drivers/media/usb/gspca/stv06xx/gspca_stv06xx.o
+00:11:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv20.o
+00:11:20   CC [M]  drivers/media/radio/radio-maxiradio.o
+00:11:20   CC [M]  drivers/media/usb/gspca/m5602/m5602_s5k4aa.o
+00:11:20   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_ethtool.o
+00:11:20   CC [M]  drivers/media/pci/cx18/cx18-scb.o
+00:11:20   CC [M]  drivers/media/dvb-frontends/nxt6000.o
+00:11:20   CC [M]  drivers/hwmon/sch5636.o
+00:11:20   CC [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic_hw.o
+00:11:20   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/geneve.o
+00:11:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce80/hw_factory_dce80.o
+00:11:20   CC [M]  drivers/md/dm-raid.o
+00:11:20   CC [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet_vnd.o
+00:11:20   CC [M]  drivers/media/v4l2-core/v4l2-mem2mem.o
+00:11:20   CC [M]  drivers/media/usb/uvc/uvc_entity.o
+00:11:21   CC [M]  drivers/hwmon/sht15.o
+00:11:21   CC [M]  drivers/net/ethernet/netronome/nfp/bpf/main.o
+00:11:21   CC [M]  drivers/media/pci/cx23885/cx23885-dvb.o
+00:11:21   CC [M]  drivers/media/radio/radio-shark.o
+00:11:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce110/hw_translate_dce110.o
+00:11:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv25.o
+00:11:21   CC [M]  drivers/media/dvb-frontends/mt352.o
+00:11:21   LD [M]  drivers/media/usb/gspca/m5602/gspca_m5602.o
+00:11:21   CC [M]  drivers/media/usb/gspca/gl860/gl860.o
+00:11:21   CC [M]  drivers/media/pci/cx18/cx18-dvb.o
+00:11:21   CC [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet_handlers.o
+00:11:21   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/port_tun.o
+00:11:21   LD [M]  drivers/media/usb/uvc/uvcvideo.o
+00:11:21   CC [M]  drivers/media/usb/gspca/gl860/gl860-mi1320.o
+00:11:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce110/hw_factory_dce110.o
+00:11:21   CC [M]  drivers/hwmon/sht21.o
+00:11:22   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_ctx.o
+00:11:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv2a.o
+00:11:22   CC [M]  drivers/media/v4l2-core/videobuf-core.o
+00:11:22   CC [M]  drivers/media/radio/radio-shark2.o
+00:11:22   CC [M]  drivers/media/dvb-frontends/zl10036.o
+00:11:22   CC [M]  drivers/net/ethernet/netronome/nfp/bpf/offload.o
+00:11:22   CC [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic_main.o
+00:11:22   CC [M]  drivers/net/ethernet/qlogic/qed/qed_chain.o
+00:11:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce120/hw_translate_dce120.o
+00:11:22   CC [M]  drivers/media/pci/cx18/cx18-io.o
+00:11:22   CC [M]  drivers/md/dm-thin.o
+00:11:22   CC [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet_map_data.o
+00:11:22   CC [M]  drivers/hwmon/sht3x.o
+00:11:22   CC [M]  drivers/media/usb/gspca/gl860/gl860-ov2640.o
+00:11:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv30.o
+00:11:22   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_rep.o
+00:11:23   CC [M]  drivers/media/dvb-frontends/zl10039.o
+00:11:23   CC [M]  drivers/media/radio/radio-tea5777.o
+00:11:23   CC [M]  drivers/media/pci/cx23885/cx23885-417.o
+00:11:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dce120/hw_factory_dce120.o
+00:11:23   CC [M]  drivers/net/ethernet/qlogic/qed/qed_cxt.o
+00:11:23   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_io.o
+00:11:23   CC [M]  drivers/media/pci/cx18/cx18-alsa-main.o
+00:11:23   CC [M]  drivers/media/v4l2-core/videobuf-dma-sg.o
+00:11:23   CC [M]  drivers/hwmon/shtc1.o
+00:11:23   CC [M]  drivers/media/usb/gspca/gl860/gl860-ov9655.o
+00:11:23   CC [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet_map_command.o
+00:11:23   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv34.o
+00:11:23   CC [M]  drivers/net/ethernet/netronome/nfp/bpf/verifier.o
+00:11:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn10/hw_translate_dcn10.o
+00:11:23   CC [M]  drivers/media/dvb-frontends/zl10353.o
+00:11:24   CC [M]  drivers/media/radio/dsbr100.o
+00:11:24   CC [M]  drivers/media/v4l2-core/videobuf-vmalloc.o
+00:11:24   CC [M]  drivers/hwmon/sis5595.o
+00:11:24   CC [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic_init.o
+00:11:24   LD [M]  drivers/net/ethernet/qualcomm/rmnet/rmnet.o
+00:11:24   AR      drivers/net/ethernet/qualcomm/built-in.a
+00:11:24   CC [M]  drivers/media/pci/cx18/cx18-alsa-pcm.o
+00:11:24   LD [M]  drivers/media/v4l2-core/videodev.o
+00:11:24   CC [M]  drivers/media/pci/cx23885/cx23885-ioctl.o
+00:11:24   CC [M]  drivers/hwmon/smsc47b397.o
+00:11:24   CC [M]  drivers/media/usb/gspca/gl860/gl860-mi2020.o
+00:11:24   CC [M]  drivers/md/dm-thin-metadata.o
+00:11:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn10/hw_factory_dcn10.o
+00:11:24   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv35.o
+00:11:24   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rep/bond.o
+00:11:24   CC [M]  drivers/media/dvb-frontends/cx22702.o
+00:11:24   LD [M]  drivers/media/v4l2-core/tuner.o
+00:11:24   CC      drivers/gpu/drm/drm_fb_cma_helper.o
+00:11:25   CC [M]  drivers/media/pci/cx88/cx88-cards.o
+00:11:25   CC [M]  drivers/media/radio/radio-mr800.o
+00:11:25   CC [M]  drivers/net/ethernet/qlogic/qed/qed_dcbx.o
+00:11:25   CC [M]  drivers/hwmon/smsc47m1.o
+00:11:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn20/hw_translate_dcn20.o
+00:11:25   CC [M]  drivers/net/ethernet/netronome/nfp/bpf/jit.o
+00:11:25   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_sysfs.o
+00:11:25   CC [M]  drivers/media/pci/cx23885/cx23885-ir.o
+00:11:25   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv40.o
+00:11:25   LD [M]  drivers/media/pci/cx18/cx18.o
+00:11:25   LD [M]  drivers/media/pci/cx18/cx18-alsa.o
+00:11:25   LD [M]  drivers/media/usb/gspca/gl860/gspca_gl860.o
+00:11:25   CC [M]  drivers/media/usb/gspca/gspca.o
+00:11:25   CC [M]  drivers/media/usb/pwc/pwc-if.o
+00:11:25   CC [M]  drivers/md/dm-verity-fec.o
+00:11:25   CC [M]  drivers/media/dvb-frontends/drxd_firm.o
+00:11:25   CC [M]  drivers/media/usb/pwc/pwc-misc.o
+00:11:25   CC [M]  drivers/media/dvb-frontends/drxd_hard.o
+00:11:25   CC [M]  drivers/hwmon/smsc47m192.o
+00:11:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn20/hw_factory_dcn20.o
+00:11:25   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/mod_hdr.o
+00:11:26   CC [M]  drivers/media/radio/radio-keene.o
+00:11:26   CC [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic_ethtool.o
+00:11:26   CC [M]  drivers/media/pci/cx88/cx88-core.o
+00:11:26   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv44.o
+00:11:26   CC [M]  drivers/media/pci/cx23885/cx23885-av.o
+00:11:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn21/hw_translate_dcn21.o
+00:11:26   CC [M]  drivers/md/dm-verity-verify-sig.o
+00:11:26   CC [M]  drivers/media/pci/cx88/cx88-i2c.o
+00:11:26   CC [M]  drivers/net/ethernet/qlogic/qed/qed_debug.o
+00:11:26   CC [M]  drivers/hwmon/amc6821.o
+00:11:26   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_minidump.o
+00:11:26   CC [M]  drivers/media/usb/pwc/pwc-ctrl.o
+00:11:26   CC [M]  drivers/media/usb/gspca/autogain_functions.o
+00:11:27   CC [M]  drivers/media/radio/radio-ma901.o
+00:11:27   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/mapping.o
+00:11:27   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/nv50.o
+00:11:27   CC [M]  drivers/md/dm-verity-target.o
+00:11:27   CC [M]  drivers/media/pci/cx23885/cx23885-input.o
+00:11:27   CC [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic_ctx.o
+00:11:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn21/hw_factory_dcn21.o
+00:11:27   CC [M]  drivers/media/dvb-frontends/tda10021.o
+00:11:27   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en_tc.o
+00:11:27   CC [M]  drivers/media/pci/cx88/cx88-tvaudio.o
+00:11:27   AR      drivers/net/ethernet/realtek/built-in.a
+00:11:27   CC [M]  drivers/net/ethernet/realtek/8139cp.o
+00:11:27   LD [M]  drivers/net/ethernet/netronome/nfp/nfp.o
+00:11:27   CC [M]  drivers/media/usb/gspca/benq.o
+00:11:27   CC [M]  drivers/hwmon/tc74.o
+00:11:27   AR      drivers/net/ethernet/rdc/built-in.a
+00:11:27   CC [M]  drivers/net/ethernet/rdc/r6040.o
+00:11:27   CC [M]  drivers/media/usb/pwc/pwc-v4l.o
+00:11:27   CC [M]  drivers/media/radio/radio-tea5764.o
+00:11:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn30/hw_translate_dcn30.o
+00:11:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/g84.o
+00:11:28   CC [M]  drivers/media/dvb-frontends/tda10023.o
+00:11:28   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_83xx_hw.o
+00:11:28   CC [M]  drivers/media/pci/cx23885/cx23888-ir.o
+00:11:28   LD [M]  drivers/net/ethernet/qlogic/netxen/netxen_nic.o
+00:11:28   AR      drivers/net/ethernet/rocker/built-in.a
+00:11:28   CC [M]  drivers/net/ethernet/rocker/rocker_main.o
+00:11:28   CC [M]  drivers/hwmon/thmc50.o
+00:11:28   CC [M]  drivers/md/dm-cache-target.o
+00:11:28   CC [M]  drivers/media/pci/cx88/cx88-dsp.o
+00:11:28   CC [M]  drivers/media/usb/gspca/conex.o
+00:11:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/dcn30/hw_factory_dcn30.o
+00:11:28   CC [M]  drivers/media/radio/saa7706h.o
+00:11:28   CC [M]  drivers/media/pci/bt8xx/bttv-driver.o
+00:11:28   CC [M]  drivers/media/usb/pwc/pwc-uncompress.o
+00:11:28   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gt200.o
+00:11:29   CC [M]  drivers/media/dvb-frontends/stv0297.o
+00:11:29   CC [M]  drivers/net/ethernet/realtek/8139too.o
+00:11:29   CC [M]  drivers/hwmon/tmp102.o
+00:11:29   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/diagnostics/hw_translate_diag.o
+00:11:29   CC [M]  drivers/media/pci/cx23885/netup-init.o
+00:11:29   CC [M]  drivers/media/pci/cx88/cx88-input.o
+00:11:29   CC [M]  drivers/media/usb/gspca/cpia1.o
+00:11:29   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/mcp79.o
+00:11:29   CC [M]  drivers/media/radio/radio-wl1273.o
+00:11:29   CC [M]  drivers/net/ethernet/qlogic/qed/qed_dev.o
+00:11:29   CC [M]  drivers/media/usb/pwc/pwc-dec1.o
+00:11:29   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/gpio/diagnostics/hw_factory_diag.o
+00:11:30   CC [M]  drivers/media/dvb-frontends/nxt200x.o
+00:11:30   CC [M]  drivers/hwmon/tmp103.o
+00:11:30   CC [M]  drivers/md/dm-cache-metadata.o
+00:11:30   CC [M]  drivers/media/pci/cx23885/cimax2.o
+00:11:30   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/irq_service.o
+00:11:30   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gt215.o
+00:11:30   CC [M]  drivers/net/ethernet/rocker/rocker_tlv.o
+00:11:30   CC [M]  drivers/net/ethernet/realtek/atp.o
+00:11:30   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_83xx_init.o
+00:11:30   CC [M]  drivers/media/usb/pwc/pwc-dec23.o
+00:11:30   CC [M]  drivers/media/pci/cx88/cx88-video.o
+00:11:30   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rep/tc.o
+00:11:30   CC [M]  drivers/hwmon/tmp108.o
+00:11:30   CC [M]  drivers/media/usb/gspca/dtcs033.o
+00:11:31   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dce60/irq_service_dce60.o
+00:11:31   CC [M]  drivers/media/dvb-frontends/or51211.o
+00:11:31   CC [M]  drivers/media/pci/bt8xx/bttv-cards.o
+00:11:31   CC [M]  drivers/media/radio/tea575x.o
+00:11:31   CC [M]  drivers/md/dm-cache-policy.o
+00:11:31   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/mcp89.o
+00:11:31   CC [M]  drivers/media/pci/cx23885/netup-eeprom.o
+00:11:31   CC [M]  drivers/net/ethernet/rocker/rocker_ofdpa.o
+00:11:31   CC [M]  drivers/net/ethernet/realtek/r8169_main.o
+00:11:31   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dce80/irq_service_dce80.o
+00:11:31   CC [M]  drivers/media/usb/pwc/pwc-kiara.o
+00:11:31   CC [M]  drivers/hwmon/tmp401.o
+00:11:31   CC [M]  drivers/media/usb/gspca/etoms.o
+00:11:31   CC [M]  drivers/media/dvb-frontends/or51132.o
+00:11:31   CC [M]  drivers/md/dm-cache-background-tracker.o
+00:11:32   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf100.o
+00:11:32   CC [M]  drivers/media/pci/cx88/cx88-vbi.o
+00:11:32   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rep/neigh.o
+00:11:32   LD [M]  drivers/media/radio/shark2.o
+00:11:32   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dce110/irq_service_dce110.o
+00:11:32   CC [M]  drivers/media/usb/gspca/finepix.o
+00:11:32   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_83xx_vnic.o
+00:11:32   CC [M]  drivers/media/pci/cx23885/cx23885-f300.o
+00:11:32   CC [M]  drivers/net/ethernet/qlogic/qed/qed_devlink.o
+00:11:32   CC [M]  drivers/media/pci/bt8xx/bttv-if.o
+00:11:32   CC [M]  drivers/media/usb/pwc/pwc-timon.o
+00:11:32   CC [M]  drivers/md/dm-cache-policy-smq.o
+00:11:32   CC [M]  drivers/hwmon/tmp421.o
+00:11:32   CC [M]  drivers/media/dvb-frontends/bcm3510.o
+00:11:32   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dce120/irq_service_dce120.o
+00:11:33   CC [M]  drivers/media/pci/saa7134/saa7134-cards.o
+00:11:33   CC [M]  drivers/media/pci/cx88/cx88-mpeg.o
+00:11:33   CC [M]  drivers/media/usb/gspca/jeilinj.o
+00:11:33   CC [M]  drivers/net/ethernet/qlogic/qed/qed_hw.o
+00:11:33   LD [M]  drivers/net/ethernet/rocker/rocker.o
+00:11:33   CC [M]  drivers/net/bareudp.o
+00:11:33   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_sriov_common.o
+00:11:33   CC [M]  drivers/media/pci/cx23885/cx23885-alsa.o
+00:11:33   CC [M]  drivers/media/pci/bt8xx/bttv-risc.o
+00:11:33   LD [M]  drivers/media/usb/pwc/pwc.o
+00:11:33   CC      drivers/gpu/drm/drm_aperture.o
+00:11:33   CC [M]  drivers/hwmon/tmp513.o
+00:11:33   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn10/irq_service_dcn10.o
+00:11:33   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/fs_chains.o
+00:11:33   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf104.o
+00:11:33   CC [M]  drivers/media/dvb-frontends/s5h1420.o
+00:11:33   CC [M]  drivers/md/dm-ebs-target.o
+00:11:34   CC [M]  drivers/media/usb/gspca/jl2005bcd.o
+00:11:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn20/irq_service_dcn20.o
+00:11:34   CC [M]  drivers/media/pci/saa7134/saa7134-core.o
+00:11:34   CC [M]  drivers/net/ethernet/qlogic/qede/qede_main.o
+00:11:34   CC [M]  drivers/media/pci/cx88/cx88-alsa.o
+00:11:34   CC [M]  drivers/net/ethernet/qlogic/qed/qed_init_fw_funcs.o
+00:11:34   CC [M]  drivers/hwmon/via-cputemp.o
+00:11:34   CC [M]  drivers/net/ethernet/realtek/r8169_firmware.o
+00:11:34   CC [M]  drivers/media/pci/cx23885/altera-ci.o
+00:11:34   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf108.o
+00:11:34   CC [M]  drivers/media/pci/bt8xx/bttv-vbi.o
+00:11:34   CC [M]  drivers/net/ethernet/realtek/r8169_phy_config.o
+00:11:34   CC [M]  drivers/hwmon/via686a.o
+00:11:34   CC [M]  drivers/media/pci/saa7164/saa7164-cards.o
+00:11:34   CC [M]  drivers/md/dm-era-target.o
+00:11:34   CC [M]  drivers/media/dvb-frontends/lgdt330x.o
+00:11:34   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn21/irq_service_dcn21.o
+00:11:35   CC [M]  drivers/media/usb/gspca/kinect.o
+00:11:35   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_sriov_pf.o
+00:11:35   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun.o
+00:11:35   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf110.o
+00:11:35   LD [M]  drivers/media/pci/cx23885/cx23885.o
+00:11:35   AR      drivers/net/ethernet/silan/built-in.a
+00:11:35   CC [M]  drivers/net/ethernet/silan/sc92031.o
+00:11:35   CC [M]  drivers/media/pci/cx88/cx88-blackbird.o
+00:11:35   CC [M]  drivers/media/pci/bt8xx/bttv-i2c.o
+00:11:35   CC [M]  drivers/net/ethernet/qlogic/qed/qed_init_ops.o
+00:11:35   CC [M]  drivers/hwmon/vt1211.o
+00:11:35   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn30/irq_service_dcn30.o
+00:11:35   CC [M]  drivers/media/pci/saa7134/saa7134-i2c.o
+00:11:35   CC [M]  drivers/media/pci/saa7164/saa7164-core.o
+00:11:35   CC [M]  drivers/media/dvb-frontends/lgdt3305.o
+00:11:35   LD [M]  drivers/net/ethernet/realtek/r8169.o
+00:11:35   CC [M]  drivers/media/usb/au0828/au0828-core.o
+00:11:35   CC [M]  drivers/md/dm-clone-target.o
+00:11:36   CC [M]  drivers/media/usb/gspca/konica.o
+00:11:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf117.o
+00:11:36   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn302/irq_service_dcn302.o
+00:11:36   CC [M]  drivers/net/ethernet/qlogic/qede/qede_fp.o
+00:11:36   CC [M]  drivers/media/pci/bt8xx/bttv-gpio.o
+00:11:36   CC [M]  drivers/net/ethernet/qlogic/qed/qed_int.o
+00:11:36   CC [M]  drivers/hwmon/vt8231.o
+00:11:36   CC [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic_dcb.o
+00:11:36   CC [M]  drivers/media/usb/gspca/mars.o
+00:11:36   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/indir_table.o
+00:11:36   CC [M]  drivers/media/pci/saa7134/saa7134-ts.o
+00:11:36   CC [M]  drivers/media/pci/cx88/cx88-dvb.o
+00:11:36   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gf119.o
+00:11:36   CC [M]  drivers/media/dvb-frontends/lgdt3306a.o
+00:11:36   CC [M]  drivers/media/dvb-frontends/mxl692.o
+00:11:37   CC [M]  drivers/media/usb/au0828/au0828-i2c.o
+00:11:37   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn303/irq_service_dcn303.o
+00:11:37   CC [M]  drivers/md/dm-clone-metadata.o
+00:11:37   CC [M]  drivers/media/pci/saa7164/saa7164-i2c.o
+00:11:37   CC [M]  drivers/media/pci/bt8xx/bttv-input.o
+00:11:37   CC [M]  drivers/hwmon/w83627ehf.o
+00:11:37   CC [M]  drivers/media/usb/gspca/mr97310a.o
+00:11:37   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gk104.o
+00:11:37   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/irq/dcn31/irq_service_dcn31.o
+00:11:37   CC [M]  drivers/media/pci/saa7134/saa7134-tvaudio.o
+00:11:37   LD [M]  drivers/net/ethernet/qlogic/qlcnic/qlcnic.o
+00:11:37   CC [M]  drivers/net/ethernet/qlogic/qed/qed_l2.o
+00:11:37   CC [M]  drivers/md/dm-log-writes.o
+00:11:37   CC [M]  drivers/media/pci/saa7164/saa7164-dvb.o
+00:11:38   CC [M]  drivers/media/usb/au0828/au0828-cards.o
+00:11:38   CC [M]  drivers/md/dm-integrity.o
+00:11:38   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_encap.o
+00:11:38   CC      drivers/gpu/drm/drm_auth.o
+00:11:38   CC [M]  drivers/media/dvb-frontends/lg2160.o
+00:11:38   CC [M]  drivers/media/pci/bt8xx/bttv-audio-hook.o
+00:11:38   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/virtual/virtual_link_encoder.o
+00:11:38   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gk110.o
+00:11:38   CC [M]  drivers/media/pci/cx88/cx88-vp3054-i2c.o
+00:11:38   CC [M]  drivers/net/ethernet/qlogic/qede/qede_filter.o
+00:11:38   CC [M]  drivers/media/usb/gspca/nw80x.o
+00:11:38   CC [M]  drivers/hwmon/w83l785ts.o
+00:11:38   CC [M]  drivers/net/ethernet/qlogic/qed/qed_main.o
+00:11:38   CC [M]  drivers/media/usb/au0828/au0828-dvb.o
+00:11:38   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/virtual/virtual_stream_encoder.o
+00:11:39   CC [M]  drivers/media/usb/hdpvr/hdpvr-control.o
+00:11:39   CC [M]  drivers/media/pci/saa7164/saa7164-fw.o
+00:11:39   CC [M]  drivers/media/pci/saa7134/saa7134-vbi.o
+00:11:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gk110b.o
+00:11:39   CC [M]  drivers/media/pci/bt8xx/btcx-risc.o
+00:11:39   CC [M]  drivers/media/dvb-frontends/cx24123.o
+00:11:39   LD [M]  drivers/media/pci/cx88/cx88xx.o
+00:11:39   LD [M]  drivers/media/pci/cx88/cx8800.o
+00:11:39   LD [M]  drivers/media/pci/cx88/cx8802.o
+00:11:39   CC [M]  drivers/hwmon/w83l786ng.o
+00:11:39   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-i2c-core.o
+00:11:39   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_resource.o
+00:11:39   CC [M]  drivers/media/usb/gspca/ov519.o
+00:11:39   AR      drivers/net/ethernet/sis/built-in.a
+00:11:39   CC [M]  drivers/net/ethernet/sis/sis190.o
+00:11:39   CC [M]  drivers/media/pci/bt8xx/bt878.o
+00:11:39   CC [M]  drivers/media/usb/hdpvr/hdpvr-core.o
+00:11:39   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gk208.o
+00:11:40   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_vxlan.o
+00:11:40   CC [M]  drivers/media/usb/au0828/au0828-video.o
+00:11:40   CC [M]  drivers/media/pci/saa7134/saa7134-video.o
+00:11:40   CC [M]  drivers/media/pci/saa7164/saa7164-bus.o
+00:11:40   CC [M]  drivers/net/ethernet/qlogic/qede/qede_ethtool.o
+00:11:40   CC [M]  drivers/media/dvb-frontends/lnbh25.o
+00:11:40   AR      drivers/hwmon/built-in.a
+00:11:40   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-audio.o
+00:11:40   CC [M]  drivers/net/ethernet/qlogic/qed/qed_mcp.o
+00:11:40   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gk20a.o
+00:11:40   CC [M]  drivers/media/usb/hdpvr/hdpvr-video.o
+00:11:40   CC [M]  drivers/media/pci/bt8xx/dvb-bt8xx.o
+00:11:41   CC [M]  drivers/md/dm-zoned-target.o
+00:11:41   CC [M]  drivers/net/ethernet/sis/sis900.o
+00:11:41   CC [M]  drivers/media/dvb-frontends/lnbp21.o
+00:11:41   AR      drivers/net/ethernet/qlogic/built-in.a
+00:11:41   CC [M]  drivers/md/dm-zoned-metadata.o
+00:11:41   CC [M]  drivers/media/pci/saa7164/saa7164-cmd.o
+00:11:41   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_gre.o
+00:11:41   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-encoder.o
+00:11:41   CC [M]  drivers/media/usb/gspca/ov534.o
+00:11:41   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gm107.o
+00:11:41   CC [M]  drivers/media/usb/au0828/au0828-vbi.o
+00:11:41   CC [M]  drivers/media/dvb-frontends/lnbp22.o
+00:11:41   CC [M]  drivers/media/pci/saa7134/saa7134-input.o
+00:11:41   CC [M]  drivers/net/ethernet/qlogic/qede/qede_ptp.o
+00:11:42   CC      drivers/gpu/drm/drm_cache.o
+00:11:42   CC [M]  drivers/media/pci/bt8xx/dst.o
+00:11:42   CC [M]  drivers/media/usb/hdpvr/hdpvr-i2c.o
+00:11:42   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_init.o
+00:11:42   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gm200.o
+00:11:42   CC [M]  drivers/media/pci/saa7164/saa7164-api.o
+00:11:42   CC [M]  drivers/net/gtp.o
+00:11:42   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_geneve.o
+00:11:42   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-video-v4l.o
+00:11:42   CC [M]  drivers/media/pci/tw686x/tw686x-core.o
+00:11:42   CC [M]  drivers/media/usb/gspca/ov534_9.o
+00:11:42   CC [M]  drivers/media/dvb-frontends/isl6405.o
+00:11:42   LD [M]  drivers/media/usb/au0828/au0828.o
+00:11:42   CC [M]  drivers/media/pci/tw686x/tw686x-video.o
+00:11:42   CC [M]  drivers/md/dm-zoned-reclaim.o
+00:11:42   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_hwseq.o
+00:11:42   CC [M]  drivers/net/ethernet/qlogic/qed/qed_mng_tlv.o
+00:11:42   CC [M]  drivers/net/ethernet/qlogic/qede/qede_dcbnl.o
+00:11:42   LD [M]  drivers/media/usb/hdpvr/hdpvr.o
+00:11:42   CC [M]  drivers/media/pci/tw686x/tw686x-audio.o
+00:11:43   CC [M]  drivers/media/pci/saa7134/saa7134-empress.o
+00:11:43   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gm20b.o
+00:11:43   CC [M]  drivers/media/pci/bt8xx/dst_ca.o
+00:11:43   CC [M]  drivers/media/dvb-frontends/isl6421.o
+00:11:43   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-eeprom.o
+00:11:43   CC [M]  drivers/md/dm-writecache.o
+00:11:43   LD [M]  drivers/md/linear.o
+00:11:43   CC [M]  drivers/media/pci/saa7164/saa7164-buffer.o
+00:11:43   CC [M]  drivers/media/usb/gspca/pac207.o
+00:11:43   CC [M]  drivers/net/ethernet/qlogic/qede/qede_rdma.o
+00:11:43   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_mplsoudp.o
+00:11:43   CC [M]  drivers/net/ethernet/qlogic/qed/qed_ptp.o
+00:11:44   LD [M]  drivers/md/raid456.o
+00:11:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp100.o
+00:11:44   LD [M]  drivers/media/pci/bt8xx/bttv.o
+00:11:44   CC [M]  drivers/net/ethernet/sfc/falcon/efx.o
+00:11:44   LD [M]  drivers/media/pci/tw686x/tw686x.o
+00:11:44   AR      drivers/net/ethernet/sfc/built-in.a
+00:11:44   CC      drivers/gpu/drm/drm_file.o
+00:11:44   AR      drivers/net/ethernet/smsc/built-in.a
+00:11:44   CC [M]  drivers/net/ethernet/smsc/smc91c92_cs.o
+00:11:44   CC [M]  drivers/net/ethernet/sfc/falcon/nic.o
+00:11:44   CC [M]  drivers/media/pci/saa7134/saa7134-go7007.o
+00:11:44   CC [M]  drivers/media/dvb-frontends/tda10086.o
+00:11:44   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-main.o
+00:11:44   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dpp.o
+00:11:44   CC [M]  drivers/net/ethernet/qlogic/qed/qed_selftest.o
+00:11:44   CC [M]  drivers/media/pci/saa7164/saa7164-encoder.o
+00:11:44   LD [M]  drivers/net/ethernet/qlogic/qede/qede.o
+00:11:44   CC [M]  drivers/media/usb/gspca/pac7302.o
+00:11:44   CC [M]  drivers/media/dvb-frontends/tda826x.o
+00:11:44   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/diag/en_tc_tracepoint.o
+00:11:44   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp102.o
+00:11:45   LD [M]  drivers/md/dm-bio-prison.o
+00:11:45   CC [M]  drivers/net/nlmon.o
+00:11:45   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_main.o
+00:11:45   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dpp_cm.o
+00:11:45   CC [M]  drivers/media/pci/saa7134/saa7134-alsa.o
+00:11:45   AR      drivers/net/ethernet/sun/built-in.a
+00:11:45   CC [M]  drivers/net/ethernet/sun/sunhme.o
+00:11:45   CC [M]  drivers/media/pci/saa7134/saa7134-dvb.o
+00:11:45   LD [M]  drivers/md/dm-multipath.o
+00:11:45   LD [M]  drivers/md/dm-round-robin.o
+00:11:45   LD [M]  drivers/md/dm-queue-length.o
+00:11:45   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-hdw.o
+00:11:45   LD [M]  drivers/md/dm-service-time.o
+00:11:45   LD [M]  drivers/md/dm-historical-service-time.o
+00:11:45   LD [M]  drivers/md/dm-io-affinity.o
+00:11:45   CC [M]  drivers/net/ethernet/smsc/epic100.o
+00:11:45   LD [M]  drivers/md/dm-log-userspace.o
+00:11:45   LD [M]  drivers/md/dm-thin-pool.o
+00:11:45   LD [M]  drivers/md/dm-verity.o
+00:11:45   LD [M]  drivers/md/dm-cache.o
+00:11:45   LD [M]  drivers/md/dm-cache-smq.o
+00:11:45   LD [M]  drivers/md/dm-ebs.o
+00:11:45   CC [M]  drivers/net/ethernet/qlogic/qed/qed_sp_commands.o
+00:11:45   LD [M]  drivers/md/dm-era.o
+00:11:45   LD [M]  drivers/md/dm-clone.o
+00:11:45   LD [M]  drivers/md/dm-zoned.o
+00:11:45   AR      drivers/md/built-in.a
+00:11:45   CC [M]  drivers/media/dvb-frontends/tda8261.o
+00:11:45   AR      drivers/net/ethernet/tehuti/built-in.a
+00:11:45   CC [M]  drivers/net/ethernet/tehuti/tehuti.o
+00:11:45   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp104.o
+00:11:45   CC [M]  drivers/media/usb/gspca/pac7311.o
+00:11:45   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc/post_act.o
+00:11:45   CC [M]  drivers/media/pci/saa7164/saa7164-vbi.o
+00:11:46   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_hubp.o
+00:11:46   CC [M]  drivers/media/pci/solo6x10/solo6x10-core.o
+00:11:46   CC [M]  drivers/media/dvb-frontends/dib0070.o
+00:11:46   CC [M]  drivers/net/ethernet/qlogic/qed/qed_spq.o
+00:11:46   CC [M]  drivers/net/ethernet/sfc/falcon/farch.o
+00:11:46   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp107.o
+00:11:46   CC [M]  drivers/media/usb/cx231xx/cx231xx-video.o
+00:11:46   CC [M]  drivers/net/ethernet/smsc/smsc9420.o
+00:11:46   CC [M]  drivers/net/ethernet/sun/sungem.o
+00:11:46   CC [M]  drivers/media/usb/gspca/se401.o
+00:11:46   LD [M]  drivers/media/pci/saa7134/saa7134.o
+00:11:46   CC [M]  drivers/net/ethernet/qlogic/qla3xxx.o
+00:11:46   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc_ct.o
+00:11:47   LD [M]  drivers/media/pci/saa7164/saa7164.o
+00:11:47   CC      drivers/gpu/drm/drm_gem.o
+00:11:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp108.o
+00:11:47   CC [M]  drivers/media/dvb-frontends/dib0090.o
+00:11:47   AR      drivers/net/ethernet/stmicro/built-in.a
+00:11:47   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_mpc.o
+00:11:47   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_ethtool.o
+00:11:47   CC [M]  drivers/media/pci/solo6x10/solo6x10-i2c.o
+00:11:47   CC [M]  drivers/net/ethernet/qlogic/qed/qed_fcoe.o
+00:11:47   CC [M]  drivers/media/usb/gspca/sn9c2028.o
+00:11:47   CC [M]  drivers/net/ethernet/smsc/smsc911x.o
+00:11:47   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gp10b.o
+00:11:47   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-v4l2.o
+00:11:47   CC [M]  drivers/media/usb/cx231xx/cx231xx-i2c.o
+00:11:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_opp.o
+00:11:48   CC [M]  drivers/net/ethernet/sfc/efx.o
+00:11:48   CC [M]  drivers/net/ethernet/sun/cassini.o
+00:11:48   CC [M]  drivers/net/ethernet/sfc/efx_common.o
+00:11:48   CC [M]  drivers/media/pci/solo6x10/solo6x10-p2m.o
+00:11:48   CC [M]  drivers/net/ethernet/qlogic/qed/qed_iscsi.o
+00:11:48   CC [M]  drivers/net/ethernet/sfc/falcon/falcon.o
+00:11:48   CC [M]  drivers/media/dvb-frontends/tua6100.o
+00:11:48   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_hubbub.o
+00:11:48   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/gv100.o
+00:11:48   CC [M]  drivers/media/usb/gspca/sn9c20x.o
+00:11:48   CC [M]  drivers/net/ethernet/sfc/efx_channels.o
+00:11:48   CC [M]  drivers/media/usb/cx231xx/cx231xx-cards.o
+00:11:49   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/tc/sample.o
+00:11:49   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.o
+00:11:49   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-ctrl.o
+00:11:49   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_optc.o
+00:11:49   CC [M]  drivers/media/dvb-frontends/s5h1409.o
+00:11:49   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/tu102.o
+00:11:49   CC [M]  drivers/media/pci/solo6x10/solo6x10-v4l2.o
+00:11:49   CC [M]  drivers/media/usb/em28xx/em28xx-core.o
+00:11:49   CC [M]  drivers/media/usb/usbtv/usbtv-core.o
+00:11:49   CC [M]  drivers/net/ethernet/qlogic/qed/qed_ll2.o
+00:11:49   AR      drivers/media/pci/built-in.a
+00:11:49   CC      drivers/gpu/drm/drm_ioctl.o
+00:11:50   CC [M]  drivers/media/usb/cx231xx/cx231xx-core.o
+00:11:50   CC [M]  drivers/net/ethernet/stmicro/stmmac/ring_mode.o
+00:11:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_mmhubbub.o
+00:11:50   CC [M]  drivers/media/usb/gspca/sonixb.o
+00:11:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxnv40.o
+00:11:50   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-std.o
+00:11:50   CC [M]  drivers/media/dvb-frontends/itd1000.o
+00:11:50   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/eswitch.o
+00:11:50   CC [M]  drivers/net/ethernet/sun/niu.o
+00:11:50   CC [M]  drivers/media/usb/usbtv/usbtv-video.o
+00:11:50   CC [M]  drivers/net/ethernet/sfc/falcon/tx.o
+00:11:50   CC [M]  drivers/media/pci/solo6x10/solo6x10-tw28.o
+00:11:50   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-devattr.o
+00:11:50   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_stream_encoder.o
+00:11:50   CC [M]  drivers/media/usb/em28xx/em28xx-i2c.o
+00:11:50   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxnv50.o
+00:11:50   AR      drivers/net/ethernet/ti/built-in.a
+00:11:50   CC [M]  drivers/net/ethernet/ti/tlan.o
+00:11:50   CC [M]  drivers/net/ethernet/stmicro/stmmac/chain_mode.o
+00:11:51   CC [M]  drivers/media/usb/gspca/sonixj.o
+00:11:51   CC [M]  drivers/media/dvb-frontends/au8522_common.o
+00:11:51   CC [M]  drivers/media/usb/cx231xx/cx231xx-avcore.o
+00:11:51   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_link_encoder.o
+00:11:51   CC [M]  drivers/media/usb/usbtv/usbtv-audio.o
+00:11:51   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac_lib.o
+00:11:51   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-context.o
+00:11:51   CC [M]  drivers/media/pci/solo6x10/solo6x10-gpio.o
+00:11:51   CC [M]  drivers/net/ethernet/qlogic/qed/qed_ooo.o
+00:11:51   CC [M]  drivers/media/usb/em28xx/em28xx-cards.o
+00:11:51   AR      drivers/net/ethernet/via/built-in.a
+00:11:51   CC [M]  drivers/net/ethernet/via/via-rhine.o
+00:11:51   CC [M]  drivers/net/ethernet/sfc/falcon/rx.o
+00:11:52   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dccg.o
+00:11:52   CC [M]  drivers/media/dvb-frontends/au8522_dig.o
+00:11:52   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-io.o
+00:11:52   CC [M]  drivers/media/usb/go7007/go7007-v4l2.o
+00:11:52   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.o
+00:11:52   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.o
+00:11:52   LD [M]  drivers/media/usb/usbtv/usbtv.o
+00:11:52   CC [M]  drivers/media/usb/gspca/spca500.o
+00:11:52   CC [M]  drivers/media/usb/go7007/go7007-driver.o
+00:11:52   CC [M]  drivers/media/pci/solo6x10/solo6x10-disp.o
+00:11:52   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_vmid.o
+00:11:52   CC [M]  drivers/net/ethernet/qlogic/qed/qed_iwarp.o
+00:11:52   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-ioread.o
+00:11:53   CC [M]  drivers/media/dvb-frontends/au8522_decoder.o
+00:11:53   CC [M]  drivers/media/usb/cx231xx/cx231xx-417.o
+00:11:53   CC [M]  drivers/media/usb/em28xx/em28xx-camera.o
+00:11:53   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dwb.o
+00:11:53   CC [M]  drivers/net/ethernet/sfc/falcon/selftest.o
+00:11:53   CC [M]  drivers/net/ethernet/via/via-velocity.o
+00:11:53   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.o
+00:11:53   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-cx2584x-v4l.o
+00:11:53   CC [M]  drivers/media/usb/gspca/spca501.o
+00:11:53   CC [M]  drivers/media/pci/solo6x10/solo6x10-enc.o
+00:11:53   CC [M]  drivers/media/pci/solo6x10/solo6x10-v4l2-enc.o
+00:11:53   CC [M]  drivers/media/usb/go7007/go7007-i2c.o
+00:11:53   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf100.o
+00:11:54   CC [M]  drivers/media/dvb-frontends/tda10048.o
+00:11:54   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dwb_scl.o
+00:11:54   CC [M]  drivers/media/usb/em28xx/em28xx-video.o
+00:11:54   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac100_core.o
+00:11:54   CC [M]  drivers/media/usb/cx231xx/cx231xx-pcb-cfg.o
+00:11:54   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-wm8775.o
+00:11:54   CC [M]  drivers/media/usb/gspca/spca505.o
+00:11:54   CC [M]  drivers/media/usb/go7007/go7007-fw.o
+00:11:54   CC [M]  drivers/net/ethernet/sfc/nic.o
+00:11:54   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn20/dcn20_dsc.o
+00:11:54   CC [M]  drivers/net/ethernet/sfc/falcon/ethtool.o
+00:11:54   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf104.o
+00:11:54   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads_termtbl.o
+00:11:54   CC [M]  drivers/net/vrf.o
+00:11:54   CC [M]  drivers/net/ethernet/qlogic/qed/qed_rdma.o
+00:11:55   CC [M]  drivers/media/dvb-frontends/cx24113.o
+00:11:55   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac100_dma.o
+00:11:55   CC [M]  drivers/media/pci/solo6x10/solo6x10-g723.o
+00:11:55   CC [M]  drivers/media/usb/cx231xx/cx231xx-vbi.o
+00:11:55   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-cs53l32a.o
+00:11:55   CC [M]  drivers/media/usb/gspca/spca506.o
+00:11:55   CC [M]  drivers/media/usb/cx231xx/cx231xx-input.o
+00:11:55   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf108.o
+00:11:55   CC [M]  drivers/net/ethernet/stmicro/stmmac/enh_desc.o
+00:11:55   CC [M]  drivers/media/usb/gspca/spca508.o
+00:11:55   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dsc/dc_dsc.o
+00:11:55   CC [M]  drivers/media/dvb-frontends/s5h1411.o
+00:11:55   CC [M]  drivers/media/usb/em28xx/em28xx-vbi.o
+00:11:56   CC [M]  drivers/media/pci/solo6x10/solo6x10-eeprom.o
+00:11:56   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/ecpf.o
+00:11:56   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-dvb.o
+00:11:56   CC [M]  drivers/net/ethernet/sfc/falcon/qt202x_phy.o
+00:11:56   CC [M]  drivers/media/usb/gspca/spca561.o
+00:11:56   CC [M]  drivers/media/usb/cx231xx/cx231xx-audio.o
+00:11:56   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf110.o
+00:11:56   CC [M]  drivers/media/dvb-frontends/tda665x.o
+00:11:56   CC [M]  drivers/net/ethernet/qlogic/qed/qed_roce.o
+00:11:56   CC [M]  drivers/media/usb/go7007/snd-go7007.o
+00:11:56   CC [M]  drivers/net/ethernet/stmicro/stmmac/norm_desc.o
+00:11:56   CC [M]  drivers/media/usb/as102/as102_drv.o
+00:11:56   CC [M]  drivers/media/dvb-frontends/lgs8gxx.o
+00:11:56   CC [M]  drivers/media/usb/em28xx/em28xx-audio.o
+00:11:56   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dsc/rc_calc.o
+00:11:56   CC      drivers/gpu/drm/drm_irq.o
+00:11:56   LD [M]  drivers/media/pci/solo6x10/solo6x10.o
+00:11:57   CC [M]  drivers/net/ethernet/sfc/farch.o
+00:11:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf117.o
+00:11:57   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/rdma.o
+00:11:57   CC [M]  drivers/net/ethernet/sfc/falcon/mdio_10g.o
+00:11:57   CC [M]  drivers/media/usb/pvrusb2/pvrusb2-sysfs.o
+00:11:57   CC [M]  drivers/media/usb/gspca/spca1528.o
+00:11:57   CC [M]  drivers/net/ethernet/stmicro/stmmac/mmc_core.o
+00:11:57   CC [M]  drivers/media/usb/cx231xx/cx231xx-dvb.o
+00:11:57   CC [M]  drivers/net/ethernet/sfc/falcon/tenxpress.o
+00:11:57   CC [M]  drivers/media/usb/as102/as102_fw.o
+00:11:57   CC [M]  drivers/media/usb/go7007/go7007-usb.o
+00:11:57   AR      drivers/media/usb/built-in.a
+00:11:57   CC [M]  drivers/net/vsockmon.o
+00:11:57   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dsc/rc_calc_dpi.o
+00:11:57   CC [M]  drivers/net/ethernet/qlogic/qed/qed_sriov.o
+00:11:57   CC [M]  drivers/media/dvb-frontends/atbm8830.o
+00:11:57   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgf119.o
+00:11:57   CC [M]  drivers/media/usb/em28xx/em28xx-dvb.o
+00:11:57   LD [M]  drivers/media/usb/pvrusb2/pvrusb2.o
+00:11:58   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_hwtstamp.o
+00:11:58   AR      drivers/net/ethernet/wiznet/built-in.a
+00:11:58   CC [M]  drivers/net/ethernet/wiznet/w5100.o
+00:11:58   CC [M]  drivers/media/usb/gspca/sq905.o
+00:11:58   CC [M]  drivers/media/usb/as102/as10x_cmd.o
+00:11:58   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/legacy.o
+00:11:58   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_init.o
+00:11:58   CC [M]  drivers/net/ethernet/wiznet/w5100-spi.o
+00:11:58   CC [M]  drivers/media/usb/em28xx/em28xx-input.o
+00:11:58   CC [M]  drivers/media/dvb-frontends/af9013.o
+00:11:58   CC [M]  drivers/media/usb/go7007/go7007-loader.o
+00:11:58   LD [M]  drivers/media/usb/cx231xx/cx231xx.o
+00:11:58   CC [M]  drivers/net/ethernet/sfc/falcon/txc43128_phy.o
+00:11:58   LD [M]  drivers/media/usb/cx231xx/cx231xx-alsa.o
+00:11:58   AR      drivers/net/ethernet/xilinx/built-in.a
+00:11:58   CC [M]  drivers/net/ethernet/xilinx/ll_temac_main.o
+00:11:58   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgk104.o
+00:11:58   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_ptp.o
+00:11:58   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_resource.o
+00:11:59   CC [M]  drivers/media/usb/go7007/s2250-board.o
+00:11:59   CC [M]  drivers/media/usb/as102/as10x_cmd_stream.o
+00:11:59   CC [M]  drivers/media/usb/gspca/sq905c.o
+00:11:59   CC [M]  drivers/media/dvb-frontends/cx24116.o
+00:11:59   CC [M]  drivers/net/ethernet/wiznet/w5300.o
+00:11:59   CC      drivers/gpu/drm/drm_drv.o
+00:11:59   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgk110.o
+00:11:59   LD [M]  drivers/media/usb/go7007/go7007.o
+00:11:59   LD [M]  drivers/media/usb/em28xx/em28xx.o
+00:11:59   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/devlink_port.o
+00:11:59   LD [M]  drivers/media/usb/em28xx/em28xx-v4l.o
+00:11:59   LD [M]  drivers/media/usb/em28xx/em28xx-alsa.o
+00:11:59   LD [M]  drivers/media/usb/em28xx/em28xx-rc.o
+00:11:59   CC [M]  drivers/net/ethernet/sfc/falcon/falcon_boards.o
+00:11:59   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac4_descs.o
+00:11:59   CC [M]  drivers/net/ethernet/xilinx/ll_temac_mdio.o
+00:11:59   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_ipp.o
+00:11:59   CC [M]  drivers/media/usb/gspca/sq930x.o
+00:11:59   CC [M]  drivers/media/usb/as102/as102_usb_drv.o
+00:12:00   LD [M]  drivers/media/usb/go7007/s2250.o
+00:12:00   CC [M]  drivers/net/ethernet/qlogic/qed/qed_vf.o
+00:12:00   CC      drivers/gpu/drm/drm_sysfs.o
+00:12:00   CC [M]  drivers/net/ethernet/sfc/siena.o
+00:12:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgk110b.o
+00:12:00   CC [M]  drivers/net/mhi_net.o
+00:12:00   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_hw_sequencer.o
+00:12:00   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.o
+00:12:00   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/vporttbl.o
+00:12:00   CC [M]  drivers/media/dvb-frontends/cx24117.o
+00:12:00   CC [M]  drivers/net/ethernet/xilinx/xilinx_emaclite.o
+00:12:00   CC [M]  drivers/net/ethernet/sfc/falcon/mtd.o
+00:12:00   CC [M]  drivers/media/usb/as102/as10x_cmd_cfg.o
+00:12:00   CC [M]  drivers/net/ethernet/sfc/ef10.o
+00:12:00   CC [M]  drivers/net/ethernet/sfc/tx.o
+00:12:00   CC [M]  drivers/media/usb/gspca/sunplus.o
+00:12:00   AR      drivers/net/ethernet/xircom/built-in.a
+00:12:00   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgk208.o
+00:12:00   CC [M]  drivers/net/ethernet/xircom/xirc2ps_cs.o
+00:12:00   CC [M]  drivers/net/sungem_phy.o
+00:12:00   LD [M]  drivers/net/ethernet/xilinx/ll_temac.o
+00:12:00   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac4_lib.o
+00:12:01   CC [M]  drivers/net/ethernet/sfc/tx_common.o
+00:12:01   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/qos.o
+00:12:01   LD [M]  drivers/net/ethernet/qlogic/qed/qed.o
+00:12:01   LD [M]  drivers/media/usb/as102/dvb-as102.o
+00:12:01   CC [M]  drivers/media/usb/gspca/stk014.o
+00:12:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_hw_sequencer_debug.o
+00:12:01   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgk20a.o
+00:12:01   CC [M]  drivers/media/dvb-frontends/cx24120.o
+00:12:01   LD [M]  drivers/net/ethernet/sfc/falcon/sfc-falcon.o
+00:12:01   CC      drivers/gpu/drm/drm_hashtab.o
+00:12:01   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac4_core.o
+00:12:01   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_main.o
+00:12:01   CC [M]  drivers/net/xen-netfront.o
+00:12:01   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_dpp.o
+00:12:01   CC [M]  drivers/media/dvb-frontends/si21xx.o
+00:12:02   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/acl/helper.o
+00:12:02   CC      drivers/gpu/drm/drm_mm.o
+00:12:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgm107.o
+00:12:02   AR      drivers/net/ethernet/pensando/built-in.a
+00:12:02   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac5.o
+00:12:02   CC [M]  drivers/media/usb/gspca/stk1135.o
+00:12:02   CC [M]  drivers/net/ntb_netdev.o
+00:12:02   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_bus_pci.o
+00:12:02   CC [M]  drivers/media/dvb-frontends/si2168.o
+00:12:02   CC [M]  drivers/net/ethernet/altera/altera_tse_main.o
+00:12:02   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_opp.o
+00:12:02   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/acl/egress_lgcy.o
+00:12:02   CC      drivers/gpu/drm/drm_crtc.o
+00:12:02   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgm200.o
+00:12:02   CC [M]  drivers/media/usb/gspca/stv0680.o
+00:12:02   CC [M]  drivers/net/thunderbolt.o
+00:12:03   CC [M]  drivers/net/ethernet/sfc/tx_tso.o
+00:12:03   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_devlink.o
+00:12:03   CC [M]  drivers/net/ethernet/dnet.o
+00:12:03   CC [M]  drivers/net/ethernet/stmicro/stmmac/hwif.o
+00:12:03   CC [M]  drivers/net/ethernet/altera/altera_tse_ethtool.o
+00:12:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_optc.o
+00:12:03   CC [M]  drivers/media/dvb-frontends/stv0288.o
+00:12:03   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgm20b.o
+00:12:03   CC [M]  drivers/net/ethernet/sfc/rx.o
+00:12:03   CC      drivers/gpu/drm/drm_fourcc.o
+00:12:03   CC [M]  drivers/net/net_failover.o
+00:12:03   CC [M]  drivers/net/ethernet/jme.o
+00:12:03   CC [M]  drivers/media/usb/gspca/t613.o
+00:12:03   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_dev.o
+00:12:03   CC [M]  drivers/net/ethernet/altera/altera_msgdma.o
+00:12:03   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/acl/egress_ofld.o
+00:12:03   CC [M]  drivers/net/ethernet/sfc/rx_common.o
+00:12:03   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_hubp.o
+00:12:03   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_tc.o
+00:12:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgp100.o
+00:12:04   CC [M]  drivers/media/dvb-frontends/stb6000.o
+00:12:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgp102.o
+00:12:04   CC [M]  drivers/media/usb/gspca/topro.o
+00:12:04   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/acl/ingress_lgcy.o
+00:12:04   CC [M]  drivers/net/ethernet/altera/altera_sgdma.o
+00:12:04   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_debugfs.o
+00:12:04   CC      drivers/gpu/drm/drm_modes.o
+00:12:04   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwxgmac2_core.o
+00:12:04   CC [M]  drivers/media/dvb-frontends/s921.o
+00:12:04   CC [M]  drivers/net/ethernet/fealnx.o
+00:12:04   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_mpc.o
+00:12:04   CC [M]  drivers/net/ethernet/altera/altera_utils.o
+00:12:04   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgp104.o
+00:12:04   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/acl/ingress_ofld.o
+00:12:05   CC [M]  drivers/net/ethernet/ethoc.o
+00:12:05   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_lif.o
+00:12:05   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_rx_filter.o
+00:12:05   CC [M]  drivers/media/usb/gspca/touptek.o
+00:12:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_dpp_dscl.o
+00:12:05   CC [M]  drivers/net/ethernet/sfc/selftest.o
+00:12:05   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.o
+00:12:05   LD [M]  drivers/net/ethernet/altera/altera_tse.o
+00:12:05   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgp107.o
+00:12:05   CC [M]  drivers/media/dvb-frontends/stv6110.o
+00:12:05   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_dpp_cm.o
+00:12:05   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.o
+00:12:05   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_ethtool.o
+00:12:05   CC [M]  drivers/net/ethernet/sfc/ethtool.o
+00:12:05   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/rep/bridge.o
+00:12:06   CC [M]  drivers/media/usb/gspca/tv8532.o
+00:12:06   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_cm_common.o
+00:12:06   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxgv100.o
+00:12:06   CC      drivers/gpu/drm/drm_edid.o
+00:12:06   CC [M]  drivers/net/ethernet/sfc/ethtool_common.o
+00:12:06   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_txrx.o
+00:12:06   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwxgmac2_descs.o
+00:12:06   CC [M]  drivers/media/dvb-frontends/stv0900_core.o
+00:12:06   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_stats.o
+00:12:06   CC [M]  drivers/net/ethernet/sfc/ptp.o
+00:12:06   CC      drivers/gpu/drm/drm_displayid.o
+00:12:06   CC [M]  drivers/media/dvb-frontends/stv0900_sw.o
+00:12:06   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/mpfs.o
+00:12:06   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_hubbub.o
+00:12:06   CC [M]  drivers/media/usb/gspca/vc032x.o
+00:12:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/gr/ctxtu102.o
+00:12:07   CC [M]  drivers/net/ethernet/stmicro/stmmac/stmmac_xdp.o
+00:12:07   CC      drivers/gpu/drm/drm_encoder_slave.o
+00:12:07   CC [M]  drivers/net/ethernet/sfc/mcdi.o
+00:12:07   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mpeg/nv31.o
+00:12:07   CC [M]  drivers/net/ethernet/sfc/mcdi_port.o
+00:12:07   CC [M]  drivers/net/ethernet/stmicro/stmmac/dwmac-intel.o
+00:12:07   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_stream_encoder.o
+00:12:07   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/clock.o
+00:12:07   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_fw.o
+00:12:07   CC      drivers/gpu/drm/drm_trace_points.o
+00:12:07   CC [M]  drivers/media/dvb-frontends/stv090x.o
+00:12:08   CC [M]  drivers/media/usb/gspca/vicam.o
+00:12:08   CC [M]  drivers/net/ethernet/pensando/ionic/ionic_phc.o
+00:12:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mpeg/nv40.o
+00:12:08   CC [M]  drivers/net/ethernet/sfc/mcdi_port_common.o
+00:12:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn10/dcn10_link_encoder.o
+00:12:08   CC [M]  drivers/media/dvb-frontends/stv6110x.o
+00:12:08   CC      drivers/gpu/drm/drm_prime.o
+00:12:08   LD [M]  drivers/net/ethernet/stmicro/stmmac/stmmac.o
+00:12:08   CC [M]  drivers/media/usb/gspca/xirlink_cit.o
+00:12:08   CC      drivers/gpu/drm/drm_rect.o
+00:12:08   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_init.o
+00:12:08   CC [M]  drivers/net/ethernet/sfc/mcdi_functions.o
+00:12:08   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/ipoib/ipoib.o
+00:12:08   CC [M]  drivers/media/dvb-frontends/m88ds3103.o
+00:12:08   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mpeg/nv44.o
+00:12:08   CC      drivers/gpu/drm/drm_vma_manager.o
+00:12:08   LD [M]  drivers/net/ethernet/pensando/ionic/ionic.o
+00:12:08   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/ipoib/ethtool.o
+00:12:09   CC [M]  drivers/media/dvb-frontends/mn88472.o
+00:12:09   CC [M]  drivers/media/usb/gspca/zc3xx.o
+00:12:09   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/ipoib/ipoib_vlan.o
+00:12:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_hubp.o
+00:12:09   CC [M]  drivers/net/ethernet/sfc/mcdi_filters.o
+00:12:09   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/crypto.o
+00:12:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mpeg/nv50.o
+00:12:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_hubbub.o
+00:12:09   CC [M]  drivers/media/dvb-frontends/mn88473.o
+00:12:09   LD [M]  drivers/media/usb/gspca/gspca_main.o
+00:12:09   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/accel/tls.o
+00:12:09   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_resource.o
+00:12:09   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mpeg/g84.o
+00:12:09   CC [M]  drivers/net/ethernet/sfc/mcdi_mon.o
+00:12:09   LD [M]  drivers/media/usb/gspca/gspca_benq.o
+00:12:09   CC [M]  drivers/media/dvb-frontends/isl6423.o
+00:12:10   CC      drivers/gpu/drm/drm_flip_work.o
+00:12:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_hwseq.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_conex.o
+00:12:10   CC [M]  drivers/net/ethernet/sfc/ef100.o
+00:12:10   CC      drivers/gpu/drm/drm_modeset_lock.o
+00:12:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mspdec/base.o
+00:12:10   CC [M]  drivers/media/dvb-frontends/ec100.o
+00:12:10   CC [M]  drivers/net/ethernet/sfc/ef100_nic.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_cpia1.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_dtcs033.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_etoms.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_finepix.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_jeilinj.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_jl2005bcd.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_kinect.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_konica.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_mars.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_mr97310a.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_nw80x.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_ov519.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_ov534.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_ov534_9.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_pac207.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_pac7302.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_pac7311.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_se401.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sn9c2028.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sn9c20x.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sonixb.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sonixj.o
+00:12:10   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mspdec/g98.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca500.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca501.o
+00:12:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_link_encoder.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca505.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca506.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca508.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca561.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_spca1528.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sq905.o
+00:12:10   CC [M]  drivers/media/dvb-frontends/ds3000.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sq905c.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sq930x.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_sunplus.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_stk014.o
+00:12:10   CC      drivers/gpu/drm/drm_atomic.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_stk1135.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_stv0680.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_t613.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_topro.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_touptek.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_tv8532.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_vc032x.o
+00:12:10   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn21/dcn21_dccg.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_vicam.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_xirlink_cit.o
+00:12:10   LD [M]  drivers/media/usb/gspca/gspca_zc3xx.o
+00:12:10   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/accel/ipsec.o
+00:12:10   CC [M]  drivers/net/ethernet/sfc/ef100_netdev.o
+00:12:11   CC      drivers/gpu/drm/drm_bridge.o
+00:12:11   CC [M]  drivers/media/dvb-frontends/ts2020.o
+00:12:11   CC [M]  drivers/media/dvb-frontends/mb86a16.o
+00:12:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_init.o
+00:12:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mspdec/gt215.o
+00:12:11   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fpga/cmd.o
+00:12:11   CC      drivers/gpu/drm/drm_framebuffer.o
+00:12:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mspdec/gf100.o
+00:12:11   CC [M]  drivers/media/dvb-frontends/mb86a20s.o
+00:12:11   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fpga/core.o
+00:12:11   AR      drivers/media/built-in.a
+00:12:11   CC      drivers/gpu/drm/drm_connector.o
+00:12:11   CC [M]  drivers/net/ethernet/sfc/ef100_ethtool.o
+00:12:11   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_hubbub.o
+00:12:11   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/mspdec/gk104.o
+00:12:11   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fpga/conn.o
+00:12:11   CC      drivers/gpu/drm/drm_blend.o
+00:12:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_hubp.o
+00:12:12   CC [M]  drivers/net/ethernet/sfc/ef100_rx.o
+00:12:12   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/fpga/sdk.o
+00:12:12   CC      drivers/gpu/drm/drm_encoder.o
+00:12:12   CC [M]  drivers/media/dvb-frontends/ix2505v.o
+00:12:12   CC [M]  drivers/net/ethernet/sfc/ef100_tx.o
+00:12:12   CC      drivers/gpu/drm/drm_mode_object.o
+00:12:12   LD [M]  drivers/net/thunderbolt-net.o
+00:12:12   CC [M]  drivers/media/dvb-frontends/stv0367.o
+00:12:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msppp/base.o
+00:12:12   CC [M]  drivers/net/ethernet/sfc/mtd.o
+00:12:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dpp.o
+00:12:12   CC      drivers/gpu/drm/drm_property.o
+00:12:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msppp/g98.o
+00:12:12   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_optc.o
+00:12:12   CC [M]  drivers/net/ethernet/sfc/sriov.o
+00:12:12   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msppp/gt215.o
+00:12:12   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_domain.o
+00:12:12   CC [M]  drivers/media/dvb-frontends/cxd2820r_core.o
+00:12:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dccg.o
+00:12:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msppp/gf100.o
+00:12:13   CC      drivers/gpu/drm/drm_plane.o
+00:12:13   CC [M]  drivers/media/dvb-frontends/cxd2820r_c.o
+00:12:13   CC [M]  drivers/media/dvb-frontends/cxd2820r_t.o
+00:12:13   CC [M]  drivers/net/ethernet/sfc/siena_sriov.o
+00:12:13   CC      drivers/gpu/drm/drm_color_mgmt.o
+00:12:13   CC [M]  drivers/media/dvb-frontends/cxd2820r_t2.o
+00:12:13   CC [M]  drivers/media/dvb-frontends/cxd2841er.o
+00:12:13   CC [M]  drivers/media/dvb-frontends/drxk_hard.o
+00:12:13   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_table.o
+00:12:13   CC [M]  drivers/net/ethernet/sfc/ef10_sriov.o
+00:12:13   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_hwseq.o
+00:12:13   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/base.o
+00:12:13   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_matcher.o
+00:12:13   CC      drivers/gpu/drm/drm_print.o
+00:12:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_mpc.o
+00:12:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/g98.o
+00:12:14   CC      drivers/gpu/drm/drm_dumb_buffers.o
+00:12:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_vpg.o
+00:12:14   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/gt215.o
+00:12:14   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_rule.o
+00:12:14   CC      drivers/gpu/drm/drm_mode_config.o
+00:12:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_afmt.o
+00:12:14   CC [M]  drivers/media/dvb-frontends/tda18271c2dd.o
+00:12:14   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_icm_pool.o
+00:12:14   CC [M]  drivers/media/dvb-frontends/stv0910.o
+00:12:14   CC      drivers/gpu/drm/drm_vblank.o
+00:12:14   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dio_stream_encoder.o
+00:12:14   CC [M]  drivers/media/dvb-frontends/stv6111.o
+00:12:15   CC      drivers/gpu/drm/drm_syncobj.o
+00:12:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/mcp89.o
+00:12:15   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_buddy.o
+00:12:15   CC [M]  drivers/media/dvb-frontends/mxl5xx.o
+00:12:15   LD [M]  drivers/net/ethernet/sfc/sfc.o
+00:12:15   CC      drivers/gpu/drm/drm_lease.o
+00:12:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/gf100.o
+00:12:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dwb.o
+00:12:15   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_ste.o
+00:12:15   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/msvld/gk104.o
+00:12:15   CC      drivers/gpu/drm/drm_writeback.o
+00:12:15   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_send.o
+00:12:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dpp_cm.o
+00:12:15   CC      drivers/gpu/drm/drm_client.o
+00:12:15   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dwb_cm.o
+00:12:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/nvenc/base.o
+00:12:16   CC [M]  drivers/media/dvb-frontends/si2165.o
+00:12:16   CC      drivers/gpu/drm/drm_client_modeset.o
+00:12:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_ste_v0.o
+00:12:16   CC [M]  drivers/media/dvb-frontends/a8293.o
+00:12:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/nvenc/gm107.o
+00:12:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_ste_v1.o
+00:12:16   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_cm_common.o
+00:12:16   CC [M]  drivers/media/dvb-frontends/sp2.o
+00:12:16   CC      drivers/gpu/drm/drm_atomic_uapi.o
+00:12:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_cmd.o
+00:12:16   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/nvdec/base.o
+00:12:16   CC [M]  drivers/media/dvb-frontends/tda10071.o
+00:12:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_fw.o
+00:12:16   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_mmhubbub.o
+00:12:16   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/dr_action.o
+00:12:16   CC      drivers/gpu/drm/drm_hdcp.o
+00:12:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_dio_link_encoder.o
+00:12:17   CC      drivers/gpu/drm/drm_managed.o
+00:12:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/nvdec/gm107.o
+00:12:17   CC      drivers/gpu/drm/drm_vblank_work.o
+00:12:17   CC      drivers/gpu/drm/drm_agpsupport.o
+00:12:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/base.o
+00:12:17   CC [M]  drivers/media/dvb-frontends/rtl2830.o
+00:12:17   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/steering/fs_dr.o
+00:12:17   CC [M]  drivers/media/dvb-frontends/rtl2832.o
+00:12:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn30/dcn30_resource.o
+00:12:17   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/nv40.o
+00:12:17   CC      drivers/gpu/drm/drm_bufs.o
+00:12:17   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/vhca_event.o
+00:12:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_init.o
+00:12:17   CC [M]  drivers/media/dvb-frontends/m88rs2000.o
+00:12:17   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/dev/dev.o
+00:12:17   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_resource.o
+00:12:17   CC [M]  drivers/media/dvb-frontends/af9033.o
+00:12:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/nv50.o
+00:12:18   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_dccg.o
+00:12:18   CC      drivers/gpu/drm/drm_context.o
+00:12:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/dev/driver.o
+00:12:18   CC [M]  drivers/media/dvb-frontends/as102_fe.o
+00:12:18   CC      drivers/gpu/drm/drm_dma.o
+00:12:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/cmd.o
+00:12:18   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_dio_link_encoder.o
+00:12:18   CC [M]  drivers/media/dvb-frontends/gp8psk-fe.o
+00:12:18   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/g84.o
+00:12:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/hw_table.o
+00:12:18   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/sf/devlink.o
+00:12:18   CC      drivers/gpu/drm/drm_legacy_misc.o
+00:12:18   CC [M]  drivers/media/dvb-frontends/tc90522.o
+00:12:19   CC      drivers/gpu/drm/drm_lock.o
+00:12:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gt200.o
+00:12:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_hwseq.o
+00:12:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gt215.o
+00:12:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/en/hv_vhca_stats.o
+00:12:19   CC      drivers/gpu/drm/drm_memory.o
+00:12:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gf100.o
+00:12:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_panel_cntl.o
+00:12:19   CC      drivers/gpu/drm/drm_scatter.o
+00:12:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/vxlan.o
+00:12:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gf108.o
+00:12:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn301/dcn301_hubbub.o
+00:12:19   CC [M]  drivers/media/dvb-frontends/horus3a.o
+00:12:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn302/dcn302_init.o
+00:12:19   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gf117.o
+00:12:19   CC [M]  drivers/media/dvb-frontends/ascot2e.o
+00:12:19   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/hv.o
+00:12:19   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn302/dcn302_hwseq.o
+00:12:19   CC      drivers/gpu/drm/drm_vm.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/pm/gk104.o
+00:12:20   CC [M]  drivers/media/dvb-frontends/helene.o
+00:12:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn302/dcn302_resource.o
+00:12:20   CC      drivers/gpu/drm/drm_ioc32.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sec/g98.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sec2/base.o
+00:12:20   CC [M]  drivers/media/dvb-frontends/zd1301_demod.o
+00:12:20   CC      drivers/gpu/drm/drm_gem_cma_helper.o
+00:12:20   CC [M]  drivers/media/dvb-frontends/cxd2099.o
+00:12:20   CC      drivers/gpu/drm/drm_gem_shmem_helper.o
+00:12:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn303/dcn303_init.o
+00:12:20   CC [M]  drivers/net/ethernet/mellanox/mlx5/core/lib/hv_vhca.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sec2/gp102.o
+00:12:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn303/dcn303_hwseq.o
+00:12:20   CC      drivers/gpu/drm/drm_panel.o
+00:12:20   LD [M]  drivers/media/dvb-frontends/stb0899.o
+00:12:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn303/dcn303_resource.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sec2/gp108.o
+00:12:20   LD [M]  drivers/media/dvb-frontends/drxd.o
+00:12:20   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_resource.o
+00:12:20   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sec2/tu102.o
+00:12:20   CC      drivers/gpu/drm/drm_pci.o
+00:12:21   LD [M]  drivers/media/dvb-frontends/stv0900.o
+00:12:21   CC      drivers/gpu/drm/drm_debugfs.o
+00:12:21   LD [M]  drivers/media/dvb-frontends/cxd2820r.o
+00:12:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/base.o
+00:12:21   CC      drivers/gpu/drm/drm_debugfs_crc.o
+00:12:21   CC      drivers/gpu/drm/drm_edid_load.o
+00:12:21   LD [M]  drivers/media/dvb-frontends/drxk.o
+00:12:21   CC      drivers/gpu/drm/drm_mipi_dsi.o
+00:12:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/nv04.o
+00:12:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_hubbub.o
+00:12:21   CC      drivers/gpu/drm/drm_panel_orientation_quirks.o
+00:12:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_hwseq.o
+00:12:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/nv10.o
+00:12:21   CC [M]  drivers/gpu/drm/drm_gem_vram_helper.o
+00:12:21   LD [M]  drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.o
+00:12:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/nv50.o
+00:12:21   AR      drivers/net/ethernet/built-in.a
+00:12:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_init.o
+00:12:21   CC [M]  drivers/gpu/drm/drm_gem_ttm_helper.o
+00:12:21   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/gf100.o
+00:12:21   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_hubp.o
+00:12:21   AR      drivers/net/built-in.a
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/chan.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/sw/nvsw.o
+00:12:22   CC [M]  drivers/gpu/drm/drm_mipi_dbi.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_dccg.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nvkm/engine/vp/g84.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_optc.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_acpi.o
+00:12:22   AR      drivers/gpu/drm/built-in.a
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_dio_link_encoder.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_debugfs.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dcn31/dcn31_panel_cntl.o
+00:12:22   LD [M]  drivers/gpu/drm/drm_ttm_helper.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce120/dce120_resource.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_drm.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce120/dce120_timing_generator.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_hwmon.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce120/dce120_hw_sequencer.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce112/dce112_compressor.o
+00:12:22   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce112/dce112_hw_sequencer.o
+00:12:22   LD [M]  drivers/gpu/drm/drm_vram_helper.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_ioc32.o
+00:12:22   CC [M]  drivers/gpu/drm/nouveau/nouveau_led.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce112/dce112_resource.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_nvif.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_timing_generator.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_usif.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_compressor.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_vga.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_hw_sequencer.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo0039.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_resource.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_opp_regamma_v.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo5039.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_opp_csc_v.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo74c1.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_timing_generator_v.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo85b5.o
+00:12:23   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_mem_input_v.o
+00:12:23   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo9039.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_opp_v.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_bo90b5.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce110/dce110_transform_v.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce100/dce100_resource.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_boa0b5.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_gem.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce100/dce100_hw_sequencer.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_mem.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce80/dce80_timing_generator.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce80/dce80_hw_sequencer.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_prime.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce80/dce80_resource.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_sgdma.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce60/dce60_timing_generator.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_ttm.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce60/dce60_hw_sequencer.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_vmm.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dce60/dce60_resource.o
+00:12:24   CC [M]  drivers/gpu/drm/nouveau/nouveau_backlight.o
+00:12:24   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_stat.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nouveau_bios.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nouveau_connector.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nouveau_display.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nouveau_dp.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_resource.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nouveau_fbcon.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_hw_sequencer.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_sink.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nv04_fbcon.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_surface.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nv50_fbcon.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link_hwss.o
+00:12:25   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link_dp.o
+00:12:25   CC [M]  drivers/gpu/drm/nouveau/nvc0_fbcon.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link_ddc.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_debug.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_stream.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link_enc_cfg.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/arb.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/crtc.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_link_dpcd.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/cursor.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/core/dc_vm_helper.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/dac.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dc_helper.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/dfp.o
+00:12:26   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dc_dmub_srv.o
+00:12:26   CC [M]  drivers/gpu/drm/nouveau/dispnv04/disp.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dc_edid_parser.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv04/hw.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv04/overlay.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/freesync/freesync.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv04/tvmodesnv17.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv04/tvnv04.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/color/color_gamma.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv04/tvnv17.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/color/color_table.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv50/disp.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/info_packet/info_packet.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv50/lut.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/power/power_helpers.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_srv.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_srv_stat.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv50/core.o
+00:12:27   CC [M]  drivers/gpu/drm/nouveau/dispnv50/core507d.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_reg.o
+00:12:27   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn20.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/core827d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/core907d.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn21.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/core917d.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn30.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/corec37d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/corec57d.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn301.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/crc.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn302.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/crc907d.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn303.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/crcc37d.o
+00:12:28   CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dmub/src/dmub_dcn31.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/dac507d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/dac907d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/pior507d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/sor507d.o
+00:12:28   CC [M]  drivers/gpu/drm/nouveau/dispnv50/sor907d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/sorc37d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/head.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/head507d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/head827d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/head907d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/head917d.o
+00:12:29   LD [M]  drivers/gpu/drm/amd/amdgpu/amdgpu.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/headc37d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/headc57d.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wimm.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wimmc37b.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wndw.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wndwc37e.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wndwc57e.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/wndwc67e.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/base.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/base507c.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/base827c.o
+00:12:29   CC [M]  drivers/gpu/drm/nouveau/dispnv50/base907c.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/base917c.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/curs.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/curs507a.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/curs907a.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/cursc37a.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/oimm.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/oimm507b.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/ovly.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/ovly507e.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/ovly827e.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/ovly907e.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/dispnv50/ovly917e.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nouveau_abi16.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nouveau_chan.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nouveau_dma.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nouveau_fence.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nv04_fence.o
+00:12:30   CC [M]  drivers/gpu/drm/nouveau/nv10_fence.o
+00:12:31   CC [M]  drivers/gpu/drm/nouveau/nv17_fence.o
+00:12:31   CC [M]  drivers/gpu/drm/nouveau/nv50_fence.o
+00:12:31   CC [M]  drivers/gpu/drm/nouveau/nv84_fence.o
+00:12:31   CC [M]  drivers/gpu/drm/nouveau/nvc0_fence.o
+00:12:31   LD [M]  drivers/gpu/drm/nouveau/nouveau.o
+00:12:32   AR      drivers/gpu/built-in.a
+00:12:32 make[2]: *** [Makefile:1906: drivers] Error 2
+00:12:32 make[1]: *** [scripts/Makefile.package:109: targz-pkg] Error 2
+00:12:32 make: *** [Makefile:1618: targz-pkg] Error 2

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -414,6 +414,42 @@ LOG_DIR = 'tests/logs/kbuild'
             },
         ],
      }),
+
+    # Compiler error in a file with timestamps should not include them in the summary
+    #
+    # 00:00:14 In file included from ./include/uapi/linux/posix_types.h:5,
+    # 00:00:14                  from ./include/uapi/linux/types.h:14,
+    # 00:00:14                  from ./include/linux/types.h:6,
+    # 00:00:14                  from arch/x86/realmode/rm/wakeup.h:11,
+    # 00:00:14                  from arch/x86/realmode/rm/wakemain.c:2:
+    # 00:00:14 ./include/linux/stddef.h:11:9: error: cannot use keyword ‘false’ as enumeration constant
+    # 00:00:14    11 |         false   = 0,
+    # 00:00:14       |         ^~~~~
+    # 00:00:14 ./include/linux/stddef.h:11:9: note: ‘false’ is a keyword with ‘-std=c23’ onwards
+    # 00:00:14 ./include/linux/types.h:30:33: error: ‘bool’ cannot be defined via ‘typedef’
+    # 00:00:14    30 | typedef _Bool                   bool;
+    # 00:00:14       |                                 ^~~~
+    # 00:00:14 ./include/linux/types.h:30:33: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
+    # 00:00:14 ./include/linux/types.h:30:1: warning: useless type name in empty declaration
+    # 00:00:14    30 | typedef _Bool                   bool;
+    # 00:00:14       | ^~~~~~~
+    # 00:00:14 make[5]: *** [scripts/Makefile.build:289: arch/x86/realmode/rm/wakemain.o] Error 1
+    (
+        'kbuild_018.log',
+        'kbuild',
+        {
+            "errors": [
+                {
+                    "error_summary": "./include/linux/stddef.h:11:9: error: cannot use keyword ‘false’ as enumeration constant",
+                    "error_type": "kbuild.compiler.error",
+                    "location": "2",
+                    "script": "scripts/Makefile.build:289",
+                    "src_file": "arch/x86/realmode/rm/wakemain.c",
+                    "target": "arch/x86/realmode/rm/wakemain.o"
+                }
+            ]
+        },
+    )
 ])
 def test_kbuild(log_file, parser_id, expected):
     log_file = os.path.join(LOG_DIR, log_file)


### PR DESCRIPTION
KbuildCompilerError._parse_compiler_error() is the only method covered by the new test case, the rest of them were only updated for consistency

Resolves: https://github.com/kernelci/logspec/issues/15