### PR TITLE
Add sub-signature to enable matching of gcc vs clang

### DIFF
--- a/logspec/errors/kbuild.py
+++ b/logspec/errors/kbuild.py
@@ -30,6 +30,8 @@ class KbuildCompilerError(Error):
         self.target = target
         self.src_file = ""
         self.location = ""
+        self.line_no = ""
+        self.position = ""
         self.error_type = "kbuild.compiler"
         self._signature_fields.extend([
             'src_file',
@@ -132,12 +134,13 @@ class KbuildCompilerError(Error):
         drivers/../link_factory.c:743:1: error: the frame size of 1040 bytes is larger than 1024 bytes [-Werror=frame-larger-than=]
         """
         file_pattern = os.path.splitext(self.target)[0]
-        match = re.search(f'^.*?(?P<src_file>{file_pattern}.*?):(?P<location>.*?): (?P<type>.*?): (?P<message>.*?)\n',
+        match = re.search(fr'^.*?(?P<src_file>{file_pattern}.*?):(?P<line_no>\d+):(?P<position>\d+): (?P<type>.*?): (?P<message>.*?)\n',
                           text, flags=re.MULTILINE)
         if match:
             self._report = text[match.start():]
             self.src_file = match.group('src_file')
-            self.location = match.group('location')
+            self.line_no = match.group('line_no')
+            self.position = match.group('position')
             self.error_type += f".{match.group('type')}"
             self.error_summary = match.group('message')
             return len(text)
@@ -233,6 +236,10 @@ class KbuildCompilerError(Error):
                 break
         if self.location:
             self._signature_fields.append('location')
+        if self.line_no:
+            self._signature_fields.append('line_no')
+        if self.position:
+            self._signature_fields.append('position')
         return parse_end_pos
 
 

--- a/logspec/errors/kbuild.py
+++ b/logspec/errors/kbuild.py
@@ -33,6 +33,7 @@ class KbuildCompilerError(Error):
         self.line_no = ""
         self.position = ""
         self.error_type = "kbuild.compiler"
+        self._add_signature_loc = True
         self._signature_fields.extend([
             'src_file',
             'target',

--- a/logspec/main.py
+++ b/logspec/main.py
@@ -30,11 +30,21 @@ def format_data_output(data, full=False):
                 for d in data_dict[key]:
                     if isinstance(d, dict):
                         remove_keys(d, prefix)
+
+    def remove_empty_error_keys(data):
+        """Removes keys with empty values (e.g., "") from the 'errors' entry in the data."""
+        for error in data.get('errors', []):
+            if hasattr(error, '__dict__'):
+                # Handle objects with __dict__ attribute
+                for key in [k for k, v in vars(error).items() if v == ""]:
+                    delattr(error, key)
+
     if full:
         json_serializer = JsonSerializeDebug
     else:
         json_serializer = JsonSerialize
         remove_keys(data, '_')
+        remove_empty_error_keys(data)
     return json.dumps(data, indent=4, sort_keys=True, cls=json_serializer, ensure_ascii=False)
 
 

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -31,7 +31,8 @@ LOG_DIR = 'tests/logs/kbuild'
              {
                  "error_summary": "label at end of compound statement",
                  'error_type' : "kbuild.compiler.error",
-                 'location'   : "1266:3",
+                 'line_no'   : "1266",
+                 'position'   : "3",
                  'script'     : "scripts/Makefile.build:244",
                  'src_file'   : "drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.c",
                  'target'     : "drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.o",
@@ -195,7 +196,8 @@ LOG_DIR = 'tests/logs/kbuild'
              {
                  "error_summary": "the frame size of 1040 bytes is larger than 1024 bytes [-Werror=frame-larger-than=]",
                  "error_type": "kbuild.compiler.error",
-                 "location": "743:1",
+                 "line_no": "743",
+                 "position": "1",
                  "script": "scripts/Makefile.build:244",
                  "src_file": "drivers/gpu/drm/amd/amdgpu/../display/dc/link/link_factory.c",
                  "target": "drivers/gpu/drm/amd/amdgpu/../display/dc/link/link_factory.o",


### PR DESCRIPTION
This PR adds `signature_loc` with a signature that exclude the error summary message and the line position of the error, so we could generate the same hash for errors both from gcc and clang.

```
(.venv) poutine logspec > ./logspec.py ../tmp-logs/clang.log kbuild --json-full | grep signature_loc
            "_add_signature_loc": true,
            "_signature_loc": "90bb5a8b390fa147b4ddb0cab769c38e39b30e61",
(.venv) poutine logspec > ./logspec.py ../tmp-logs/gcc.log kbuild --json-full | grep signature_loc
            "_add_signature_loc": true,
            "_signature_loc": "90bb5a8b390fa147b4ddb0cab769c38e39b30e61",
```

Related to #11 